### PR TITLE
- Fixed compile error that appeared with Clang 5.1 on Mac 10.8.5

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -574,7 +574,7 @@ bool CvCapture_GStreamer::open( int type, const char* filename )
             return false;
         }
         g_object_unref(G_OBJECT(testfac));
-        filename = "v4lsrc ! "COLOR_ELEM" ! appsink";
+        filename = "v4lsrc ! " COLOR_ELEM " ! appsink";
     }
     if (type == CV_CAP_GSTREAMER_V4L2){
         testfac = gst_element_factory_find("v4l2src");
@@ -582,7 +582,7 @@ bool CvCapture_GStreamer::open( int type, const char* filename )
             return false;
         }
         g_object_unref(G_OBJECT(testfac));
-        filename = "v4l2src ! "COLOR_ELEM" ! appsink";
+        filename = "v4l2src ! " COLOR_ELEM " ! appsink";
     }
 
 


### PR DESCRIPTION
    modules/videoio/src/cap_gstreamer.cpp:577:31: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
            filename = "v4lsrc ! "COLOR_ELEM" ! appsink";
                              ^
    modules/videoio/src/cap_gstreamer.cpp:585:32: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
            filename = "v4l2src ! "COLOR_ELEM" ! appsink";