### PR TITLE
Print missing error message only if OPENCV_OPENCL_RUNTIME is used

### DIFF
--- a/modules/core/src/opencl/runtime/opencl_core.cpp
+++ b/modules/core/src/opencl/runtime/opencl_core.cpp
@@ -70,7 +70,8 @@ static void* AppleCLGetProcAddress(const char* name)
             handle = dlopen(oclpath, RTLD_LAZY | RTLD_GLOBAL);
             if (handle == NULL)
             {
-                fprintf(stderr, ERROR_MSG_CANT_LOAD);
+                if (envPath)
+                    fprintf(stderr, ERROR_MSG_CANT_LOAD);
             }
             else if (dlsym(handle, OPENCL_FUNC_TO_CHECK_1_1) == NULL)
             {
@@ -108,7 +109,8 @@ static void* WinGetProcAddress(const char* name)
                 handle = LoadLibraryA(path);
                 if (!handle)
                 {
-                    fprintf(stderr, ERROR_MSG_CANT_LOAD);
+                    if (envPath)
+                        fprintf(stderr, ERROR_MSG_CANT_LOAD);
                 }
                 else if (GetProcAddress(handle, OPENCL_FUNC_TO_CHECK_1_1) == NULL)
                 {
@@ -145,7 +147,8 @@ static void* GetProcAddress(const char* name)
             handle = dlopen(path, RTLD_LAZY | RTLD_GLOBAL);
             if (handle == NULL)
             {
-                fprintf(stderr, ERROR_MSG_CANT_LOAD);
+                if (envPath)
+                    fprintf(stderr, ERROR_MSG_CANT_LOAD);
             }
             else if (dlsym(handle, OPENCL_FUNC_TO_CHECK_1_1) == NULL)
             {


### PR DESCRIPTION
Remove useless error message. Message `Failed to load OpenCL runtime` is displayed every time during OpenCV's launching on systems without OpenCL.