### PR TITLE
Allow YUYV capture via libv4l

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -136,7 +136,8 @@ enum { CAP_PROP_POS_MSEC       =0,
 // Currently, these are supported through the libv4l interface only.
 enum { CAP_MODE_BGR  = 0, // BGR24 (default)
        CAP_MODE_RGB  = 1, // RGB24
-       CAP_MODE_GRAY = 2  // Y8
+       CAP_MODE_GRAY = 2, // Y8
+       CAP_MODE_YUYV = 3  // YUYV
      };
 
 

--- a/modules/videoio/include/opencv2/videoio/videoio_c.h
+++ b/modules/videoio/include/opencv2/videoio/videoio_c.h
@@ -299,7 +299,8 @@ enum
 {
     CV_CAP_MODE_BGR  = 0, // BGR24 (default)
     CV_CAP_MODE_RGB  = 1, // RGB24
-    CV_CAP_MODE_GRAY = 2  // Y8
+    CV_CAP_MODE_GRAY = 2, // Y8
+    CV_CAP_MODE_YUYV = 3  // YUYV
 };
 
 enum


### PR DESCRIPTION
Support uncompressed capturing for webcams which support the YUYV pixel format.
After the read we can convert to BGR:
cv::cvtColor(m,out,CV_YUV2BGR_YUYV);