### PR TITLE
Uniform computation of variable size

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -327,9 +327,9 @@ struct HWFeatures
         if (cpufile >= 0)
         {
             Elf32_auxv_t auxv;
-            const size_t size_auxv_t = sizeof(Elf32_auxv_t);
+            const size_t size_auxv_t = sizeof(auxv);
 
-            while ((size_t)read(cpufile, &auxv, sizeof(Elf32_auxv_t)) == size_auxv_t)
+            while ((size_t)read(cpufile, &auxv, size_auxv_t) == size_auxv_t)
             {
                 if (auxv.a_type == AT_HWCAP)
                 {


### PR DESCRIPTION
The original code passes the constant in one place and `sizeof` in another although the same thing is being meant. Also the original code uses type name to compute the size whereas using the variable itself is more fool-proof (if you change the variable type but forget to change the `sizeof` you're screwed).