### PR TITLE
Fix Assertion in pyrUp

### DIFF
--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -435,7 +435,7 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
 
 void cv::pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int borderType )
 {
-    CV_Assert(borderType == BORDER_DEFAULT);
+    CV_Assert(borderType != BORDER_CONSTANT);
 
     Mat src = _src.getMat();
     Size dsz = _dsz == Size() ? Size(src.cols*2, src.rows*2) : _dsz;


### PR DESCRIPTION
Fix the assertion in pyrUp so that it matches the commit message and intention
of the commit it was introduced in, 511ed4388ec233b471c9a4300f508640d2e7fdd9.
It incorrectly rejects any parameter other than BORDER_DEFAULT instead of
only rejecting BORDER_CONSTANT.

This issue also exists in master.