### PR TITLE
upgrade traincascade default memory

### DIFF
--- a/apps/traincascade/traincascade.cpp
+++ b/apps/traincascade/traincascade.cpp
@@ -14,8 +14,8 @@ int main( int argc, char* argv[] )
     int numPos    = 2000;
     int numNeg    = 1000;
     int numStages = 20;
-    int precalcValBufSize = 256,
-        precalcIdxBufSize = 256;
+    int precalcValBufSize = 1024,
+        precalcIdxBufSize = 1024;
     bool baseFormatSave = false;
 
     CvCascadeParams cascadeParams;


### PR DESCRIPTION
Using only 256 MB of memory for calculating the feature pool and weak classifiers for the boosting process seems kind of stupid to me, since current day to day systems have AT least 2GB of memory available. Many people don't know however that this drastically influences the training time and possible features that can be stored in memory. I therefore suggest increasing it already to 1GB for each buffer.

What do you think? If agreed I will perform similar adaptation to 3.0 branch! 