### PR TITLE
Fixing race condition in solvePnPRansac

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -196,18 +196,16 @@ namespace cv
                 }
             }
 
+            resultsMutex.lock();
             if (localInliers.size() > inliers.size())
             {
-                resultsMutex.lock();
-
                 inliers.clear();
                 inliers.resize(localInliers.size());
                 memcpy(&inliers[0], &localInliers[0], sizeof(int) * localInliers.size());
                 localRvec.copyTo(rvec);
                 localTvec.copyTo(tvec);
-
-                resultsMutex.unlock();
             }
+            resultsMutex.unlock();
         }
 
         static void pnpTask(const vector<char>& pointsMask, const Mat& objectPoints, const Mat& imagePoints,


### PR DESCRIPTION
`solvePnPRansac` is currently reading the `inliers` vector from multiple threads without a lock, which it is potentially being written to in another thread.  This race condition can result in the wrong sample being chosen as the ransac winner.

This PR expands the extent of the `resultsMutex` to ensure that `inliers` cannot be read while it is being updated.
