### PR TITLE
Add CUDA libdirs to pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,6 +540,9 @@ if(HAVE_CUDA AND NOT ENABLE_DYNAMIC_CUDA)
   if(HAVE_CUFFT)
     set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} ${CUDA_cufft_LIBRARY})
   endif()
+  foreach(p ${CUDA_LIBS_PATH})
+    set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} -L${p})
+  endforeach()
 endif()
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
When compiled with CUDA support, OpenCV's pkg-config file lists the CUDA libs
(-lcu*). However the directories containing these libraries are not written to
the file, hence causing link errors when using the pkg-config file afterwards
if the CUDA libs were not installed in the standard library path (e.g. on my
system they are located in `/opt/cuda/lib64`).

This PR adds -L flags for directories from the CUDA_LIBS_PATH variable (already
available in the OpenCV CMakefiles and passed to link_directories()) to the
OPENCV_LINKER_LIBS list, so that they are included in the opencv.pc file.