### PR TITLE
fix ocv_add_module CMake macro (2.4):

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -106,7 +106,6 @@ endmacro()
 #   ocv_add_module(yaom INTERNAL opencv_core opencv_highgui opencv_flann OPTIONAL opencv_gpu)
 macro(ocv_add_module _name)
   string(TOLOWER "${_name}" name)
-  string(REGEX REPLACE "^opencv_" "" ${name} "${name}")
   set(the_module opencv_${name})
 
   # the first pass - collect modules info, the second pass - create targets


### PR DESCRIPTION
it tries to remove 'opencv_' prefix from 'name' variable, but
it creates new variable with the same name as module