### PR TITLE
Act on INSTALL_PYTHON_EXAMPLES

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -22,6 +22,10 @@ if(ANDROID AND BUILD_ANDROID_EXAMPLES)
   add_subdirectory(android)
 endif()
 
+if(INSTALL_PYTHON_EXAMPLES)
+  add_subdirectory(python2)
+endif()
+
 #
 # END OF BUILD CASE 1: Build samples with library sources
 #

--- a/samples/python2/CMakeLists.txt
+++ b/samples/python2/CMakeLists.txt
@@ -1,0 +1,6 @@
+if(INSTALL_PYTHON_EXAMPLES)
+  file(GLOB install_list *.py )
+  install(FILES ${install_list}
+          DESTINATION ${OPENCV_SAMPLES_SRC_INSTALL_PATH}/python2
+          PERMISSIONS OWNER_READ GROUP_READ WORLD_READ COMPONENT samples)
+endif()


### PR DESCRIPTION
Python samples not installed with -DINSTALL_PYTHON_EXAMPLES=ON.
This fixes it for me, based on other samples CMakeLists.txt.
