### PR TITLE
OCL: Create cl buffer when UMat switch from OpenCL off to OpenCL on.

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -302,8 +302,11 @@ public:
     //virtual void deallocate(int* refcount, uchar* datastart, uchar* data) = 0;
     virtual UMatData* allocate(int dims, const int* sizes, int type,
                                void* data, size_t* step, int flags, UMatUsageFlags usageFlags) const = 0;
+    virtual void allocate(UMatData* u, int dims, const int* sizes, int type,
+                          void* data, size_t* step, int flags, UMatUsageFlags usageFlags) const = 0;
     virtual bool allocate(UMatData* data, int accessflags, UMatUsageFlags usageFlags) const = 0;
     virtual void deallocate(UMatData* data) const = 0;
+    virtual void deallocateData(UMatData* data) const = 0;
     virtual void map(UMatData* data, int accessflags) const;
     virtual void unmap(UMatData* data) const;
     virtual void download(UMatData* data, void* dst, int dims, const size_t sz[],

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -196,6 +196,12 @@ public:
         return u;
     }
 
+    void allocate(UMatData* u, int dims, const int* sizes, int type,
+                       void* data0, size_t* step, int /*flags*/, UMatUsageFlags /*usageFlags*/) const
+    {
+        return;
+    }
+
     bool allocate(UMatData* u, int /*accessFlags*/, UMatUsageFlags /*usageFlags*/) const
     {
         if(!u) return false;
@@ -214,6 +220,27 @@ public:
                 u->origdata = 0;
             }
             delete u;
+        }
+    }
+
+    void deallocateData(UMatData* u) const
+    {
+        CV_Assert(u->urefcount >= 0);
+        CV_Assert(u->refcount >= 0);
+        if(u && u->refcount == 0)
+        {
+            if( !(u->flags & UMatData::USER_ALLOCATED) )
+            {
+                fastFree(u->origdata);
+                u->origdata = 0;
+                u->data = 0;
+                u->size = 0;
+                u->capacity = 0;
+                u->flags = 0;
+                u->allocatorFlags_ = 0;
+                u->prevAllocator = 0;
+                u->currAllocator = 0;
+            }
         }
     }
 };

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -196,8 +196,8 @@ public:
         return u;
     }
 
-    void allocate(UMatData* u, int dims, const int* sizes, int type,
-                       void* data0, size_t* step, int /*flags*/, UMatUsageFlags /*usageFlags*/) const
+    void allocate(UMatData* /*u*/, int /*dims*/, const int* /*sizes*/, int /*type*/,
+                  void* /*data0*/, size_t* /*step*/, int /*flags*/, UMatUsageFlags /*usageFlags*/) const
     {
         return;
     }

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3951,7 +3951,7 @@ public:
         }
     }
 
-    void deallocateData(UMatData* u) const
+    void deallocateData(UMatData* /*u*/) const
     {
         return;
     }

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3767,6 +3767,57 @@ public:
         return u;
     }
 
+    void allocate(UMatData* u, int dims, const int* sizes, int type,
+                       void* data, size_t* step, int flags, UMatUsageFlags usageFlags) const
+    {
+        if(!useOpenCL())
+            return;
+
+        UMatDataAutoLock lock(u);
+
+        CV_Assert(data == 0);
+        size_t total = CV_ELEM_SIZE(type);
+        for( int i = dims-1; i >= 0; i-- )
+        {
+            if( step )
+                step[i] = total;
+            total *= sizes[i];
+        }
+
+        Context& ctx = Context::getDefault();
+        int createFlags = 0, flags0 = 0;
+        getBestFlags(ctx, flags, usageFlags, createFlags, flags0);
+
+        size_t capacity = 0;
+        void* handle = NULL;
+        int allocatorFlags = 0;
+        if (createFlags == 0)
+        {
+            handle = bufferPool.allocate(total, capacity);
+            if (!handle)
+                return;
+            allocatorFlags = ALLOCATOR_FLAGS_BUFFER_POOL_USED;
+        }
+        else
+        {
+            capacity = total;
+            cl_int retval = 0;
+            handle = clCreateBuffer((cl_context)ctx.ptr(),
+                                          CL_MEM_READ_WRITE|createFlags, total, 0, &retval);
+            if( !handle || retval != CL_SUCCESS )
+                return;
+        }
+        u->prevAllocator = u->currAllocator = this;
+        u->data = 0;
+        u->size = total;
+        u->capacity = capacity;
+        u->handle = handle;
+        u->flags = flags0;
+        u->allocatorFlags_ = allocatorFlags;
+        CV_DbgAssert(!u->tempUMat()); // for bufferPool.release() consistency in deallocate()
+        return;
+    }
+
     bool allocate(UMatData* u, int accessFlags, UMatUsageFlags usageFlags) const
     {
         if(!u)
@@ -3898,6 +3949,11 @@ public:
             u->capacity = 0;
             delete u;
         }
+    }
+
+    void deallocateData(UMatData* u) const
+    {
+        return;
     }
 
     void map(UMatData* u, int accessFlags) const

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -177,7 +177,7 @@ public:
         return allocate(o, dims0, sizes, type, step);
     }
 
-    void allocate(UMatData* u, int dims, const int* sizes, int type, void* data0, size_t* step, int /*flags*/, UMatUsageFlags /*usageFlags*/) const
+    void allocate(UMatData* /*u*/, int /*dims*/, const int* /*sizes*/, int /*type*/, void* /*data0*/, size_t* /*step*/, int /*flags*/, UMatUsageFlags /*usageFlags*/) const
     {
         return;
     }
@@ -198,7 +198,7 @@ public:
         }
     }
 
-    void deallocateData(UMatData* u) const
+    void deallocateData(UMatData* /*u*/) const
     {
         return;
     }

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -177,6 +177,11 @@ public:
         return allocate(o, dims0, sizes, type, step);
     }
 
+    void allocate(UMatData* u, int dims, const int* sizes, int type, void* data0, size_t* step, int /*flags*/, UMatUsageFlags /*usageFlags*/) const
+    {
+        return;
+    }
+
     bool allocate(UMatData* u, int accessFlags, UMatUsageFlags usageFlags) const
     {
         return stdAllocator->allocate(u, accessFlags, usageFlags);
@@ -191,6 +196,11 @@ public:
             Py_XDECREF(o);
             delete u;
         }
+    }
+
+    void deallocateData(UMatData* u) const
+    {
+        return;
     }
 
     const MatAllocator* stdAllocator;


### PR DESCRIPTION
When UMat is created when OpenCL is off, the data buffer in UMatData
is allocated from cpu side. However, if OpenCL is then on, cl buffer
will not be allocated for this UMat. As a result, if this UMat is used
as a parameter of cl kernel, OpenCL path will fail and fall back to
cpu path. With this patch, the sample tapi-example-hog will run
correctly when switch between CPU and OpenCL mode.

Signed-off-by: Chuanbo Weng <chuanbo.weng@intel.com>