### PR TITLE
Fixed: wrong conversion of float-based Mat input inside the AKAZE.

### DIFF
--- a/modules/features2d/src/akaze.cpp
+++ b/modules/features2d/src/akaze.cpp
@@ -172,7 +172,14 @@ namespace cv
                 cvtColor(image, img, COLOR_BGR2GRAY);
 
             Mat img1_32;
-            img.convertTo(img1_32, CV_32F, 1.0 / 255.0, 0);
+            if ( img.depth() == CV_32F )
+                img1_32 = img;
+            else if ( img.depth() == CV_8U )
+                img.convertTo(img1_32, CV_32F, 1.0 / 255.0, 0);
+            else if ( img.depth() == CV_16U )
+                img.convertTo(img1_32, CV_32F, 1.0 / 65535.0, 0);
+
+            CV_Assert( ! img1_32.empty() );
 
             AKAZEOptions options;
             options.descriptor = descriptor;


### PR DESCRIPTION
I noticed that the AKAZE detector (3.0.0-beta and after) does not find any key points, if the type of is input image is CV_32F. For the same image as CV_8U the result is as expected:

    $ ./a.out ~/Downloads/graf/img1.ppm 
    keypoints in image3b = 2947
    keypoints in image3f = 0

This behavior can be reproduced with this example:

	#include <opencv2/core.hpp>
	#include <opencv2/features2d.hpp>
	#include <opencv2/highgui.hpp>
	
	#include <iostream>
	#include <vector>
	
	using namespace cv;
	using namespace std;
	
	Ptr< AKAZE > akaze = AKAZE::create();
	
	namespace {
	
	size_t runAkaze( const cv::Mat image )
	{
		std::vector< KeyPoint > keypoints;
		cv::Mat descriptors;
	
		akaze->detectAndCompute( image, noArray(), keypoints, descriptors );
	
		return keypoints.size();
	}
	
	} // namespace
	
	int main( int argc, char ** argv )
	{
		if ( argc != 2 )
		{
			std::cout << "Usage: a.out /path/to/image.ppm" << std::endl;
			return 1;
		}
	
		Mat3b image3b = imread( argv[ 1 ] );
		Mat3f image3f;
		image3b.convertTo( image3f, CV_32FC3, 1./255. );
	
		size_t count3b = runAkaze( image3b );
		size_t count3f = runAkaze( image3f );
	
		std::cout << "keypoints in image3b = " << count3b << std::endl;
		std::cout << "keypoints in image3f = " << count3f << std::endl;
	
		return 0;
	}

The problem is that the input of the detector, regardless of its depth, is converted to float as if it were of depth CV_8U. The solution is to normalize depending on the depth of the input.


