### PR TITLE
OCL: [Brute Force Match]Optimize OCL BFM.

### DIFF
--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -306,8 +306,8 @@ static bool ocl_radiusMatchSingle(InputArray query, InputArray train,
     if (k.empty())
         return false;
 
-    size_t globalSize[] = {(train_rows + block_size - 1) / block_size * block_size, (query_rows + block_size - 1) / block_size * block_size, 1};
-    size_t localSize[] = {block_size, block_size, 1};
+    size_t globalSize[] = {(train_rows + block_size - 1) / block_size * block_size, (query_rows + block_size - 1) / block_size * block_size};
+    size_t localSize[] = {block_size, block_size};
 
     int idx = 0;
     idx = k.set(idx, ocl::KernelArg::PtrReadOnly(uquery));


### PR DESCRIPTION
1. Remove unnecessary global/local dim for radius match.
2. Remove unecessary barrier.
3. Merge 1st and 2nd best searching of knn match.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>

check_regression=*OCL*
test_modules=features2d
build_examples=OFF