### PR TITLE
OCL: Data race fix between oclCleanupCallback and Mat::GetUMat();

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -449,6 +449,29 @@ protected:
 
 /////////////////////////////////////// Mat ///////////////////////////////////////////
 
+// Event counter class
+// Signal event if internal counter is zero and unsignal event if counter is greater than zero
+// With this some thread can wait on query of concurrent tasks.
+class CV_EXPORTS EventCnt
+{
+public:
+    EventCnt(bool delayedInit = false);
+    ~EventCnt();
+    EventCnt(const EventCnt& m);
+    EventCnt& operator = (const EventCnt& m);
+
+    void initialize();
+    bool isInitialized();
+
+    int increment(); // increment event wait counter
+    int decriment(); // decriment event wait counter
+    void wait(); // wait for event
+
+    struct Impl;
+protected:
+    Impl* impl;
+};
+
 // note that umatdata might be allocated together
 // with the matrix data, not as a separate object.
 // therefore, it does not have constructor or destructor;
@@ -483,6 +506,7 @@ struct CV_EXPORTS UMatData
     uchar* origdata;
     size_t size;
 
+    cv::EventCnt cleanUpEvent;
     int flags;
     void* handle;
     void* userdata;

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -641,8 +641,14 @@ void Mat::addref()
 
 inline void Mat::release()
 {
-    if( u && CV_XADD(&u->refcount, -1) == 1 )
-        deallocate();
+    if( u )
+    {
+        // If this is last Mat wait for cleanup to finish or "u" may become invalid
+        if( u->refcount == 1 )
+            u->cleanUpEvent.wait();
+        if( CV_XADD(&u->refcount, -1) == 1 )
+            deallocate();
+    }
     u = NULL;
     datastart = dataend = datalimit = data = 0;
     for(int i = 0; i < dims; i++)

--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -55,6 +55,7 @@ CV_EXPORTS_W bool haveAmdBlas();
 CV_EXPORTS_W bool haveAmdFft();
 CV_EXPORTS_W void setUseOpenCL(bool flag);
 CV_EXPORTS_W void finish();
+CV_EXPORTS_W void flush();
 
 CV_EXPORTS bool haveSVM();
 
@@ -290,6 +291,7 @@ public:
 
     bool create(const Context& c=Context(), const Device& d=Device());
     void finish();
+    void flush();
     void* ptr() const;
     static Queue& getDefault();
 

--- a/modules/core/perf/opencl/perf_matop.cpp
+++ b/modules/core/perf/opencl/perf_matop.cpp
@@ -13,59 +13,6 @@
 namespace cvtest {
 namespace ocl {
 
-
-///////////// oclCleanupCallback threadsafe check ////////////////////////
-
-typedef Size_MatType CleanupCallbackFixture;
-
-// Case 1: reuse of old src Mat in OCL pipe. Hard to catch!
-OCL_PERF_TEST(CleanupCallbackFixture, CleanupCallback_1)
-{
-    const Size srcSize = szQVGA;
-    const int type = CV_8UC1;
-    const int dtype = CV_16UC1;
-
-    checkDeviceMaxMemoryAllocSize(srcSize, dtype);
-
-    Mat src(srcSize, type);
-    UMat dst(srcSize, dtype);
-
-    declare.in(src, WARMUP_RNG).out(dst);
-
-    OCL_TEST_CYCLE_MULTIRUN(1000)
-    {
-        UMat tmpUMat = src.getUMat(ACCESS_RW);
-        tmpUMat.convertTo(dst, dtype);
-        ::cv::ocl::finish();
-    }
-
-    SANITY_CHECK(src);
-}
-
-// Case 2: concurent deallocation of UMatData between UMat and Mat deallocators. Hard to catch!
-OCL_PERF_TEST(CleanupCallbackFixture, CleanupCallback_2)
-{
-    const Size srcSize = szQVGA;
-    const int type = CV_8UC1;
-    const int dtype = CV_16UC1;
-
-    checkDeviceMaxMemoryAllocSize(srcSize, dtype);
-
-    UMat dst(srcSize, dtype);
-
-    OCL_TEST_CYCLE_MULTIRUN(1000)
-    {
-        Mat src(srcSize, type);
-        {
-            UMat tmpUMat = src.getUMat(ACCESS_RW);
-            tmpUMat.convertTo(dst, dtype);
-        }
-        ::cv::ocl::finish();
-    }
-
-    SANITY_CHECK_NOTHING();
-}
-
 ///////////// SetTo ////////////////////////
 
 typedef Size_MatType SetToFixture;

--- a/modules/core/perf/opencl/perf_matop.cpp
+++ b/modules/core/perf/opencl/perf_matop.cpp
@@ -13,6 +13,59 @@
 namespace cvtest {
 namespace ocl {
 
+
+///////////// oclCleanupCallback threadsafe check ////////////////////////
+
+typedef Size_MatType CleanupCallbackFixture;
+
+// Case 1: reuse of old src Mat in OCL pipe. Hard to catch!
+OCL_PERF_TEST(CleanupCallbackFixture, CleanupCallback_1)
+{
+    const Size srcSize = szQVGA;
+    const int type = CV_8UC1;
+    const int dtype = CV_16UC1;
+
+    checkDeviceMaxMemoryAllocSize(srcSize, dtype);
+
+    Mat src(srcSize, type);
+    UMat dst(srcSize, dtype);
+
+    declare.in(src, WARMUP_RNG).out(dst);
+
+    OCL_TEST_CYCLE_MULTIRUN(1000)
+    {
+        UMat tmpUMat = src.getUMat(ACCESS_RW);
+        tmpUMat.convertTo(dst, dtype);
+        ::cv::ocl::finish();
+    }
+
+    SANITY_CHECK(src);
+}
+
+// Case 2: concurent deallocation of UMatData between UMat and Mat deallocators. Hard to catch!
+OCL_PERF_TEST(CleanupCallbackFixture, CleanupCallback_2)
+{
+    const Size srcSize = szQVGA;
+    const int type = CV_8UC1;
+    const int dtype = CV_16UC1;
+
+    checkDeviceMaxMemoryAllocSize(srcSize, dtype);
+
+    UMat dst(srcSize, dtype);
+
+    OCL_TEST_CYCLE_MULTIRUN(1000)
+    {
+        Mat src(srcSize, type);
+        {
+            UMat tmpUMat = src.getUMat(ACCESS_RW);
+            tmpUMat.convertTo(dst, dtype);
+        }
+        ::cv::ocl::finish();
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
 ///////////// SetTo ////////////////////////
 
 typedef Size_MatType SetToFixture;

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1092,12 +1092,12 @@ EventCnt& EventCnt::operator = (const EventCnt& m)
     return *this;
 }
 
-void EventCnt::initialize() { impl?impl:(impl = new EventCnt::Impl); }
+void EventCnt::initialize() { if(!impl){impl = new EventCnt::Impl;} }
 bool EventCnt::isInitialized() { return impl?true:false; }
 
 int EventCnt::increment() { return (impl?impl->increment():0); }
 int EventCnt::decriment() { return (impl?impl->decriment():0); }
-void EventCnt::wait() { impl?impl->wait():impl; }
+void EventCnt::wait() { if(impl){impl->wait();} }
 
 //////////////////////////////// thread-local storage ////////////////////////////////
 

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -50,7 +50,7 @@ namespace cv {
 enum { UMAT_NLOCKS = 31 };
 static Mutex umatLocks[UMAT_NLOCKS];
 
-UMatData::UMatData(const MatAllocator* allocator)
+UMatData::UMatData(const MatAllocator* allocator) : cleanUpEvent(true)
 {
     prevAllocator = currAllocator = allocator;
     urefcount = refcount = 0;
@@ -221,6 +221,7 @@ UMat Mat::getUMat(int accessFlags, UMatUsageFlags usageFlags) const
         temp_u = a->allocate(dims, size.p, type(), data, step.p, accessFlags, usageFlags);
         temp_u->refcount = 1;
     }
+
     UMat::getStdAllocator()->allocate(temp_u, accessFlags, usageFlags); // TODO result is not checked
     hdr.flags = flags;
     setSize(hdr, dims, size.p, step.p);


### PR DESCRIPTION
Case 1: reuse of old src Mat in OCL pipe leads to data race with oclCleanupCallback and can result in asser fail or other undefined behavior.

Case 2: concurent deallocation of UMatData between UMat (oclCleanupCallback) and Mat (stack) deallocators.

EventCnt object was added to UMatData to track status of oclCleanupCallback;
Two test cases were implemented to reproduce the problem;