### PR TITLE
OCL: [objdetect]Enable OpenCL path of resize (CV_8U) and integral for cascade classifier on Intel platform.

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2942,7 +2942,7 @@ static bool ocl_resize( InputArray _src, OutputArray _dst, Size dsize,
         char buf[2][32];
 
         // integer path is slower because of CPU part, so it's disabled
-        if (depth == CV_8U && ((void)0, 0))
+        if (depth == CV_8U && ocl::Device::getDefault().isIntel())
         {
             AutoBuffer<uchar> _buffer((dsize.width + dsize.height)*(sizeof(int) + sizeof(short)*2));
             int* xofs = (int*)(uchar*)_buffer, * yofs = xofs + dsize.width;

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -1223,9 +1223,8 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
          !isOldFormatCascade() &&
          maskGenerator.empty() &&
          !outputRejectLevels;
-#endif
 
-    /*if( use_ocl )
+    if( use_ocl && ocl::Device::getDefault().isIntel() )
     {
         if (_image.channels() > 1)
             cvtColor(_image, ugrayImage, COLOR_BGR2GRAY);
@@ -1235,7 +1234,8 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
             _image.copyTo(ugrayImage);
         gray = ugrayImage;
     }
-    else*/
+    else
+#endif
     {
         if (_image.channels() > 1)
             cvtColor(_image, grayImage, COLOR_BGR2GRAY);


### PR DESCRIPTION
It will improve (decrease) the mean values of
OCL_Cascade_Image_MinSize_CascadeClassifier.CascadeClassifier/*
about 10% ~ 30% on Intel platform.

Signed-off-by: Yan Wang <yan.wang@linux.intel.com>

check_regression=*
test_filter=*
test_modules=objdetect
build_examples=OFF