### PR TITLE
Disable object libraries building for cmake 2.8.7 and earlier

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -20,7 +20,7 @@
 # OPENCV_MODULE_${the_module}_PRIVATE_OPT_DEPS
 # OPENCV_MODULE_${the_module}_IS_PART_OF_WORLD
 # OPENCV_MODULE_${the_module}_CUDA_OBJECTS - compiled CUDA objects list
-# OPENCV_MODULE_${the_module}_CHILDREN - list of submodules for compound modules
+# OPENCV_MODULE_${the_module}_CHILDREN - list of submodules for compound modules (cmake >= 2.8.8)
 # HAVE_${the_module} - for fast check of module availability
 
 # To control the setup of the module you could also set:
@@ -666,7 +666,7 @@ macro(_ocv_create_module)
   if (OPENCV_MODULE_${the_module}_CHILDREN)
     status("Complex module ${the_module}")
     foreach (m ${OPENCV_MODULE_${the_module}_CHILDREN})
-      if (BUILD_${m} AND TARGET ${m}_object) # ambigous?
+      if (BUILD_${m} AND TARGET ${m}_object)
         get_target_property(_sub_links ${m} LINK_LIBRARIES)
         list(APPEND sub_objs $<TARGET_OBJECTS:${m}_object>)
         list(APPEND sub_links ${_sub_links})

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -788,8 +788,9 @@ function(ocv_add_library target)
 
   add_library(${target} ${ARGN} ${cuda_objs})
 
-  # Add OBJECT library to use in compound modules
-  if (NOT OPENCV_MODULE_${target}_CHILDREN
+  # Add OBJECT library (added in cmake 2.8.8) to use in compound modules
+  if (NOT CMAKE_VERSION VERSION_LESS "2.8.8"
+      AND NOT OPENCV_MODULE_${target}_CHILDREN
       AND NOT OPENCV_MODULE_${target}_CLASS STREQUAL "BINDINGS"
       AND NOT ${target} STREQUAL "opencv_ts"
     )


### PR DESCRIPTION
OBJECT library feature has been added to cmake starting from version 2.8.8, but some systems still have older versions of cmake installed (2.8.7 in Ubuntu 12.04 LTS). Since this feature is not needed to build the library itself (only for compound modules) it can be safely turned off.