### PR TITLE
fix formula getGaussianKernel in docs

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1051,7 +1051,7 @@ CV_EXPORTS_W Ptr<LineSegmentDetector> createLineSegmentDetector(
 The function computes and returns the \f$\texttt{ksize} \times 1\f$ matrix of Gaussian filter
 coefficients:
 
-\f[G_i= \alpha *e^{-(i-( \texttt{ksize} -1)/2)^2/(2* \texttt{sigma} )^2},\f]
+\f[G_i= \alpha *e^{-(i-( \texttt{ksize} -1)/2)^2/(2* \texttt{sigma}^2)},\f]
 
 where \f$i=0..\texttt{ksize}-1\f$ and \f$\alpha\f$ is the scale factor chosen so that \f$\sum_i G_i=1\f$.
 


### PR DESCRIPTION
this was fixed for 2.4 branch:http://docs.opencv.org/2.4/modules/imgproc/doc/filtering.html?highlight=getgaussiankernel#cv2.getGaussianKernel
but not yet for master docs: http://docs.opencv.org/ref/master/d4/d86/group__imgproc__filter.html#gac05a120c1ae92a6060dd0db190a61afa 

More info http://code.opencv.org/issues/3887