### PR TITLE
Fix building of samples

### DIFF
--- a/samples/gpu/opengl.cpp
+++ b/samples/gpu/opengl.cpp
@@ -109,5 +109,3 @@ int main(int argc, char* argv[])
 
     return 0;
 }
-
-#endif


### PR DESCRIPTION
Samples do not build due to and endif existing without and if.
Therefore the solution was to simply remove it.