### PR TITLE
Several small stabilization fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -995,7 +995,7 @@ if(WITH_IPP AND HAVE_IPP)
     status("     linked:" BUILD_WITH_DYNAMIC_IPP THEN "dynamic" ELSE "static")
   endif()
 else()
-  status("    Use IPP:"   WITH_IPP AND NOT HAVE_IPP THEN "IPP not found" ELSE NO)
+  status("    Use IPP:"   WITH_IPP AND NOT HAVE_IPP THEN "IPP not found or implicitly disabled" ELSE NO)
 endif()
 
 if(DEFINED WITH_IPP_A)

--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -88,6 +88,9 @@ function(find_python preferred_version min_version library_env include_dir_env
         find_host_package(PythonLibs "${_version_major_minor}")
       else()
         find_host_package(PythonLibs "${_version_major_minor}.${_version_patch}" EXACT)
+        if(NOT PYTHONLIBS_FOUND)
+            find_host_package(PythonLibs "${_version_major_minor}.${_version_patch}")
+        endif()
       endif()
 
       if(PYTHONLIBS_FOUND)

--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -75,10 +75,10 @@ function(find_python preferred_version min_version library_env include_dir_env
 
     if(NOT ANDROID AND NOT IOS)
       ocv_check_environment_variables(${library_env} ${include_dir_env})
-      if(${library_env})
+      if(${${library_env}})
           set(PYTHON_LIBRARY "${${library_env}}")
       endif()
-      if(${include_dir_env})
+      if(${${include_dir_env}})
           set(PYTHON_INCLUDE_DIR "${${include_dir_env}}")
       endif()
 
@@ -88,9 +88,6 @@ function(find_python preferred_version min_version library_env include_dir_env
         find_host_package(PythonLibs "${_version_major_minor}")
       else()
         find_host_package(PythonLibs "${_version_major_minor}.${_version_patch}" EXACT)
-        if(NOT PYTHONLIBS_FOUND)
-            find_host_package(PythonLibs "${_version_major_minor}.${_version_patch}")
-        endif()
       endif()
 
       if(PYTHONLIBS_FOUND)

--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -75,10 +75,10 @@ function(find_python preferred_version min_version library_env include_dir_env
 
     if(NOT ANDROID AND NOT IOS)
       ocv_check_environment_variables(${library_env} ${include_dir_env})
-      if(${library})
+      if(${library_env})
           set(PYTHON_LIBRARY "${${library_env}}")
       endif()
-      if(${include_dir})
+      if(${include_dir_env})
           set(PYTHON_INCLUDE_DIR "${${include_dir_env}}")
       endif()
 

--- a/cmake/OpenCVFindIPP.cmake
+++ b/cmake/OpenCVFindIPP.cmake
@@ -35,7 +35,7 @@ unset(IPP_VERSION_MINOR)
 unset(IPP_VERSION_BUILD)
 
 if (X86 AND UNIX AND NOT APPLE AND NOT ANDROID AND BUILD_SHARED_LIBS)
-    message(STATUS "On 32-bit Linux IPP can not currently be used with dynamic libs. Set BUILD_SHARED_LIBS=OFF")
+    message(STATUS "On 32-bit Linux IPP can not currently be used with dynamic libs because of linker errors. Set BUILD_SHARED_LIBS=OFF")
     return()
 endif()
 

--- a/cmake/OpenCVFindIPP.cmake
+++ b/cmake/OpenCVFindIPP.cmake
@@ -34,6 +34,11 @@ unset(IPP_VERSION_MAJOR)
 unset(IPP_VERSION_MINOR)
 unset(IPP_VERSION_BUILD)
 
+if (X86 AND UNIX AND NOT APPLE AND NOT ANDROID AND BUILD_SHARED_LIBS)
+    message(STATUS "On 32-bit Linux IPP can not currently be used with dynamic libs. Set BUILD_SHARED_LIBS=OFF")
+    return()
+endif()
+
 set(IPP_X64 0)
 if(CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 8)
     set(IPP_X64 1)

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -2314,7 +2314,10 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
                     depth == CV_8U ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_8u_C1R :
                     depth == CV_8S ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_8s_C1R :
                     depth == CV_16U ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_16u_C1R :
-                    /*depth == CV_32F ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_32f_C1R :*/ 0;
+                #if !((defined _MSC_VER && defined _M_IX86) || defined __i386__)
+                    depth == CV_32F ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_32f_C1R :
+                #endif
+                    0;
                 CV_SUPPRESS_DEPRECATED_END
 
                 if( ippFuncC1 )

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -2314,7 +2314,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
                     depth == CV_8U ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_8u_C1R :
                     depth == CV_8S ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_8s_C1R :
                     depth == CV_16U ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_16u_C1R :
-                    depth == CV_32F ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_32f_C1R : 0;
+                    /*depth == CV_32F ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_32f_C1R :*/ 0;
                 CV_SUPPRESS_DEPRECATED_END
 
                 if( ippFuncC1 )


### PR DESCRIPTION
1) make sure Python 2.7 is detected on Ubuntu (including libs) when it's there.
2) disable IPP on 32-bit Linux when OpenCV is built as shared libs. Otherwise we get linker errors
3) disable IPP's minMaxIdx 32-bit floating-point flavor in a hope that it fixes some test failures