### PR TITLE
fixing undesired behaviour

### DIFF
--- a/apps/traincascade/imagestorage.cpp
+++ b/apps/traincascade/imagestorage.cpp
@@ -32,20 +32,12 @@ bool CvCascadeImageReader::NegReader::create( const string _filename, Size _winS
     if ( !file.is_open() )
         return false;
 
-    size_t pos = _filename.rfind('\\');
-    char dlmrt = '\\';
-    if (pos == string::npos)
-    {
-        pos = _filename.rfind('/');
-        dlmrt = '/';
-    }
-    dirname = pos == string::npos ? "" : _filename.substr(0, pos) + dlmrt;
     while( !file.eof() )
     {
         std::getline(file, str);
         if (str.empty()) break;
         if (str.at(0) == '#' ) continue; /* comment */
-        imgFilenames.push_back(dirname + str);
+        imgFilenames.push_back(str);
     }
     file.close();
 


### PR DESCRIPTION
How to illustrate what is going wrong?

 - Start by creating a complete traincascade layout with all files necessary
 - Now run the following command inside the folder with adapted parameters to your case

`opencv_traincascade -data cascade/ -vec data.vec -bg negatives.txt -numPos 25 -numNeg 250 -numStages 20 -w 59 -h 23 -precalcValBufSize 2048 -precalcIdxBufSize 2048`

 - You will notice that everything works fine. 
 - But what if you want to use absolute paths, and not the relative files? Then it goes dramatically wrong using the following command:

`opencv_traincascade -data /data/datasets/candy_model/working_model/cascade/0/ -vec /data/datasets/candy_model/working_model/data.vec -bg /data/datasets/candy_model/working_model/negatives.txt -numPos 25 -numNeg 250 -numStages 20 -w 59 -h 23 -precalcValBufSize 2048 -precalcIdxBufSize 2048`

 - It doesnt start training because negative files cannot be found

REASON for the error: the code below looks where the negative.txt file is stored and then looks in the same folder for images. It adds the folder before each line of the file entry. However this behaviour is nowhere documented and every single tutorial out there, including my own, tell people to make a negatives.txt file with the complete path to the file, either relative or absolute.

In this case, situations like `/data/datasets/candy_model/working_model//data/datasets/candy_model/working_model/negatives1.txt` can occur when reading in the negative file if the first entry equals `/data/datasets/candy_model/working_model/negatives1.txt`. 

Best fix for this is to remove this weird structure all together and make people aware that they need to put the exact locations in the negative summation file.
