### PR TITLE
Fix for Visual Studio multiprocess builds for CMake versions > 2.8

### DIFF
--- a/cmake/OpenCVCRTLinkage.cmake
+++ b/cmake/OpenCVCRTLinkage.cmake
@@ -77,7 +77,7 @@ else()
   endforeach(flag_var)
 endif()
 
-if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} LESS 2.8 AND NOT ${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION} LESS 8.6)
+if(CMAKE_VERSION VERSION_GREATER "2.8.6")
   include(ProcessorCount)
   ProcessorCount(N)
   if(NOT N EQUAL 0)


### PR DESCRIPTION
In case CMake version is greater than 2.8 (3.0.1 for example) the /MP option was not added to Visual Studio which increased building time