### PR TITLE
Fix windows build with CUDA

### DIFF
--- a/modules/cudaarithm/src/cuda/minmax.cu
+++ b/modules/cudaarithm/src/cuda/minmax.cu
@@ -134,7 +134,7 @@ void cv::cuda::minMax(InputArray _src, double* minVal, double* maxVal, InputArra
         *maxVal = vals[1];
 }
 
-namespace cv { namespace cuda { namespace internal {
+namespace cv { namespace cuda { namespace device {
 
 void findMaxAbs(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream);
 
@@ -155,7 +155,7 @@ namespace
     }
 }
 
-void cv::cuda::internal::findMaxAbs(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream)
+void cv::cuda::device::findMaxAbs(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream)
 {
     typedef void (*func_t)(const GpuMat& _src, const GpuMat& mask, GpuMat& _dst, Stream& stream);
     static const func_t funcs[] =

--- a/modules/cudaarithm/src/cuda/norm.cu
+++ b/modules/cudaarithm/src/cuda/norm.cu
@@ -128,7 +128,7 @@ double cv::cuda::norm(InputArray _src1, InputArray _src2, int normType)
     return val;
 }
 
-namespace cv { namespace cuda { namespace internal {
+namespace cv { namespace cuda { namespace device {
 
 void normL2(cv::InputArray _src, cv::OutputArray _dst, cv::InputArray _mask, Stream& stream);
 
@@ -158,7 +158,7 @@ namespace
     }
 }
 
-void cv::cuda::internal::normL2(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream)
+void cv::cuda::device::normL2(InputArray _src, OutputArray _dst, InputArray _mask, Stream& stream)
 {
     typedef void (*func_t)(const GpuMat& _src, const GpuMat& mask, GpuMat& _dst, Stream& stream);
     static const func_t funcs[] =

--- a/modules/cudaarithm/src/reductions.cpp
+++ b/modules/cudaarithm/src/reductions.cpp
@@ -84,7 +84,7 @@ void cv::cuda::sqrIntegral(InputArray, OutputArray, Stream&) { throw_no_cuda(); 
 ////////////////////////////////////////////////////////////////////////
 // norm
 
-namespace cv { namespace cuda { namespace internal {
+namespace cv { namespace cuda { namespace device {
 
 void normL2(cv::InputArray _src, cv::OutputArray _dst, cv::InputArray _mask, Stream& stream);
 
@@ -106,11 +106,11 @@ void cv::cuda::calcNorm(InputArray _src, OutputArray dst, int normType, InputArr
     }
     else if (normType == NORM_L2)
     {
-        cv::cuda::internal::normL2(src_single_channel, dst, mask, stream);
+        cv::cuda::device::normL2(src_single_channel, dst, mask, stream);
     }
     else // NORM_INF
     {
-        cv::cuda::internal::findMaxAbs(src_single_channel, dst, mask, stream);
+        cv::cuda::device::findMaxAbs(src_single_channel, dst, mask, stream);
     }
 }
 


### PR DESCRIPTION
Renamed `cv::cuda::internal` namespace to `cv::cuda::device` to prevent conflicts with `cv::internal`.

For http://code.opencv.org/issues/4197