### PR TITLE
Memory snapshots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,11 +232,15 @@ OCV_OPTION(ENABLE_WINRT_MODE          "Build with Windows Runtime support"      
 OCV_OPTION(ENABLE_WINRT_MODE_NATIVE   "Build with Windows Runtime native C++ support"            OFF  IF WIN32 )
 OCV_OPTION(ANDROID_EXAMPLES_WITH_LIBS "Build binaries of Android examples with native libraries" OFF  IF ANDROID )
 OCV_OPTION(ENABLE_IMPL_COLLECTION     "Collect implementation data on function call"             OFF )
+OCV_OPTION(ENABLE_MEMORY_SNAPSHOTS    "Collect memory allocation data"                           OFF  IF (NOT ANDROID AND NOT IOS) )
 
 if(ENABLE_IMPL_COLLECTION)
   add_definitions(-DCV_COLLECT_IMPL_DATA)
 endif()
 
+if(ENABLE_MEMORY_SNAPSHOTS)
+  add_definitions(-DCV_COLLECT_ALLOC_DATA)
+endif()
 
 # ----------------------------------------------------------------------------
 #  Get actual OpenCV version number from sources

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -134,7 +134,7 @@ CV_EXPORTS void error( const Exception& exc );
 
 /*! @brief Holds information about memory usage by OpenCV objects.
 
-A memory snapshot contains brief information of number of allocated 
+A memory snapshot contains brief information of number of allocated
 objects, their size, peak memory usage, number of live objects and allocations
 count. By comparing two snapshots user can identify places in code, that 
 potentially can lead to memory-related problems like extreme memory usage or large
@@ -142,26 +142,26 @@ number of temporary objects.
  */
 struct CV_EXPORTS MemorySnapshot
 {
-	//! @brief Total amount of allocated memory.
+    //! @brief Total amount of allocated memory.
     size_t allocatedMemory;
 
-	//! @brief  Maximum amount of allocated memory for the whole time.
+    //! @brief  Maximum amount of allocated memory for the whole time.
     size_t peakMemoryUsage;
 
-	//! @brief  Maximum amount of allocated memory since last snapshot.
-	size_t peakMemoryUsageSinceLastSnapshot;
-	
-	//! @brief  Number of memory allocations count for the whole program running time.
+    //! @brief  Maximum amount of allocated memory since last snapshot.
+    size_t peakMemoryUsageSinceLastSnapshot;
+
+    //! @brief  Number of memory allocations count for the whole program running time.
     size_t allocationsCount;
 
-	//! @brief  Number of memory deallocations for the whole program running time.
-	size_t deallocationsCount;
-    
-	//! @brief  Number of allocated objects that are still live (e.g not deallocated).
-	size_t liveObjects;
+    //! @brief  Number of memory deallocations for the whole program running time.
+    size_t deallocationsCount;
+
+    //! @brief  Number of allocated objects that are still live (e.g not deallocated).
+    size_t liveObjects;
 };
 
-/*! @brief Creates memory snapshot for a given moment. 
+/*! @brief Creates memory snapshot for a given moment.
 */
 CV_EXPORTS MemorySnapshot memorySnapshot();
 

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -132,6 +132,39 @@ It is possible to alternate error processing by using cv::redirectError().
  */
 CV_EXPORTS void error( const Exception& exc );
 
+/*! @brief Holds information about memory usage by OpenCV objects.
+
+A memory snapshot contains brief information of number of allocated 
+objects, their size, peak memory usage, number of live objects and allocations
+count. By comparing two snapshots user can identify places in code, that 
+potentially can lead to memory-related problems like extreme memory usage or large
+number of temporary objects.
+ */
+struct CV_EXPORTS MemorySnapshot
+{
+	//! @brief Total amount of allocated memory.
+    size_t allocatedMemory;
+
+	//! @brief  Maximum amount of allocated memory for the whole time.
+    size_t peakMemoryUsage;
+
+	//! @brief  Maximum amount of allocated memory since last snapshot.
+	size_t peakMemoryUsageSinceLastSnapshot;
+	
+	//! @brief  Number of memory allocations count for the whole program running time.
+    size_t allocationsCount;
+
+	//! @brief  Number of memory deallocations for the whole program running time.
+	size_t deallocationsCount;
+    
+	//! @brief  Number of allocated objects that are still live (e.g not deallocated).
+	size_t liveObjects;
+};
+
+/*! @brief Creates memory snapshot for a given moment. 
+*/
+CV_EXPORTS MemorySnapshot memorySnapshot();
+
 enum SortFlags { SORT_EVERY_ROW    = 0, //!< each matrix row is sorted independently
                  SORT_EVERY_COLUMN = 1, //!< each matrix column is sorted
                                         //!< independently; this flag and the previous one are

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -136,7 +136,7 @@ CV_EXPORTS void error( const Exception& exc );
 
 A memory snapshot contains brief information of number of allocated
 objects, their size, peak memory usage, number of live objects and allocations
-count. By comparing two snapshots user can identify places in code, that 
+count. By comparing two snapshots user can identify places in code, that
 potentially can lead to memory-related problems like extreme memory usage or large
 number of temporary objects.
  */

--- a/modules/core/src/alloc.cpp
+++ b/modules/core/src/alloc.cpp
@@ -73,7 +73,7 @@ public:
     {
         LockType guard(mAllocMutex);
 
-        auto block = mAllocatedMemory.find(ptr);
+		AllocationTable::iterator block = mAllocatedMemory.find(ptr);
         CV_Assert(block != mAllocatedMemory.end());
     
         mCurrentMemoryUsage -= block->second;
@@ -85,12 +85,7 @@ public:
 
     static MemoryManager& Instance()
     {
-        std::call_once(mInitFlag, []() {
-            if (mInstance == nullptr)
-            {
-                mInstance = new MemoryManager();
-            }
-        });
+		std::call_once(mInitFlag, createMemoryManager);
 
         return *mInstance;
     }
@@ -112,6 +107,14 @@ public:
         return std::move(snapshot);
     }
 private:
+
+	static void createMemoryManager()
+	{
+		if (mInstance == nullptr)
+		{
+			mInstance = new MemoryManager();
+		}
+	}
 
     MemoryManager()
         : mCurrentMemoryUsage(0)

--- a/modules/core/src/alloc.cpp
+++ b/modules/core/src/alloc.cpp
@@ -72,19 +72,17 @@ public:
     {
         LockType guard(mAllocMutex);
 
-		AllocationTable::iterator block = mAllocatedMemory.find(ptr);
+        AllocationTable::iterator block = mAllocatedMemory.find(ptr);
         CV_Assert(block != mAllocatedMemory.end());
-    
+
         mCurrentMemoryUsage -= block->second;
         mDeallocationsCount++;
         mAllocatedMemory.erase(block);
     }
 
-   
-
     static MemoryManager& Instance()
     {
-		std::call_once(mInitFlag, createMemoryManager);
+        std::call_once(mInitFlag, createMemoryManager);
 
         return *mInstance;
     }
@@ -92,7 +90,7 @@ public:
     MemorySnapshot makeSnapshot()
     {
         LockType guard(mAllocMutex);
-        
+
         MemorySnapshot snapshot;
         snapshot.peakMemoryUsage = mPeakMemoryUsage;
         snapshot.peakMemoryUsageSinceLastSnapshot = mPeakMemoryUsageSinceLastSnapshot;
@@ -100,20 +98,20 @@ public:
         snapshot.allocationsCount = mAllocationsCount;
         snapshot.deallocationsCount = mDeallocationsCount;
         snapshot.liveObjects = mAllocationsCount - mDeallocationsCount;
-        
+
         mPeakMemoryUsageSinceLastSnapshot = 0;
 
         return std::move(snapshot);
     }
 private:
 
-	static void createMemoryManager()
-	{
-		if (mInstance == nullptr)
-		{
-			mInstance = new MemoryManager();
-		}
-	}
+    static void createMemoryManager()
+    {
+        if (mInstance == nullptr)
+        {
+            mInstance = new MemoryManager();
+        }
+    }
 
     MemoryManager()
         : mCurrentMemoryUsage(0)

--- a/modules/core/src/alloc.cpp
+++ b/modules/core/src/alloc.cpp
@@ -45,7 +45,6 @@
 #include <map>
 #include <memory>
 #include <thread>
-#include <atomic>
 
 #define CV_USE_SYSTEM_MALLOC 1
 
@@ -147,7 +146,7 @@ std::once_flag  MemoryManager::mInitFlag;
 MemorySnapshot memorySnapshot()
 {
 #ifndef CV_COLLECT_ALLOC_DATA
-    CV_Error_(CV_StsNoMem, ("Failed to create memory snapshot. Please build OpenCV using ENABLE_MEMORY_SNAPSHOTS=YES."));	
+    CV_Error_(CV_StsNoMem, ("Failed to create memory snapshot. Please build OpenCV using ENABLE_MEMORY_SNAPSHOTS=YES."));
 #endif
 
     return std::move(MemoryManager::Instance().makeSnapshot());


### PR DESCRIPTION
Hello,

This pull request adds new option `ENABLE_MEMORY_SNAPSHOTS` to collect memory allocation statistics. It's aimed for developers that want to profile OpenCV memory usage and spot enormous memory usage and too often re-allocations.

This pull request was inspired by a small hack that I did recently to eliminate memory-crash on iOS platform which happened due to big memory usage in OpenCV. With this feature it was very easy to detect and fix a problem.

A more information on this feature can be found on my blog: [Hacking OpenCV for fun and profit](http://computer-vision-talks.com/articles/hacking-opencv-for-fun-and-profit/).