### PR TITLE
Fix potential null pointer dereference

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -1651,22 +1651,18 @@ static int
 icvGenerateQuads( CvCBQuad **out_quads, CvCBCorner **out_corners,
                   CvMemStorage *storage, CvMat *image, int flags )
 {
+    CV_Assert( out_corners && out_quads );
+    *out_quads = 0;
+    *out_corners = 0;
+
     int quad_count = 0;
     cv::Ptr<CvMemStorage> temp_storage;
-
-    if( out_quads )
-        *out_quads = 0;
-
-    if( out_corners )
-        *out_corners = 0;
 
     CvSeq *src_contour = 0;
     CvSeq *root;
     CvContourEx* board = 0;
     CvContourScanner scanner;
     int i, idx, min_size;
-
-    CV_Assert( out_corners && out_quads );
 
     // empiric bound for minimal allowed perimeter for squares
     min_size = 25; //cvRound( image->cols * image->rows * .03 * 0.01 * 0.92 );


### PR DESCRIPTION
The original code first conditionally dereferences the pointer, then asserts they are not null and then later unconditionally dereferences them:

    *out_quads = (CvCBQuad*)cvAlloc((root->total+root->total / 2) * sizeof((*out_quads)[0]));
    *out_corners = (CvCBCorner*)cvAlloc((root->total+root->total / 2) * 4 * sizeof((*out_corners)[0]));

which yields undefined behavior. The intent of function is to unconditionally dereference them (with a pre-assert).

This was found with Cppcheck.