### PR TITLE
OCL: [objdetect]Avoid deadlock becasue some work item couldn't reach barrier in loop and unsynchronized.

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -587,7 +587,7 @@ bool HaarEvaluator::read(const FileNode& node, Size _origWinSize)
     localSize = lbufSize = Size(0, 0);
     if (ocl::haveOpenCL())
     {
-        if (ocl::Device::getDefault().isAMD())
+        if (ocl::Device::getDefault().isAMD() || ocl::Device::getDefault().isIntel())
         {
             localSize = Size(8, 8);
             lbufSize = Size(origWinSize.width + localSize.width,

--- a/modules/objdetect/src/opencl/cascadedetect.cl
+++ b/modules/objdetect/src/opencl/cascadedetect.cl
@@ -233,11 +233,12 @@ void runHaarClassifier(
 
             for( stageIdx = SPLIT_STAGE; stageIdx < N_STAGES; stageIdx++ )
             {
+                barrier(CLK_LOCAL_MEM_FENCE);
                 int nrects = lcount[0];
 
-                barrier(CLK_LOCAL_MEM_FENCE);
                 if( nrects == 0 )
                     break;
+                barrier(CLK_LOCAL_MEM_FENCE);
                 if( lidx == 0 )
                     lcount[0] = 0;
 


### PR DESCRIPTION
Signed-off-by: Yan Wang <yan.wang@linux.intel.com>