### PR TITLE
coreTlsData -> getCoreTlsData()

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1471,7 +1471,7 @@ bool haveOpenCL()
 
 bool useOpenCL()
 {
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
     if( data->useOpenCL < 0 )
     {
         try
@@ -1490,7 +1490,7 @@ void setUseOpenCL(bool flag)
 {
     if( haveOpenCL() )
     {
-        CoreTLSData* data = coreTlsData.get();
+        CoreTLSData* data = getCoreTlsData().get();
         data->useOpenCL = (flag && Device::getDefault().ptr() != NULL) ? 1 : 0;
     }
 }
@@ -2161,7 +2161,7 @@ size_t Device::profilingTimerResolution() const
 const Device& Device::getDefault()
 {
     const Context& ctx = Context::getDefault();
-    int idx = coreTlsData.get()->device;
+    int idx = getCoreTlsData().get()->device;
     const Device& device = ctx.device(idx);
     return device;
 }
@@ -3040,7 +3040,7 @@ void* Queue::ptr() const
 
 Queue& Queue::getDefault()
 {
-    Queue& q = coreTlsData.get()->oclQueue;
+    Queue& q = getCoreTlsData().get()->oclQueue;
     if( !q.p && haveOpenCL() )
         q.create(Context::getDefault());
     return q;

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -255,7 +255,7 @@ struct CoreTLSData
 #endif
 };
 
-extern TLSData<CoreTLSData> coreTlsData;
+TLSData<CoreTLSData>& getCoreTlsData();
 
 #if defined(BUILD_SHARED_LIBS)
 #if defined WIN32 || defined _WIN32 || defined WINCE

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -731,7 +731,7 @@ void RNG::fill( InputOutputArray _mat, int disttype,
 
 cv::RNG& cv::theRNG()
 {
-    return coreTlsData.get()->rng;
+    return getCoreTlsData().get()->rng;
 }
 
 void cv::randu(InputOutputArray dst, InputArray low, InputArray high)

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1146,12 +1146,20 @@ TLSStorage::~TLSStorage()
     tlsData_.clear();
 }
 
-TLSData<CoreTLSData> coreTlsData;
+
+
+TLSData<CoreTLSData>& getCoreTlsData()
+{
+    static TLSData<CoreTLSData> *value = new TLSData<CoreTLSData>();
+    return *value;
+}
+
+
 
 #ifdef CV_COLLECT_IMPL_DATA
 void setImpl(int flags)
 {
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
     data->implFlags = flags;
     data->implCode.clear();
     data->implFun.clear();
@@ -1159,7 +1167,7 @@ void setImpl(int flags)
 
 void addImpl(int flag, const char* func)
 {
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
     data->implFlags |= flag;
     if(func) // use lazy collection if name was not specified
     {
@@ -1174,7 +1182,7 @@ void addImpl(int flag, const char* func)
 
 int getImpl(std::vector<int> &impl, std::vector<String> &funName)
 {
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
     impl = data->implCode;
     funName = data->implFun;
     return data->implFlags; // return actual flags for lazy collection
@@ -1182,13 +1190,13 @@ int getImpl(std::vector<int> &impl, std::vector<String> &funName)
 
 bool useCollection()
 {
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
     return data->useCollection;
 }
 
 void setUseCollection(bool flag)
 {
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
     data->useCollection = flag;
 }
 #endif
@@ -1221,7 +1229,7 @@ String getIppErrorLocation()
 bool useIPP()
 {
 #ifdef HAVE_IPP
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
     if(data->useIPP < 0)
     {
         const char* pIppEnv = getenv("OPENCV_IPP");
@@ -1238,7 +1246,7 @@ bool useIPP()
 
 void setUseIPP(bool flag)
 {
-    CoreTLSData* data = coreTlsData.get();
+    CoreTLSData* data = getCoreTlsData().get();
 #ifdef HAVE_IPP
     data->useIPP = flag;
 #else


### PR DESCRIPTION
Prevent crashes during application cleanup: access to `coreTlsData` (`ocl::useOpenCL()` and others helper calls after `coreTlsData` destruction)