### PR TITLE
iOS: fix crash from overrelease in UIImageToMat (for 3.0)

### DIFF
--- a/modules/imgcodecs/src/ios_conversions.mm
+++ b/modules/imgcodecs/src/ios_conversions.mm
@@ -120,5 +120,4 @@ void UIImageToMat(const UIImage* image,
     CGContextDrawImage(contextRef, CGRectMake(0, 0, cols, rows),
                        image.CGImage);
     CGContextRelease(contextRef);
-    CGColorSpaceRelease(colorSpace);
 }


### PR DESCRIPTION
There is release non-retained variable in UIImageToMat.
> Assertion failed: (!space->is_singleton), function color_space_dealloc, file ColorSpaces/color-space.c, line 100.

The problem has fixed in 2.4(not 2.4.10). I found same ticket for 2.4. 
- previous pull request: https://github.com/Itseez/opencv/pull/3340

Thank you.