### PR TITLE
Inclusion of a LUCID implementation

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -1283,7 +1283,7 @@ matrix, 2 = 5x5, 3 = 7x7, and so on
 @param blur_kernel Blur kernel size where 1 equates a 3x3 matrix, and so on as before. Blur is
 applied to a temporary buffer before constructing descriptors.
 */
-CV_EXPORTS void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, CV_OUT std::vector<std::vector<std::size_t> > &descriptors, const int lucid_kernel, const int blur_kernel);
+CV_EXPORTS void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, CV_OUT std::vector<std::vector<int> > &descriptors, const int lucid_kernel, const int blur_kernel);
 
 /** @brief Separable box filter blur, needed by LUCID, also exposed for the user
 

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -1283,7 +1283,7 @@ matrix, 2 = 5x5, 3 = 7x7, and so on
 @param blur_kernel Blur kernel size where 1 equates a 3x3 matrix, and so on as before. Blur is
 applied to a temporary buffer before constructing descriptors.
 */
-CV_EXPORTS void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, CV_OUT std::vector<std::vector<std::size_t> > &descriptors, const std::ptrdiff_t lucid_kernel, const std::ptrdiff_t blur_kernel);
+CV_EXPORTS void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, CV_OUT std::vector<std::vector<std::size_t> > &descriptors, const int lucid_kernel, const int blur_kernel);
 
 /** @brief Separable box filter blur, needed by LUCID, also exposed for the user
 
@@ -1291,7 +1291,7 @@ CV_EXPORTS void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoi
 @param _dst Image resulting from _src having blur applied, the output image
 @param kernel Blur kernel size where 1 equates a 3x3 matrix, 2 = 5x5, 3 = 7x7, and so on
 */
-CV_EXPORTS void separable_blur(const InputArray _src, CV_OUT OutputArray _dst, const std::ptrdiff_t kernel);
+CV_EXPORTS void separable_blur(const InputArray _src, CV_OUT OutputArray _dst, const int kernel);
 
 //! @} features2d_category
 

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -1271,6 +1271,28 @@ protected:
     Ptr<DescriptorMatcher> dmatcher;
 };
 
+
+/** @brief Constructs descriptors using LUCID algorithm
+
+@param _src Image from which descriptors should be constructed
+@param keypoints Vector of keypoints that were found in _src via a feature detector such as FAST
+@param descriptors Empty vector that is used as descriptor storage. One descriptor equates one
+vector of integers, hence a vector of vectors of ints.
+@param lucid_kernel Kernel size to consider when constructing descriptors, where 1 equates a 3x3
+matrix, 2 = 5x5, 3 = 7x7, and so on
+@param blur_kernel Blur kernel size where 1 equates a 3x3 matrix, and so on as before. Blur is
+applied to a temporary buffer before constructing descriptors.
+*/
+CV_EXPORTS void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, CV_OUT std::vector<std::vector<std::size_t> > &descriptors, const std::ptrdiff_t lucid_kernel, const std::ptrdiff_t blur_kernel);
+
+/** @brief Separable box filter blur, needed by LUCID, also exposed for the user
+
+@param _src Image on which blur should be applied
+@param _dst Image resulting from _src having blur applied, the output image
+@param kernel Blur kernel size where 1 equates a 3x3 matrix, 2 = 5x5, 3 = 7x7, and so on
+*/
+CV_EXPORTS void separable_blur(const InputArray _src, CV_OUT OutputArray _dst, const std::ptrdiff_t kernel);
+
 //! @} features2d_category
 
 //! @} features2d

