### PR TITLE
fix for installation errors caused by ffmpeg package

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -36,7 +36,7 @@ cd ffmpeg-0.10.15
 make
 sudo make install
 @endcode
- 
+
 Getting OpenCV Source Code
 --------------------------
 

--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -32,7 +32,7 @@ cd ~
 wget http://ffmpeg.org/releases/ffmpeg-0.10.15.tar.gz
 tar -xvzf ffmpeg-0.10.15.tar.gz
 cd ffmpeg-0.10.15
-./configure 
+./configure
 make
 sudo make install
 @endcode

--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -24,6 +24,19 @@ Manager:
 [required] sudo apt-get install cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
 [optional] sudo apt-get install python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
 @endcode
+
+To install the ffmpeg package, you can find all versions of releases in [ffmpeg index](http://ffmpeg.org/releases/). Take the installation of 'ffmpeg-0.10.15.tar.gz' as an example:
+Manager:
+@code{.bash}
+cd ~
+wget http://ffmpeg.org/releases/ffmpeg-0.10.15.tar.gz
+tar -xvzf ffmpeg-0.10.15.tar.gz
+cd ffmpeg-0.10.15
+./configure 
+make
+sudo make install
+@endcode
+ 
 Getting OpenCV Source Code
 --------------------------
 


### PR DESCRIPTION
While it is common to run into the problems caused by ffmpeg package, it can be fixed easily just by installing it before building opencv, my modification is to add several commands to install ffmpeg package.