### PR TITLE
fixing model size, typo in previous PR

### DIFF
--- a/data/haarcascades/haarcascade_smile.xml
+++ b/data/haarcascades/haarcascade_smile.xml
@@ -47,7 +47,7 @@
 <opencv_storage>
 <cascade type_id="opencv-cascade-classifier"><stageType>BOOST</stageType>
   <featureType>HAAR</featureType>
-  <height>19</height>
+  <height>18</height>
   <width>36</width>
   <stageParams>
     <maxWeakCount>53</maxWeakCount></stageParams>


### PR DESCRIPTION
Made small typo when pull back models from master and fixing their dimensions. Should be 18 in stead of 19. Yields slightly better detection results!