### PR TITLE
Reduce variable scope, only compute values that are used later

### DIFF
--- a/modules/core/src/array.cpp
+++ b/modules/core/src/array.cpp
@@ -504,7 +504,7 @@ cvInitNArrayIterator( int count, CvArr** arrs,
 CV_IMPL int cvNextNArraySlice( CvNArrayIterator* iterator )
 {
     assert( iterator != 0 );
-    int i, dims, size = 0;
+    int i, dims;
 
     for( dims = iterator->dims; dims > 0; dims-- )
     {
@@ -514,7 +514,7 @@ CV_IMPL int cvNextNArraySlice( CvNArrayIterator* iterator )
         if( --iterator->stack[dims-1] > 0 )
             break;
 
-        size = iterator->hdr[0]->dim[dims-1].size;
+        const int size = iterator->hdr[0]->dim[dims-1].size;
 
         for( i = 0; i < iterator->count; i++ )
             iterator->ptr[i] -= (size_t)size*iterator->hdr[i]->dim[dims-1].step;
@@ -856,7 +856,6 @@ cvCreateData( CvArr* arr )
     else if( CV_IS_MATND_HDR( arr ))
     {
         CvMatND* mat = (CvMatND*)arr;
-        int i;
         size_t total_size = CV_ELEM_SIZE(mat->type);
 
         if( mat->dim[0].size == 0 )
@@ -872,6 +871,7 @@ cvCreateData( CvArr* arr )
         }
         else
         {
+            int i;
             for( i = mat->dims - 1; i >= 0; i-- )
             {
                 size_t size = (size_t)mat->dim[i].step*mat->dim[i].size;
@@ -1055,16 +1055,19 @@ cvGetRawData( const CvArr* arr, uchar** data, int* step, CvSize* roi_size )
 
         if( roi_size || step )
         {
-            int i, size1 = mat->dim[0].size, size2 = 1;
-
-            if( mat->dims > 2 )
-                for( i = 1; i < mat->dims; i++ )
-                    size1 *= mat->dim[i].size;
-            else
-                size2 = mat->dim[1].size;
-
             if( roi_size )
             {
+                int size1 = mat->dim[0].size, size2 = 1;
+
+                if( mat->dims > 2 )
+                {
+                    int i;
+                    for( i = 1; i < mat->dims; i++ )
+                        size1 *= mat->dim[i].size;
+                }
+                else
+                    size2 = mat->dim[1].size;
+
                 roi_size->width = size2;
                 roi_size->height = size1;
             }
@@ -2458,7 +2461,6 @@ cvGetMat( const CvArr* array, CvMat* mat,
     else if( allowND && CV_IS_MATND_HDR(src) )
     {
         CvMatND* matnd = (CvMatND*)src;
-        int i;
         int size1 = matnd->dim[0].size, size2 = 1;
 
         if( !src->data.ptr )
@@ -2468,8 +2470,11 @@ cvGetMat( const CvArr* array, CvMat* mat,
             CV_Error( CV_StsBadArg, "Only continuous nD arrays are supported here" );
 
         if( matnd->dims > 2 )
+        {
+            int i;
             for( i = 1; i < matnd->dims; i++ )
                 size2 *= matnd->dim[i].size;
+        }
         else
             size2 = matnd->dims == 1 ? 1 : matnd->dim[1].size;
 
@@ -2785,7 +2790,6 @@ cvGetImage( const CvArr* array, IplImage* img )
 {
     IplImage* result = 0;
     const IplImage* src = (const IplImage*)array;
-    int depth;
 
     if( !img )
         CV_Error( CV_StsNullPtr, "" );
@@ -2800,7 +2804,7 @@ cvGetImage( const CvArr* array, IplImage* img )
         if( mat->data.ptr == 0 )
             CV_Error( CV_StsNullPtr, "" );
 
-        depth = cvIplDepth(mat->type);
+        int depth = cvIplDepth(mat->type);
 
         cvInitImageHeader( img, cvSize(mat->cols, mat->rows),
                            depth, CV_MAT_CN(mat->type) );


### PR DESCRIPTION
The original code had too wide scope of some variables, also values were used only for `roi_size != 0` but computed unconditionally.

Too wide scope items found with Cppcheck.