### PR TITLE
Reduce variable scope, fix indenting

### DIFF
--- a/modules/androidcamera/src/camera_activity.cpp
+++ b/modules/androidcamera/src/camera_activity.cpp
@@ -309,13 +309,13 @@ cv::String CameraWrapperConnector::getPathLibFolder()
 
         const char* libName=dl_info.dli_fname;
         while( ((*libName)=='/') || ((*libName)=='.') )
-        libName++;
+            libName++;
 
-        char lineBuf[2048];
         FILE* file = fopen("/proc/self/smaps", "rt");
 
         if(file)
         {
+            char lineBuf[2048];
             while (fgets(lineBuf, sizeof lineBuf, file) != NULL)
             {
                 //verify that line ends with library name


### PR DESCRIPTION
The original code has indenting not consistent with surrounding code and also a variable declared in a too wide scope.

The wide scope part was found with Cppcheck.