### PR TITLE
Update link to information about Android platform.

### DIFF
--- a/platforms/android/README.android
+++ b/platforms/android/README.android
@@ -1,1 +1,1 @@
-See http://opencv.org/android
+See http://opencv.org/platforms/android.html


### PR DESCRIPTION
The current link (http://opencv.org/android) does no longer seem to work.