### PR TITLE
Fixed allocated vector size in ML ANN algorithm

### DIFF
--- a/modules/ml/src/ann_mlp.cpp
+++ b/modules/ml/src/ann_mlp.cpp
@@ -731,7 +731,7 @@ public:
         for( i = 0; i < l_count; i++ )
         {
             int n = layer_sizes[i];
-            x[i].resize(n);
+            x[i].resize(n+1);
             df[i].resize(n);
             dw[i].create(weights[i].size(), CV_64F);
         }

--- a/samples/cpp/points_classifier.cpp
+++ b/samples/cpp/points_classifier.cpp
@@ -398,5 +398,5 @@ int main()
         }
     }
 
-    return 1;
+    return 0;
 }


### PR DESCRIPTION
Invalid write on line 829 during backward pass.

Also changed return value of `points_classifier` sample.