### PR TITLE
implement _OutputArray::assign() for _OutputArrays of type MATX (with tests)

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -2668,7 +2668,7 @@ void _OutputArray::assign(const Mat& m) const
     }
     else if (k == MATX)
     {
-        getMat() = m;
+        m.copyTo(getMat());
     }
     else
     {

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -2644,6 +2644,10 @@ void _OutputArray::assign(const UMat& u) const
     {
         u.copyTo(*(Mat*)obj); // TODO check u.getMat()
     }
+    else if (k == MATX)
+    {
+        u.copyTo(getMat()); // TODO check u.getMat()
+    }
     else
     {
         CV_Error(Error::StsNotImplemented, "");
@@ -2661,6 +2665,10 @@ void _OutputArray::assign(const Mat& m) const
     else if (k == MAT)
     {
         *(Mat*)obj = m;
+    }
+    else if (k == MATX)
+    {
+        getMat() = m;
     }
     else
     {

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -26,3 +26,107 @@ TEST(Core_SaturateCast, NegativeNotClipped)
 
     ASSERT_EQ(0xffffffff, val);
 }
+
+template<typename T, typename U>
+static double maxAbsDiff(const T &t, const U &u)
+{
+  Mat_<double> d;
+  absdiff(t, u, d);
+  double ret;
+  minMaxLoc(d, NULL, &ret);
+  return ret;
+}
+
+TEST(Core_OutputArrayAssign, _Matxd_Matd)
+{
+    Mat expected = (Mat_<double>(2,3) << 1, 2, 3, .1, .2, .3);
+    Matx23d actualx;
+    
+    {
+        OutputArray oa(actualx);
+        oa.assign(expected);
+    }
+
+    Mat actual = (Mat) actualx;
+
+    EXPECT_LE(maxAbsDiff(expected, actual), 0.0);
+}
+
+TEST(Core_OutputArrayAssign, _Matxd_Matf)
+{
+    Mat expected = (Mat_<float>(2,3) << 1, 2, 3, .1, .2, .3);
+    Matx23d actualx;
+
+    {
+        OutputArray oa(actualx);
+        oa.assign(expected);
+    }
+
+    Mat actual = (Mat) actualx;
+
+    EXPECT_LE(maxAbsDiff(expected, actual), FLT_EPSILON);
+}
+
+TEST(Core_OutputArrayAssign, _Matxf_Matd)
+{
+    Mat expected = (Mat_<double>(2,3) << 1, 2, 3, .1, .2, .3);
+    Matx23f actualx;
+
+    {
+        OutputArray oa(actualx);
+        oa.assign(expected);
+    }
+
+    Mat actual = (Mat) actualx;
+
+    EXPECT_LE(maxAbsDiff(expected, actual), FLT_EPSILON);
+}
+
+TEST(Core_OutputArrayAssign, _Matxd_UMatd)
+{
+    Mat expected = (Mat_<double>(2,3) << 1, 2, 3, .1, .2, .3);
+    UMat uexpected = expected.getUMat(ACCESS_READ);
+    Matx23d actualx;
+
+    {
+        OutputArray oa(actualx);
+        oa.assign(uexpected);
+    }
+
+    Mat actual = (Mat) actualx;
+
+    EXPECT_LE(maxAbsDiff(expected, actual), 0.0);
+}
+
+TEST(Core_OutputArrayAssign, _Matxd_UMatf)
+{
+    Mat expected = (Mat_<float>(2,3) << 1, 2, 3, .1, .2, .3);
+    UMat uexpected = expected.getUMat(ACCESS_READ);
+    Matx23d actualx;
+
+    {
+        OutputArray oa(actualx);
+        oa.assign(uexpected);
+    }
+
+    Mat actual = (Mat) actualx;
+
+    EXPECT_LE(maxAbsDiff(expected, actual), FLT_EPSILON);
+}
+
+TEST(Core_OutputArrayAssign, _Matxf_UMatd)
+{
+    Mat expected = (Mat_<double>(2,3) << 1, 2, 3, .1, .2, .3);
+    UMat uexpected = expected.getUMat(ACCESS_READ);
+    Matx23f actualx;
+
+    {
+        OutputArray oa(actualx);
+        oa.assign(uexpected);
+    }
+
+    Mat actual = (Mat) actualx;
+
+    EXPECT_LE(maxAbsDiff(expected, actual), FLT_EPSILON);
+}
+

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -41,7 +41,7 @@ TEST(Core_OutputArrayAssign, _Matxd_Matd)
 {
     Mat expected = (Mat_<double>(2,3) << 1, 2, 3, .1, .2, .3);
     Matx23d actualx;
-    
+
     {
         OutputArray oa(actualx);
         oa.assign(expected);
@@ -129,4 +129,3 @@ TEST(Core_OutputArrayAssign, _Matxf_UMatd)
 
     EXPECT_LE(maxAbsDiff(expected, actual), FLT_EPSILON);
 }
-


### PR DESCRIPTION
_OutputArray::assign(const Mat &m) throws exception when the caller passes a Matx (or derived type such as Vec3d), even when it has exactly the same type and size as m. Same for UMat. This patch fixes it.