### PR TITLE
Get rid of sysctl includes on Linux.

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -56,7 +56,7 @@
     #include <sys/types.h>
     #if defined ANDROID
         #include <sys/sysconf.h>
-    #else
+    #elif defined __APPLE__
         #include <sys/sysctl.h>
     #endif
 #endif

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -163,8 +163,6 @@ std::wstring GetTempFileNameWinRT(std::wstring prefix)
 #include <sys/types.h>
 #if defined ANDROID
 #include <sys/sysconf.h>
-#else
-#include <sys/sysctl.h>
 #endif
 #endif
 

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -139,7 +139,9 @@ extern "C" {
     #include <unistd.h>
     #include <stdio.h>
     #include <sys/types.h>
+#if defined __APPLE__
     #include <sys/sysctl.h>
+#endif
 #endif
 
 #ifndef MIN


### PR DESCRIPTION
New Linux architectures like x32 lack the sysctl() syscall.  While opencv doesn't use it anymore, relevant headers are still #included.  On x32, this fails with:
`# error "sysctl system call is unsupported in x32 kernel"`