### PR TITLE
Make conversions from integers to floating-point double explicit

### DIFF
--- a/modules/calib3d/test/test_reproject_image_to_3d.cpp
+++ b/modules/calib3d/test/test_reproject_image_to_3d.cpp
@@ -137,7 +137,12 @@ protected:
             {
                 InT d = disp(y, x);
 
-                double from[4] = { x, y, d, 1 };
+                double from[4] = {
+                    static_cast<double>(x),
+                    static_cast<double>(y),
+                    static_cast<double>(d),
+                    1.0,
+                };
                 Mat_<double> res = Q * Mat_<double>(4, 1, from);
                 res /= res(3, 0);
 

--- a/modules/calib3d/test/test_undistort_badarg.cpp
+++ b/modules/calib3d/test/test_undistort_badarg.cpp
@@ -101,7 +101,10 @@ void CV_UndistortPointsBadArgTest::run(int)
     img_size.height = 600;
     double cam[9] = {150.f, 0.f, img_size.width/2.f, 0, 300.f, img_size.height/2.f, 0.f, 0.f, 1.f};
     double dist[4] = {0.01,0.02,0.001,0.0005};
-    double s_points[N_POINTS2] = {img_size.width/4,img_size.height/4};
+    double s_points[N_POINTS2] = {
+        static_cast<double>(img_size.width) / 4.0,
+        static_cast<double>(img_size.height) / 4.0,
+    };
     double d_points[N_POINTS2];
     double p[9] = {155.f, 0.f, img_size.width/2.f+img_size.width/50.f, 0, 310.f, img_size.height/2.f+img_size.height/50.f, 0.f, 0.f, 1.f};
     double r[9] = {1,0,0,0,1,0,0,0,1};

--- a/modules/gpu/perf/perf_imgproc.cpp
+++ b/modules/gpu/perf/perf_imgproc.cpp
@@ -253,7 +253,7 @@ PERF_TEST_P(Sz_Depth_Cn_Inter_Border, ImgProc_WarpAffine,
     const double aplha = CV_PI / 4;
     const double mat[2 * 3] =
     {
-        std::cos(aplha), -std::sin(aplha), src.cols / 2,
+        std::cos(aplha), -std::sin(aplha), static_cast<double>(src.cols) / 2.0,
         std::sin(aplha),  std::cos(aplha), 0
     };
     const cv::Mat M(2, 3, CV_64F, (void*) mat);
@@ -301,7 +301,7 @@ PERF_TEST_P(Sz_Depth_Cn_Inter_Border, ImgProc_WarpPerspective,
     declare.in(src, WARMUP_RNG);
 
     const double aplha = CV_PI / 4;
-    double mat[3][3] = { {std::cos(aplha), -std::sin(aplha), src.cols / 2},
+    double mat[3][3] = { {std::cos(aplha), -std::sin(aplha), static_cast<double>(src.cols) / 2.0},
                          {std::sin(aplha),  std::cos(aplha), 0},
                          {0.0,              0.0,             1.0}};
     const cv::Mat M(3, 3, CV_64F, (void*) mat);

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -233,7 +233,12 @@ static int pyopencv_to(const PyObject* o, Mat& m, const ArgInfo info, bool allow
 
     if( PyInt_Check(o) )
     {
-        double v[] = {PyInt_AsLong((PyObject*)o), 0., 0., 0.};
+        double v[] = {
+            static_cast<double>(PyInt_AsLong((PyObject*)o)),
+            0.,
+            0.,
+            0.,
+        };
         m = Mat(4, 1, CV_64F, v).clone();
         return true;
     }


### PR DESCRIPTION
In a few places, variables with type `double` are initialized by integers, and Clang++ treats it as an error (`-Wc++11-narrowing`).

This branch makes these conversions explicit with casts.