--- a/modules/features2d/src/lucid.cpp
+++ b/modules/features2d/src/lucid.cpp
@@ -1,0 +1,220 @@
+// Ziegler, Andrew, Eric Christiansen, David Kriegman, and Serge J. Belongie.
+// "Locally uniform comparison image descriptor." In Advances in Neural Information
+// Processing Systems, pp. 1-9. 2012.
+
+// This implementation of, and any deviation from, the original algorithm as
+// proposed by Ziegler et al. is not endorsed by Ziegler et al. nor does it
+// claim to represent their definition of locally uniform comparison image
+// descriptor. The original LUCID algorithm as proposed by Ziegler et al. remains
+// the property of its respective authors. This implementation is an adaptation of
+// said algorithm and contributed to OpenCV by Str3iber.
+
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+                          License Agreement
+               For Open Source Computer Vision Library
+                       (3-clause BSD License)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the names of the copyright holders nor the names of the contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+
+#include "precomp.hpp"
+
+namespace cv {
+    static void radix_sort(std::vector<std::size_t> *x, const std::size_t k) {
+        std::vector<std::size_t> p(k);
+
+        std::ptrdiff_t l;
+
+        std::size_t i, e = 1, h = (*x)[0];
+
+        for (i = 0; i < k; ++i) {
+            if ((*x)[i] > h)
+                h = (*x)[i];
+        }
+
+        while (h/e > 0) {
+            std::ptrdiff_t b[10] = {0};
+
+            for (i = 0; i < k; ++i)
+                ++b[(*x)[i]/e%10];
+            for (i = 1; i < 10; ++i)
+                b[i] += b[i-1];
+            for (l = k-1; l >= 0; --l)
+                p[--b[(*x)[l]/e%10]] = (*x)[l];
+            for (i = 0; i < k; ++i)
+                (*x)[i] = p[i];
+
+            e *= 10;
+        }
+    }
+
+    void separable_blur(const InputArray _src, OutputArray _dst, const std::ptrdiff_t kernel) {
+        std::ptrdiff_t z, p, r, g, b, m = kernel*2+1, width, height;
+
+        Point3_<uchar> *pnt;
+
+        Mat src = _src.getMat();
+        _dst.create(src.size(), src.type());
+        Mat dst = _dst.getMat();
+
+        width = dst.cols, height = dst.rows;
+
+        for (std::ptrdiff_t y = 0; y < height; ++y) {
+            for (std::ptrdiff_t x = 0; x < width; ++x) {
+                z = kernel*-1;
+
+                if (!x) {
+                    r = 0, g = 0, b = 0;
+
+                    for (p = x+z; z <= kernel; ++z, p=x+z) {
+                        pnt = src.ptr<Point3_<uchar> >(y, (p < 0 ? width+p : p >= width ? p-width : p));
+                        r += pnt->z;
+                        g += pnt->y;
+                        b += pnt->x;
+                    }
+                }
+                else {
+                    p = x+z-1;
+
+                    pnt = src.ptr<Point3_<uchar> >(y, (p < 0 ? width+p : p >= width ? p-width : p));
+                    r -= pnt->z;
+                    g -= pnt->y;
+                    b -= pnt->x;
+
+                    p = x+kernel;
+
+                    pnt = src.ptr<Point3_<uchar> >(y, (p < 0 ? width+p : p >= width ? p-width : p));
+                    r += pnt->z;
+                    g += pnt->y;
+                    b += pnt->x;
+                }
+
+                pnt = dst.ptr<Point3_<uchar> >(y, x);
+                pnt->z = r/m;
+                pnt->y = g/m;
+                pnt->x = b/m;
+            }
+        }
+
+        for (std::ptrdiff_t x = 0, rl = 0, gl = 0, bl = 0, rn = 0, gn = 0, bn = 0; x < width; ++x) {
+            for (std::ptrdiff_t y = 0; y < height; ++y) {
+                z = kernel*-1;
+
+                if (!y) {
+                    r = 0, g = 0, b = 0;
+
+                    for (p = y+z; z <= kernel; ++z, p=y+z) {
+                        pnt = dst.ptr<Point3_<uchar> >((p < 0 ? height+p : p >= height ? p-height : p), x);
+                        r += pnt->z;
+                        g += pnt->y;
+                        b += pnt->x;
+                    }
+                }
+                else {
+                    p = y+z-1;
+
+                    pnt = dst.ptr<Point3_<uchar> >((p < 0 ? height+p : p >= height ? p-height : p), x);
+                    r -= pnt->z, r -= rl;
+                    g -= pnt->y, g -= gl;
+                    b -= pnt->x, b -= bl;
+
+                    p = y+kernel;
+
+                    pnt = dst.ptr<Point3_<uchar> >((p < 0 ? height+p : p >= height ? p-height : p), x);
+                    r += pnt->z, r += rn;
+                    g += pnt->y, g += gn;
+                    b += pnt->x, b += bn;
+                }
+
+                pnt = dst.ptr<Point3_<uchar> >(y, x);
+                rl = pnt->z;
+                gl = pnt->y;
+                bl = pnt->x;
+                rn = r/m;
+                gn = g/m;
+                bn = b/m;
+                pnt->z = rn;
+                pnt->y = gn;
+                pnt->x = bn;
+            }
+        }
+    }
+
+    void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, std::vector<std::vector<std::size_t> > &descriptors, const std::ptrdiff_t lucid_kernel, const std::ptrdiff_t blur_kernel) {
+        Mat src;
+
+        separable_blur(_src.getMat(), src, blur_kernel);
+
+        Point3_<uchar> *pnt;
+
+        std::ptrdiff_t x, y, j, d, p, m = static_cast<std::ptrdiff_t>(std::pow(lucid_kernel*2+1, 2)*3), width = src.cols, height = src.rows;
+
+        std::vector<Point2i> corners;
+
+        corners.reserve(keypoints.size());
+        for (std::size_t i = 0; i < keypoints.size(); ++i)
+            corners.push_back(keypoints[i].pt);
+
+        descriptors.clear();
+        descriptors.reserve(corners.size());
+
+        for (std::size_t i = 0; i < corners.size(); ++i) {
+            x = corners[i].x-lucid_kernel, y = corners[i].y-lucid_kernel, d = x+2*lucid_kernel, p = y+2*lucid_kernel, j = x;
+
+            std::vector<std::size_t> buf;
+            buf.reserve(m);
+
+            while (x <= d) {
+                pnt = src.ptr<Point3_<uchar> >((y < 0 ? height+y : y >= height ? y-height : y), (x < 0 ? width+x : x >= width ? x-width : x));
+
+                buf.push_back(pnt->x);
+                buf.push_back(pnt->y);
+                buf.push_back(pnt->z);
+
+                ++x;
+                if (x > d) {
+                    if (y < p) {
+                        ++y;
+
+                        x = j;
+                    }
+                    else
+                        break;
+                }
+            }
+
+            radix_sort(&buf, m);
+            descriptors.push_back(buf);
+        }
+
+        descriptors.swap(descriptors);
+    }
+}

