### PR TITLE
Fix GPU HOG implementation

### DIFF
--- a/modules/gpu/src/hog.cpp
+++ b/modules/gpu/src/hog.cpp
@@ -127,9 +127,6 @@ cv::gpu::HOGDescriptor::HOGDescriptor(Size win_size_, Size block_size_, Size blo
 
     Size cells_per_block = Size(block_size.width / cell_size.width, block_size.height / cell_size.height);
     CV_Assert(cells_per_block == Size(2, 2));
-
-    cv::Size blocks_per_win = numPartsWithin(win_size, block_size, block_stride);
-    hog::set_up_constants(nbins, block_stride.width, block_stride.height, blocks_per_win.width, blocks_per_win.height);
 }
 
 size_t cv::gpu::HOGDescriptor::getDescriptorSize() const
@@ -221,6 +218,9 @@ void cv::gpu::HOGDescriptor::computeGradient(const GpuMat& img, GpuMat& _grad, G
 
 void cv::gpu::HOGDescriptor::computeBlockHistograms(const GpuMat& img)
 {
+    cv::Size blocks_per_win = numPartsWithin(win_size, block_size, block_stride);
+    hog::set_up_constants(nbins, block_stride.width, block_stride.height, blocks_per_win.width, blocks_per_win.height);
+
     computeGradient(img, grad, qangle);
 
     size_t block_hist_size = getBlockHistogramSize();


### PR DESCRIPTION
Move `hog::set_up_constants` from constructor to compute method.

If user changed CUDA device between constructor and computation, some variables were uninitialized.
The request fixes this bug.