### PR TITLE
cap_msmf.hpp: fix a warning about nNull being unused

### DIFF
--- a/modules/highgui/src/cap_msmf.hpp
+++ b/modules/highgui/src/cap_msmf.hpp
@@ -609,11 +609,6 @@ public:
     ComPtr() throw()
     {
     }
-    ComPtr(int nNull) throw()
-    {
-        assert(nNull == 0);
-        p = NULL;
-    }
     ComPtr(T* lp) throw()
     {
         p = lp;
@@ -644,13 +639,6 @@ public:
     {
         return p.operator==(pT);
     }
-    // For comparison to NULL
-    bool operator==(int nNull) const
-    {
-        assert(nNull == 0);
-        return p.operator==(NULL);
-    }
-
     bool operator!=(_In_opt_ T* pT) const throw()
     {
         return p.operator!=(pT);
@@ -3129,7 +3117,7 @@ public:
         HRESULT hr = CheckShutdown();
 
         if (SUCCEEDED(hr)) {
-            if (m_spClock == NULL) {
+            if (!m_spClock) {
                 hr = MF_E_NO_CLOCK; // There is no presentation clock.
             } else {
                 // Return the pointer to the caller.


### PR DESCRIPTION
The two functions featuring `nNull` are not particularly needed, so I simply removed them.