### PR TITLE
Documentation: set max-width property for inserted images

### DIFF
--- a/doc/stylesheet.css
+++ b/doc/stylesheet.css
@@ -31,3 +31,7 @@ div.contents {
 span.arrow {
     height: 13px;
 }
+
+div.image img{
+    max-width: 900px;
+}


### PR DESCRIPTION
Images in documentation will be resized if their width exceeds 900px (contents div has width 980px).