### PR TITLE
Fix possible null pointer dereference

### DIFF
--- a/modules/core/src/cuda_host_mem.cpp
+++ b/modules/core/src/cuda_host_mem.cpp
@@ -107,10 +107,13 @@ public:
 
     void deallocate(UMatData* u) const
     {
+        if (!u)
+            return;
+
         CV_Assert(u->urefcount >= 0);
         CV_Assert(u->refcount >= 0);
 
-        if (u && u->refcount == 0)
+        if (u->refcount == 0)
         {
             if ( !(u->flags & UMatData::USER_ALLOCATED) )
             {


### PR DESCRIPTION
If there was a null pointer (intended to be handled by the `if(u&&` code) it would cause undefined behavior earlier because of two unconditional `CV_Assert(u->`s.

This was found using Cppcheck.