### PR TITLE
Fixed OpenNI2 registration bug:  It was always off, even after changing the property value

### DIFF
--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -566,7 +566,7 @@ bool CvCapture_OpenNI2::setDepthGeneratorProperty( int propIdx, double propValue
                 // then the property isn't avaliable
                 if ( color.isValid() )
                 {
-                    openni::ImageRegistrationMode mode = propValue < 1.0 ? openni::IMAGE_REGISTRATION_OFF : openni::IMAGE_REGISTRATION_DEPTH_TO_COLOR;
+                    openni::ImageRegistrationMode mode = propValue < 1.0 ? openni::IMAGE_REGISTRATION_DEPTH_TO_COLOR : openni::IMAGE_REGISTRATION_OFF;
                     if( !device.getImageRegistrationMode() == mode )
                     {
                         if (device.isImageRegistrationModeSupported(mode))


### PR DESCRIPTION
Comment: The propValue < 1.0? is unnecessary since in order to enter to the if, propValue has to be less than 1.0.