### PR TITLE
TIFF support hack for aarch64 reverted.

### DIFF
--- a/modules/highgui/src/grfmt_tiff.cpp
+++ b/modules/highgui/src/grfmt_tiff.cpp
@@ -50,9 +50,8 @@
 #include "precomp.hpp"
 #include "grfmt_tiff.hpp"
 
-#if !defined _MSC_VER && !defined __BORLANDC__
-#  include <stdint.h>
-#endif
+#define int64 int64_tiff
+#define uint64 uint64_tiff
 
 #ifdef HAVE_TIFF
 # include "tiff.h"


### PR DESCRIPTION
To resolve int64 definition conflict in OpenCV core and libtiff.