### PR TITLE
correct the size of buf which holds integral sum/sumsq

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -449,6 +449,12 @@ bool FeatureEvaluator::updateScaleData( Size imgsz, const std::vector<float>& _s
         s.ystep = sc >= 2 ? 1 : 2;
         s.scale = sc;
         s.szi = Size(sz.width+1, sz.height+1);
+
+        if( i == 0 )
+        {
+            layer_dy = s.szi.height;
+        }
+
         if( layer_ofs.x + s.szi.width > sbufSize.width )
         {
             layer_ofs = Point(0, layer_ofs.y + layer_dy);


### PR DESCRIPTION
layer_dy is not initialized correctly, it results in a small height
of the buffer, and so memory write is out of range in cv::integral.