### PR TITLE
Fixed build warning in GDAL support module

### DIFF
--- a/modules/imgcodecs/src/grfmt_gdal.cpp
+++ b/modules/imgcodecs/src/grfmt_gdal.cpp
@@ -140,35 +140,6 @@ int gdal2opencv( const GDALDataType& gdalType, const int& channels ){
     return -1;
 }
 
-
-std::string GetOpenCVTypeName( const int& type ){
-
-    switch(type){
-        case CV_8UC1:
-            return "CV_8UC1";
-        case CV_8UC3:
-            return "CV_8UC3";
-        case CV_8UC4:
-            return "CV_8UC4";
-        case CV_16UC1:
-            return "CV_16UC1";
-        case CV_16UC3:
-            return "CV_16UC3";
-        case CV_16UC4:
-            return "CV_16UC4";
-        case CV_16SC1:
-            return "CV_16SC1";
-        case CV_16SC3:
-            return "CV_16SC3";
-        case CV_16SC4:
-            return "CV_16SC4";
-        default:
-            return "Unknown";
-    }
-    return "Unknown";
-}
-
-
 /**
  * GDAL Decoder Constructor
 */

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -247,7 +247,7 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0 )
     ImageDecoder decoder;
 
 #ifdef HAVE_GDAL
-    if( (flags & IMREAD_LOAD_GDAL) == IMREAD_LOAD_GDAL ){
+    if(flags != IMREAD_UNCHANGED && (flags & IMREAD_LOAD_GDAL) == IMREAD_LOAD_GDAL ){
         decoder = GdalDecoder().newDecoder();
     }else{
 #endif
@@ -275,7 +275,7 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0 )
 
     // grab the decoded type
     int type = decoder->type();
-    if( flags != -1 )
+    if( flags != IMREAD_UNCHANGED )
     {
         if( (flags & CV_LOAD_IMAGE_ANYDEPTH) == 0 )
             type = CV_MAKETYPE(CV_8U, CV_MAT_CN(type));
@@ -336,7 +336,7 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats)
     ImageDecoder decoder;
 
 #ifdef HAVE_GDAL
-    if ((flags & IMREAD_LOAD_GDAL) == IMREAD_LOAD_GDAL){
+    if (flags != IMREAD_UNCHANGED && (flags & IMREAD_LOAD_GDAL) == IMREAD_LOAD_GDAL){
         decoder = GdalDecoder().newDecoder();
     }
     else{
@@ -362,7 +362,7 @@ imreadmulti_(const String& filename, int flags, std::vector<Mat>& mats)
     {
         // grab the decoded type
         int type = decoder->type();
-        if (flags != -1)
+        if (flags != IMREAD_UNCHANGED)
         {
             if ((flags & CV_LOAD_IMAGE_ANYDEPTH) == 0)
                 type = CV_MAKETYPE(CV_8U, CV_MAT_CN(type));
@@ -508,7 +508,7 @@ imdecode_( const Mat& buf, int flags, int hdrtype, Mat* mat=0 )
     size.height = decoder->height();
 
     int type = decoder->type();
-    if( flags != -1 )
+    if( flags != IMREAD_UNCHANGED )
     {
         if( (flags & CV_LOAD_IMAGE_ANYDEPTH) == 0 )
             type = CV_MAKETYPE(CV_8U, CV_MAT_CN(type));

--- a/modules/imgcodecs/test/test_grfmt.cpp
+++ b/modules/imgcodecs/test/test_grfmt.cpp
@@ -104,7 +104,8 @@ TEST(Imgcodecs_imread, regression)
         ASSERT_TRUE(imread_compare(folder + string(filenames[i]), IMREAD_COLOR));
         ASSERT_TRUE(imread_compare(folder + string(filenames[i]), IMREAD_ANYDEPTH));
         ASSERT_TRUE(imread_compare(folder + string(filenames[i]), IMREAD_ANYCOLOR));
-        ASSERT_TRUE(imread_compare(folder + string(filenames[i]), IMREAD_LOAD_GDAL));
+        if (i != 2) // GDAL does not support hdr
+            ASSERT_TRUE(imread_compare(folder + string(filenames[i]), IMREAD_LOAD_GDAL));
     }
 }
 
@@ -684,7 +685,7 @@ public:
         compare(IMREAD_COLOR);
         compare(IMREAD_ANYDEPTH);
         compare(IMREAD_ANYCOLOR);
-        compare(IMREAD_LOAD_GDAL);
+        // compare(IMREAD_LOAD_GDAL); // GDAL does not support multi-page TIFFs
     }
 };
 


### PR DESCRIPTION
- Function `GetOpenCVTypeName` is not used
- GDAL detector is erroneously turned ON when `IMREAD_UNCHANGED` flags value is passed to `imread`