### PR TITLE
Implement CMAKE_CURRENT_LIST_DIR for older CMake

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -47,9 +47,11 @@ endif()
 
 if(NOT TARGET opencv_core)
   # Extract directory name from full path of the file currently being processed.
-  # Note that CMake 2.8.3 introduced CMAKE_CURRENT_LIST_DIR, but we do this
-  # manually to support older versions of CMake as well.
-  get_filename_component(CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+  # Note that CMake 2.8.3 introduced CMAKE_CURRENT_LIST_DIR. We reimplement it
+  # for older versions of CMake to support these as well.
+  if(CMAKE_VERSION VERSION_LESS "2.8.3")
+    get_filename_component(CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+  endif()
 
   include(${CMAKE_CURRENT_LIST_DIR}/OpenCVModules${OpenCV_MODULES_SUFFIX}.cmake)
 endif()

--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -46,6 +46,11 @@ if(NOT DEFINED OpenCV_MODULES_SUFFIX)
 endif()
 
 if(NOT TARGET opencv_core)
+  # Extract directory name from full path of the file currently being processed.
+  # Note that CMake 2.8.3 introduced CMAKE_CURRENT_LIST_DIR, but we do this
+  # manually to support older versions of CMake as well.
+  get_filename_component(CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
   include(${CMAKE_CURRENT_LIST_DIR}/OpenCVModules${OpenCV_MODULES_SUFFIX}.cmake)
 endif()
 


### PR DESCRIPTION
The use of built-in CMAKE_CURRENT_LIST_DIR requires at least
CMake 2.8.3. This fix properly defines the variable to allow its
use in versions < 2.8.3 as well.

Fixes issue #4205.