### PR TITLE
Change some vector mask types to unsigned.

### DIFF
--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -427,7 +427,7 @@ struct _VAdd32f { __m128 operator()(const __m128& a, const __m128& b) const { re
 struct _VSub32f { __m128 operator()(const __m128& a, const __m128& b) const { return _mm_sub_ps(a,b); }};
 struct _VMin32f { __m128 operator()(const __m128& a, const __m128& b) const { return _mm_min_ps(a,b); }};
 struct _VMax32f { __m128 operator()(const __m128& a, const __m128& b) const { return _mm_max_ps(a,b); }};
-static int CV_DECL_ALIGNED(16) v32f_absmask[] = { 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff };
+static unsigned int CV_DECL_ALIGNED(16) v32f_absmask[] = { 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff };
 struct _VAbsDiff32f
 {
     __m128 operator()(const __m128& a, const __m128& b) const
@@ -441,7 +441,7 @@ struct _VSub64f { __m128d operator()(const __m128d& a, const __m128d& b) const {
 struct _VMin64f { __m128d operator()(const __m128d& a, const __m128d& b) const { return _mm_min_pd(a,b); }};
 struct _VMax64f { __m128d operator()(const __m128d& a, const __m128d& b) const { return _mm_max_pd(a,b); }};
 
-static int CV_DECL_ALIGNED(16) v64f_absmask[] = { 0xffffffff, 0x7fffffff, 0xffffffff, 0x7fffffff };
+static unsigned int CV_DECL_ALIGNED(16) v64f_absmask[] = { 0xffffffff, 0x7fffffff, 0xffffffff, 0x7fffffff };
 struct _VAbsDiff64f
 {
     __m128d operator()(const __m128d& a, const __m128d& b) const

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1736,7 +1736,7 @@ public:
         #if CV_SSE3
         int CV_DECL_ALIGNED(16) buf[4];
         float CV_DECL_ALIGNED(16) bufSum[4];
-        static const int CV_DECL_ALIGNED(16) bufSignMask[] = { 0x80000000, 0x80000000, 0x80000000, 0x80000000 };
+        static const unsigned int CV_DECL_ALIGNED(16) bufSignMask[] = { 0x80000000, 0x80000000, 0x80000000, 0x80000000 };
         bool haveSSE3 = checkHardwareSupport(CV_CPU_SSE3);
         #endif
 
@@ -2003,7 +2003,7 @@ public:
         #if CV_SSE3
         int CV_DECL_ALIGNED(16) idxBuf[4];
         float CV_DECL_ALIGNED(16) bufSum32[4];
-        static const int CV_DECL_ALIGNED(16) bufSignMask[] = { 0x80000000, 0x80000000, 0x80000000, 0x80000000 };
+        static const unsigned int CV_DECL_ALIGNED(16) bufSignMask[] = { 0x80000000, 0x80000000, 0x80000000, 0x80000000 };
         bool haveSSE3 = checkHardwareSupport(CV_CPU_SSE3);
         #endif
 


### PR DESCRIPTION
When compiling OpenCV 2.4.9 with Clang++, I get a couple errors like this:

    opencv-2.4.9/modules/core/src/arithm.cpp:444:51: error: 
          constant expression evaluates to 4294967295 which cannot be narrowed to
          type 'int' [-Wc++11-narrowing]
    static int CV_DECL_ALIGNED(16) v64f_absmask[] = { 0xffffffff, 0x7fffffff...
                                                      ^~~~~~~~~~

This branch simply changes the type of the masks to unsigned.