### PR TITLE
Allow threshold function to handle multi-channel image

### DIFF
--- a/modules/cudaarithm/src/cuda/threshold.cu
+++ b/modules/cudaarithm/src/cuda/threshold.cu
@@ -101,8 +101,9 @@ double cv::cuda::threshold(InputArray _src, OutputArray _dst, double thresh, dou
 
     const int depth = src.depth();
 
-    CV_Assert( src.channels() == 1 && depth <= CV_64F );
+    CV_Assert( depth <= CV_64F );
     CV_Assert( type <= 4 /*THRESH_TOZERO_INV*/ );
+    src = src.reshape(src.channels(), src.rows);
 
     GpuMat dst = getOutputMat(_dst, src.size(), src.type(), stream);
 

--- a/modules/cudaarithm/src/cuda/threshold.cu
+++ b/modules/cudaarithm/src/cuda/threshold.cu
@@ -103,7 +103,7 @@ double cv::cuda::threshold(InputArray _src, OutputArray _dst, double thresh, dou
 
     CV_Assert( depth <= CV_64F );
     CV_Assert( type <= 4 /*THRESH_TOZERO_INV*/ );
-    src = src.reshape(src.channels(), src.rows);
+    src = src.reshape(1);
 
     GpuMat dst = getOutputMat(_dst, src.size(), src.type(), stream);
 


### PR DESCRIPTION
* remove the run time check of channel number of input image
* treat the input image as single channel