### PR TITLE
Reduce variables scope

### DIFF
--- a/modules/calib3d/src/dls.h
+++ b/modules/calib3d/src/dls.h
@@ -504,7 +504,7 @@ private:
                 H[n1][n1 - 1] = 0.0;
                 H[n1][n1] = 1.0;
                 for (int i = n1 - 2; i >= 0; i--) {
-                    double ra, sa, vr, vi;
+                    double ra, sa;
                     ra = 0.0;
                     sa = 0.0;
                     for (int j = l; j <= n1; j++) {
@@ -529,8 +529,8 @@ private:
 
                             x = H[i][i + 1];
                             y = H[i + 1][i];
-                            vr = (d[i] - p) * (d[i] - p) + e[i] * e[i] - q * q;
-                            vi = (d[i] - p) * 2.0 * q;
+                            double vr = (d[i] - p) * (d[i] - p) + e[i] * e[i] - q * q;
+                            double vi = (d[i] - p) * 2.0 * q;
                             if (vr == 0.0 && vi == 0.0) {
                                 vr = eps * norm * (std::abs(w) + std::abs(q) + std::abs(x)
                                                    + std::abs(y) + std::abs(z));


### PR DESCRIPTION
The original code had variables declared with too wide scope for no good reason.

This minor defect was found with Cppcheck.