### PR TITLE
Check if _WIN32_IE is defined with proper value in window_w32.cpp.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -48,6 +48,11 @@
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
 #endif
 
+#if (_WIN32_IE < 0x0500)
+#pragma message("WARNING: Win32 UI needs to be compiled with _WIN32_IE >= 0x0500 (_WIN32_IE_IE50)")
+#define _WIN32_IE 0x0500
+#endif
+
 #include <commctrl.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
TBBUTTONINFO struct and BTNS_xxx symbols used in the code need _WIN32_IE defined with at least 0x0500 value (_WIN32_IE_IE50) in order to be included from commctrl.h.
If this value is lower then required then compilation warning is displayed and _WIN32_IE is redefined to the minimal proper value.