### PR TITLE
Set epsilon for gpu OpticalFlowBM to 1e-6

### DIFF
--- a/modules/gpu/test/test_optflow.cpp
+++ b/modules/gpu/test/test_optflow.cpp
@@ -501,8 +501,8 @@ GPU_TEST_P(OpticalFlowBM, Accuracy)
     cv::Mat velx, vely;
     calcOpticalFlowBM(frame0, frame1, block_size, shift_size, max_range, false, velx, vely);
 
-    EXPECT_MAT_NEAR(velx, d_velx, 0);
-    EXPECT_MAT_NEAR(vely, d_vely, 0);
+    EXPECT_MAT_NEAR(velx, d_velx, 1e-6);
+    EXPECT_MAT_NEAR(vely, d_vely, 1e-6);
 }
 
 INSTANTIATE_TEST_CASE_P(GPU_Video, OpticalFlowBM, ALL_DEVICES);


### PR DESCRIPTION
Since it uses floating point arithmetic