### PR TITLE
Fix Python3 binding's submodules

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1235,7 +1235,9 @@ static void init_submodule(PyObject * root, const char * name, PyMethodDef * met
         submod = PyImport_AddModule(full_name.c_str());
         PyDict_SetItemString(d, short_name.c_str(), submod);
     }
-    root = submod;
+
+    if (short_name != "")
+        root = submod;
   }
 
   // populate module's dict


### PR DESCRIPTION
Previously the Python3 `cv2` package ends up with no submodules (`bgsegm`, `face`, etc) in it, which makes a lot of functionality unusable. By not writing over our `root` reference we ensure the new submodules are added to the correct `cv2` module.

I'm not entirely clear why this is necessary (and in Python 2 it works fine either way) but my suspicion is that somewhere (likely the second run through the `while` loop) an unsuitable reference to `cv2` is being created. I initially ran into this issue with the opencv_contrib modules but it affects all the submodule namespaces.

Ideally some of the tests would catch this but it looks like they all use `env Python`, are any run under Python 3?

Before change, Python 3:

````
>>> import cv2
>>> cv2.xfeatures2d.SIFT_create()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'xfeatures2d'
````

Afterwards:

````
>>> import cv2
>>> cv2.xfeatures2d.SIFT_create()
<xfeatures2d_SIFT 0x7f6942a83f50>
```