### PR TITLE
In cvAddText, construct QString from "text" using fromUtf8.

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -117,7 +117,7 @@ CV_IMPL void cvAddText(const CvArr* img, const char* text, CvPoint org, CvFont* 
         "putText",
         autoBlockingConnection(),
         Q_ARG(void*, (void*) img),
-        Q_ARG(QString,QString(text)),
+        Q_ARG(QString,QString::fromUtf8(text)),
         Q_ARG(QPoint, QPoint(org.x,org.y)),
         Q_ARG(void*,(void*) font));
 }


### PR DESCRIPTION
Passing a Unicode UTF-8 string into cv::addText (or cvAddText) results in extraneous characters being drawn (often â or Â) and other being dropped (if their Unicode is greater than 255). This is a symptom of ignoring the multi-byte UTF-8 escape encoding.

Fortunately the Qt library is fully Unicode compliant so can render all glyphs defined by the standard if provided by the fonts in use. (Which is a lot, tens of thousands, see: http://unicode-table.com/en/) All that is needed to fix this bug was to call Qt's QString::fromUtf8 function to indicate the array of 8-bit values should be interpreted as UTF-8 rather than as a vanilla C char string.

Note that this patch provides support for drawing Unicode with Qt, but does not help with the conceptually related problem of using Unicode in pathnames.

Example before this change:

![before](https://cloud.githubusercontent.com/assets/1909341/5785885/9f9584d6-9d91-11e4-9055-d23cead7eddc.png)

Example after this change:

![after](https://cloud.githubusercontent.com/assets/1909341/5785890/aa747858-9d91-11e4-9247-a2319035976c.png)

C++ program to draw example:

```C++
#include <opencv/highgui.h>
int main (int argc, char** argv)
{
    cv::namedWindow ("Test", 1);
    cv::moveWindow ("Test", 10, 50);
    cv::Mat image (cv::Size (1000, 200), CV_8UC3, cv::Scalar(0, 111, 222));
    CvFont fontB = cv::fontQt ("Times", 30, cv::Scalar (255, 255, 255), CV_FONT_BOLD);
    CvFont fontW = cv::fontQt ("Helvetica", 30, cv::Scalar (0, 0, 0), CV_FONT_NORMAL);
    cv::addText (image,
                 "Here is some vanilla 7-bit 'ascii' text.",
                 cv::Point (50, 60),
                 fontB);
    cv::addText (image,
                 "Here is some text with extended “Unicode” glyphs, like circle-R: ®, ",
                 cv::Point (50, 110),
                 fontW);
    cv::addText (image,
                 "superscript TM: ™ and the point-of-interest symbol (OSX cmd): ⌘",
                 cv::Point (50, 145),
                 fontW);
    cv::imshow ("Test", image);
    cv::waitKey(0);
    return 0;
}
```