--- a/modules/features2d/src/lucid.cpp
+++ b/modules/features2d/src/lucid.cpp
@@ -48,12 +48,10 @@ the use of this software, even if advised of the possibility of such damage.
 #include "precomp.hpp"
 
 namespace cv {
-    static void radix_sort(std::vector<std::size_t> *x, const std::size_t k) {
-        std::vector<std::size_t> p(k);
+    static void radix_sort(std::vector<int> *x, const int k) {
+        std::vector<int> p(k);
 
-        int l;
-
-        std::size_t i, e = 1, h = (*x)[0];
+        int l, i, e = 1, h = (*x)[0];
 
         for (i = 0; i < k; ++i) {
             if ((*x)[i] > h)
@@ -168,7 +166,7 @@ namespace cv {
         }
     }
 
-    void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, std::vector<std::vector<std::size_t> > &descriptors, const int lucid_kernel, const int blur_kernel) {
+    void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, std::vector<std::vector<int> > &descriptors, const int lucid_kernel, const int blur_kernel) {
         Mat src;
 
         separable_blur(_src.getMat(), src, blur_kernel);
@@ -189,7 +187,7 @@ namespace cv {
         for (std::size_t i = 0; i < corners.size(); ++i) {
             x = corners[i].x-lucid_kernel, y = corners[i].y-lucid_kernel, d = x+2*lucid_kernel, p = y+2*lucid_kernel, j = x;
 
-            std::vector<std::size_t> buf;
+            std::vector<int> buf;
             buf.reserve(m);
 
             while (x <= d) {

--- a/modules/features2d/src/lucid.cpp
+++ b/modules/features2d/src/lucid.cpp
@@ -51,7 +51,7 @@ namespace cv {
     static void radix_sort(std::vector<std::size_t> *x, const std::size_t k) {
         std::vector<std::size_t> p(k);
 
-        std::ptrdiff_t l;
+        int l;
 
         std::size_t i, e = 1, h = (*x)[0];
 
@@ -61,7 +61,7 @@ namespace cv {
         }
 
         while (h/e > 0) {
-            std::ptrdiff_t b[10] = {0};
+            int b[10] = {0};
 
             for (i = 0; i < k; ++i)
                 ++b[(*x)[i]/e%10];
@@ -76,8 +76,8 @@ namespace cv {
         }
     }
 
-    void separable_blur(const InputArray _src, OutputArray _dst, const std::ptrdiff_t kernel) {
-        std::ptrdiff_t z, p, r, g, b, m = kernel*2+1, width, height;
+    void separable_blur(const InputArray _src, OutputArray _dst, const int kernel) {
+        int z, p, r = 0, g = 0, b = 0, m = kernel*2+1, width, height;
 
         Point3_<uchar> *pnt;
 
@@ -87,8 +87,8 @@ namespace cv {
 
         width = dst.cols, height = dst.rows;
 
-        for (std::ptrdiff_t y = 0; y < height; ++y) {
-            for (std::ptrdiff_t x = 0; x < width; ++x) {
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
                 z = kernel*-1;
 
                 if (!x) {
@@ -118,14 +118,14 @@ namespace cv {
                 }
 
                 pnt = dst.ptr<Point3_<uchar> >(y, x);
-                pnt->z = r/m;
-                pnt->y = g/m;
-                pnt->x = b/m;
+                pnt->z = static_cast<uchar>(r/m);
+                pnt->y = static_cast<uchar>(g/m);
+                pnt->x = static_cast<uchar>(b/m);
             }
         }
 
-        for (std::ptrdiff_t x = 0, rl = 0, gl = 0, bl = 0, rn = 0, gn = 0, bn = 0; x < width; ++x) {
-            for (std::ptrdiff_t y = 0; y < height; ++y) {
+        for (int x = 0, rl = 0, gl = 0, bl = 0, rn = 0, gn = 0, bn = 0; x < width; ++x) {
+            for (int y = 0; y < height; ++y) {
                 z = kernel*-1;
 
                 if (!y) {
@@ -161,21 +161,21 @@ namespace cv {
                 rn = r/m;
                 gn = g/m;
                 bn = b/m;
-                pnt->z = rn;
-                pnt->y = gn;
-                pnt->x = bn;
+                pnt->z = static_cast<uchar>(rn);
+                pnt->y = static_cast<uchar>(gn);
+                pnt->x = static_cast<uchar>(bn);
             }
         }
     }
 
-    void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, std::vector<std::vector<std::size_t> > &descriptors, const std::ptrdiff_t lucid_kernel, const std::ptrdiff_t blur_kernel) {
+    void LUCID(const InputArray _src, const std::vector<KeyPoint> &keypoints, std::vector<std::vector<std::size_t> > &descriptors, const int lucid_kernel, const int blur_kernel) {
         Mat src;
 
         separable_blur(_src.getMat(), src, blur_kernel);
 
         Point3_<uchar> *pnt;
 
-        std::ptrdiff_t x, y, j, d, p, m = static_cast<std::ptrdiff_t>(std::pow(lucid_kernel*2+1, 2)*3), width = src.cols, height = src.rows;
+        int x, y, j, d, p, m = static_cast<int>(std::pow(lucid_kernel*2+1, 2)*3), width = src.cols, height = src.rows;
 
         std::vector<Point2i> corners;
 

--- a/modules/features2d/test/test_lucid.cpp
+++ b/modules/features2d/test/test_lucid.cpp
@@ -65,9 +65,12 @@ void CV_LUCIDTest::run(int) {
     cvtColor(image, buf, COLOR_BGR2GRAY);
 
     std::vector<KeyPoint> kpt;
-    std::vector<std::vector<std::size_t> > dsc;
+    std::vector<std::vector<int> > dsc;
 
     FAST(buf, kpt, 9, 1);
+    if (kpt.empty()) {
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
+    }
     KeyPointsFilter::retainBest(kpt, 100);
 
     LUCID(image, kpt, dsc, 1, 2);
@@ -78,6 +81,14 @@ void CV_LUCIDTest::run(int) {
                 ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
 
                 return;
+            }
+
+            for (std::size_t x = 0; x < 27; ++x) {
+                if (x > 0 && dsc[i][x] < dsc[i][x-1]) {
+                    ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+
+                    return;
+                }
             }
         }
     }

--- a/modules/features2d/test/test_lucid.cpp
+++ b/modules/features2d/test/test_lucid.cpp
@@ -1,0 +1,84 @@
+// LUCID test case by Str3iber
+
+/*
+By downloading, copying, installing or using the software you agree to this license.
+If you do not agree to this license, do not download, install,
+copy or use the software.
+
+
+                          License Agreement
+               For Open Source Computer Vision Library
+                       (3-clause BSD License)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the names of the copyright holders nor the names of the contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.
+*/
+
+#include "test_precomp.hpp"
+
+using namespace cv;
+
+class CV_LUCIDTest : public cvtest::BaseTest {
+    public:
+        CV_LUCIDTest();
+        ~CV_LUCIDTest();
+
+    protected:
+        void run(int);
+};
+
+CV_LUCIDTest::CV_LUCIDTest() {}
+CV_LUCIDTest::~CV_LUCIDTest() {}
+
+void CV_LUCIDTest::run(int) {
+    Mat image = imread(std::string(ts->get_data_path()) + "inpaint/orig.png");
+
+    if (image.empty()) {
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_TEST_DATA);
+
+        return;
+    }
+
+    Mat buf;
+    cvtColor(image, buf, COLOR_BGR2GRAY);
+
+    std::vector<KeyPoint> kpt;
+    std::vector<std::vector<std::size_t> > dsc;
+
+    FAST(buf, kpt, 9, 1);
+    cv::KeyPointsFilter::retainBest(kpt, 100);
+
+    LUCID(image, kpt, dsc, 1, 2);
+
+    if (dsc[4][21] != 168 || dsc[19][25] != 161 || dsc[28][20] != 171 || dsc[39][10] != 132 || dsc[51][13] != 138 || dsc[51][6] != 112 || dsc[72][9] != 129 || dsc[80][24] != 182 || dsc[93][1] != 77) {
+        ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+
+        return;
+    }
+
+    ts->set_failed_test_info(cvtest::TS::OK);
+}
+
+TEST(Features2d_LUCID, regression) { CV_LUCIDTest test; test.safe_run(); }

--- a/modules/features2d/test/test_lucid.cpp
+++ b/modules/features2d/test/test_lucid.cpp
@@ -68,11 +68,20 @@ void CV_LUCIDTest::run(int) {
     std::vector<std::vector<std::size_t> > dsc;
 
     FAST(buf, kpt, 9, 1);
-    cv::KeyPointsFilter::retainBest(kpt, 100);
+    KeyPointsFilter::retainBest(kpt, 100);
 
     LUCID(image, kpt, dsc, 1, 2);
 
-    if (dsc[4][21] != 168 || dsc[19][25] != 161 || dsc[28][20] != 171 || dsc[39][10] != 132 || dsc[51][13] != 138 || dsc[51][6] != 112 || dsc[72][9] != 129 || dsc[80][24] != 182 || dsc[93][1] != 77) {
+    if (!dsc.empty()) {
+        for (std::size_t i = 0; i < dsc.size(); ++i) {
+            if (dsc[i].size() != 27) {
+                ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+
+                return;
+            }
+        }
+    }
+    else {
         ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
 
         return;

--- a/samples/cpp/lucid.cpp
+++ b/samples/cpp/lucid.cpp
@@ -1,0 +1,51 @@
+#include "opencv2/core/core.hpp"
+#include "opencv2/highgui/highgui.hpp"
+#include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/features2d/features2d.hpp"
+#include <iostream>
+
+using namespace cv;
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        std::cout << "Usage: ./lucid image.jpg\n";
+        return 1;
+    }
+
+    Mat image, buf;
+    image = imread(argv[1], CV_LOAD_IMAGE_COLOR);
+
+    if (!image.data) {
+        std::cout << "Could not open or find the image\n";
+        return 1;
+    }
+
+    cvtColor(image, buf, CV_BGR2GRAY);
+
+    std::vector<KeyPoint> kpt;
+    std::vector<std::vector<std::size_t> > dsc;
+
+    FAST(buf, kpt, 9, 1);
+    KeyPointsFilter::retainBest(kpt, 100);
+
+    LUCID(image, kpt, dsc, 1, 2);
+
+    for (std::size_t i = 0; i < dsc.size(); ++i) {
+        for (std::size_t x = 0; x < dsc[i].size(); ++x) {
+            std::cout << "Descriptor #" << i << ", Value #" << x << ": " << dsc[i][x] << "\n";
+        }
+    }
+
+    separable_blur(image, buf, 6);
+
+    namedWindow("Source image", WINDOW_AUTOSIZE);
+    imshow("Source image", image);
+
+    namedWindow("Blurred image", WINDOW_AUTOSIZE);
+    imshow("Blurred image", buf);
+
+    waitKey(0);
+
+    return 0;
+}
+

--- a/samples/cpp/lucid.cpp
+++ b/samples/cpp/lucid.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
     cvtColor(image, buf, CV_BGR2GRAY);
 
     std::vector<KeyPoint> kpt;
-    std::vector<std::vector<std::size_t> > dsc;
+    std::vector<std::vector<int> > dsc;
 
     FAST(buf, kpt, 9, 1);
     KeyPointsFilter::retainBest(kpt, 100);

--- a/samples/cpp/lucid.cpp
+++ b/samples/cpp/lucid.cpp
@@ -48,4 +48,3 @@ int main(int argc, char *argv[]) {
 
     return 0;
 }
-


### PR DESCRIPTION
OpenCV currently contains at least two nonfree programs that can be used for construction of image descriptors (SURF and SIFT, to my knowledge). I offer a free adaptation of the Locally Uniform Comparison Image Descriptor (Ziegler, Andrew, Eric Christiansen, David Kriegman, and Serge J. Belongie. "Locally uniform comparison image descriptor." In Advances in Neural Information Processing Systems, pp. 1-9. 2012.), under a license compatible to GPL, hoping to provide one additional free program to OpenCV that allows descriptor construction, such that developers and users need not sacrifice the freedom of their computer for completion of this task.

This is my first contribution to OpenCV. I attempted to adhere to coding standards where required as instructed by your style guide. This initial functionality includes the construction of descriptors, as well as exposing a separable box filter blur that the developer may use on images independently. I have also included a simple test case, sample code and required documentation. This code compiles and the test succeeds on my GNU/Linux operating system, but is currently untested on other platforms. In accordance with your contribution guide, this commit does not include additional feature matching functionality that would be compatible with this image descriptor, as is stated that PRs should focus on one issue at a time. Please don't hesitate to point out in which places, if any, the code is not yet suitable for inclusion into OpenCV, and I will attempt to rectify it in a timely manner.