### PR TITLE
More accurate AVX and AVX2 control.

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -144,11 +144,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   # SSE3 and further should be disabled under MingW because it generates compiler errors
   if(NOT MINGW)
     if(ENABLE_AVX)
-      ocv_check_flag_support(CXX "-mavx" _varname)
+      add_extra_compiler_option("-mavx")
     endif()
 
     if(ENABLE_AVX2)
-      ocv_check_flag_support(CXX "-mavx2" _varname)
+      add_extra_compiler_option("-mavx2")
     endif()
 
     # GCC depresses SSEx instructions when -mavx is used. Instead, it generates new AVX instructions or AVX equivalence for all SSEx instructions when needed.

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -3002,8 +3002,12 @@ void printVersionInfo(bool useStdOut)
 #if CV_SSE4_2
     if (checkHardwareSupport(CV_CPU_SSE4_2)) cpu_features += " sse4.2";
 #endif
+#if CV_AVX
     if (checkHardwareSupport(CV_CPU_AVX)) cpu_features += " avx";
+#endif
+#if CV_AVX2
     if (checkHardwareSupport(CV_CPU_AVX2)) cpu_features += " avx2";
+#endif
 #if CV_NEON
     cpu_features += " neon"; // NEON is currently not checked at runtime
 #endif


### PR DESCRIPTION
- Previous version just checked option support, but not enable it.
- Also OpenCV tests reports invalid AVX and AVX2 support status.