### PR TITLE
Fix opencv_run_all_tests_unix.sh script:

### DIFF
--- a/cmake/templates/opencv_run_all_tests_unix.sh.in
+++ b/cmake/templates/opencv_run_all_tests_unix.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Text style
 


### PR DESCRIPTION
Use `bash` shell instead of `sh`, since on Ubuntu `sh` by default is `dash`,
and `dash` doesn't support `PIPESTATUS` feature used in this sctipt.