### PR TITLE
Fixed Bug similar to Bug#3757. UMat all dims zero after release.

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -3284,7 +3284,8 @@ inline void UMat::release()
 {
     if( u && CV_XADD(&(u->urefcount), -1) == 1 )
         deallocate();
-    size.p[0] = 0;
+    for(int i = 0; i < dims; i++)
+        size.p[i] = 0;
     u = 0;
 }
 


### PR DESCRIPTION
Initially, after calling release on a UMat object, only rows used to become 0. Now, all dims become zero. Similar to Pull Request #2891 