### PR TITLE
Multipage imread

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -134,6 +134,16 @@ returns an empty matrix ( Mat::data==NULL ). Currently, the following file forma
  */
 CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 
+/** @brief Loads a multi-page image from a file. (see imread for details.)
+
+@param filename Name of file to be loaded.
+@param flags Flags specifying the color type of a loaded image (see imread).
+            Defaults to IMREAD_ANYCOLOR, as each page may be different.
+@param mats A vector of Mat objects holding each page, if more than one.
+
+*/
+CV_EXPORTS_W bool imreadmulti(const String& filename, std::vector<Mat>& mats, int flags = IMREAD_ANYCOLOR);
+
 /** @brief Saves an image to a specified file.
 
 @param filename Name of the file.

--- a/modules/imgcodecs/src/grfmt_base.hpp
+++ b/modules/imgcodecs/src/grfmt_base.hpp
@@ -70,6 +70,9 @@ public:
     virtual bool readHeader() = 0;
     virtual bool readData( Mat& img ) = 0;
 
+    /// Called after readData to advance to the next page, if any.
+    virtual bool nextPage() { return false; }
+
     virtual size_t signatureLength() const;
     virtual bool checkSignature( const String& signature ) const;
     virtual ImageDecoder newDecoder() const;

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -118,10 +118,13 @@ bool TiffDecoder::readHeader()
 {
     bool result = false;
 
-    close();
-    // TIFFOpen() mode flags are different to fopen().  A 'b' in mode "rb" has no effect when reading.
-    // http://www.remotesensing.org/libtiff/man/TIFFOpen.3tiff.html
-    TIFF* tif = TIFFOpen( m_filename.c_str(), "r" );
+    TIFF* tif = static_cast<TIFF*>(m_tif);
+    if (!m_tif)
+    {
+        // TIFFOpen() mode flags are different to fopen().  A 'b' in mode "rb" has no effect when reading.
+        // http://www.remotesensing.org/libtiff/man/TIFFOpen.3tiff.html
+        tif = TIFFOpen(m_filename.c_str(), "r");
+    }
 
     if( tif )
     {
@@ -182,6 +185,13 @@ bool TiffDecoder::readHeader()
     return result;
 }
 
+bool TiffDecoder::nextPage()
+{
+    // Prepare the next page, if any.
+    return m_tif &&
+           TIFFReadDirectory(static_cast<TIFF*>(m_tif)) && 
+           readHeader();
+}
 
 bool  TiffDecoder::readData( Mat& img )
 {
@@ -413,7 +423,6 @@ bool  TiffDecoder::readData( Mat& img )
         }
     }
 
-    close();
     return result;
 }
 

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -189,7 +189,7 @@ bool TiffDecoder::nextPage()
 {
     // Prepare the next page, if any.
     return m_tif &&
-           TIFFReadDirectory(static_cast<TIFF*>(m_tif)) && 
+           TIFFReadDirectory(static_cast<TIFF*>(m_tif)) &&
            readHeader();
 }
 

--- a/modules/imgcodecs/src/grfmt_tiff.hpp
+++ b/modules/imgcodecs/src/grfmt_tiff.hpp
@@ -100,6 +100,7 @@ public:
     bool  readHeader();
     bool  readData( Mat& img );
     void  close();
+    bool  nextPage();
 
     size_t signatureLength() const;
     bool checkSignature( const String& signature ) const;


### PR DESCRIPTION
Added support to load multi-page images via imreadmulti API.

The mechanism is universal as BaseImageDecoder is augmented with a new function to allow for easy support of multipage decoding.
Multipage support is added to Tiff decoder, and is fully functional.

Complete tests added for both imread and imreadmulti (test images added to opencv_extra repo).

NOTES:
* The API could be alternatively named imread_multi (note the underscore). I leave this open to suggestions.
* I didn't include C API changes here as I'd like to get feedback on the interface. Specifically, should CvSeq be used for the output Mat array? Or should another approach be used?
* I didn't include 2.4 branch changes as I'd like get initial approval on the change set and API before I invest the necessary effort on 2.4 branch.
