### PR TITLE
fix to work with python 2.6

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -861,7 +861,7 @@ class PythonWrapperGenerator(object):
             decls = self.parser.parse(hdr)
             if len(decls) == 0:
                 continue
-            self.code_include.write( '#include "{}"\n'.format(hdr[hdr.rindex('opencv2/'):]) )
+            self.code_include.write( '#include "{0}"\n'.format(hdr[hdr.rindex('opencv2/'):]) )
             for decl in decls:
                 name = decl[0]
                 if name.startswith("struct") or name.startswith("class"):


### PR DESCRIPTION
I had to make this modification locally to get opencv to build with python 2.6.  Python 2.6 requires indices in the format string (the `0` I added).  This requirement was relaxed in 2.7, so what used to be there would be working for people who could upgrade. I don't think the change has any negative consequences for future python versions, but I'm no expert.