### PR TITLE
Fix cppcheck reports:

### DIFF
--- a/modules/features2d/src/kaze/utils.h
+++ b/modules/features2d/src/kaze/utils.h
@@ -7,7 +7,7 @@
  */
 inline float getAngle(float x, float y) {
 
-  if (x >= 0 && y >= 0) {
+  if (x > 0 && y >= 0) {
     return atanf(y / x);
   }
 
@@ -19,7 +19,7 @@ inline float getAngle(float x, float y) {
     return static_cast<float>(CV_PI)+atanf(y / x);
   }
 
-  if (x >= 0 && y < 0) {
+  if (x > 0 && y < 0) {
     return static_cast<float>(2.0 * CV_PI) - atanf(-y / x);
   }
 

--- a/modules/objdetect/src/haar.cpp
+++ b/modules/objdetect/src/haar.cpp
@@ -547,14 +547,14 @@ cvSetImagesForHaarClassifierCascade( CvHaarClassifierCascade* _cascade,
                 kx = r[0].width / base_w;
                 ky = r[0].height / base_h;
 
-                if( kx <= 0 )
+                if( kx < 0 )
                 {
                     flagx = 1;
                     new_base_w = cvRound( r[0].width * scale ) / kx;
                     x0 = cvRound( r[0].x * scale );
                 }
 
-                if( ky <= 0 )
+                if( ky < 0 )
                 {
                     flagy = 1;
                     new_base_h = cvRound( r[0].height * scale ) / ky;


### PR DESCRIPTION
[modules/features2d/src/kaze/utils.h:10] -> [modules/features2d/src/kaze/utils.h:11]: (warning) Either the condition 'x>=0' is useless or there is division by zero at line 11.
[modules/features2d/src/kaze/utils.h:22] -> [modules/features2d/src/kaze/utils.h:23]: (warning) Either the condition 'x>=0' is useless or there is division by zero at line 23.
[modules/objdetect/src/haar.cpp:550] -> [modules/objdetect/src/haar.cpp:553]: (warning) Either the condition 'kx<=0' is useless or there is division by zero at line 553.
[modules/objdetect/src/haar.cpp:557] -> [modules/objdetect/src/haar.cpp:560]: (warning) Either the condition 'ky<=0' is useless or there is division by zero at line 560.