### PR TITLE
fixed [-Wsign-compare] warning

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -329,7 +329,7 @@ struct HWFeatures
             Elf32_auxv_t auxv;
             const size_t size_auxv_t = sizeof(Elf32_auxv_t);
 
-            while (read(cpufile, &auxv, sizeof(Elf32_auxv_t)) == size_auxv_t)
+            while ((size_t)read(cpufile, &auxv, sizeof(Elf32_auxv_t)) == size_auxv_t)
             {
                 if (auxv.a_type == AT_HWCAP)
                 {


### PR DESCRIPTION
```
/home/sandye51/Documents/Programming/git_repo/opencv_master/modules/core/src/system.cpp: In static member function 'static cv::HWFeatures cv::HWFeatures::initialize()':
/home/sandye51/Documents/Programming/git_repo/opencv_master/modules/core/src/system.cpp:332:66: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
```