### PR TITLE
fix for issue 1915

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -649,13 +649,13 @@ bool CvCapture_FFMPEG::grabFrame()
         frame_number > ic->streams[video_stream]->nb_frames )
         return false;
 
-    av_free_packet (&packet);
-
     picture_pts = AV_NOPTS_VALUE_;
 
     // get the next frame
     while (!valid)
     {
+
+        av_free_packet (&packet);
         int ret = av_read_frame(ic, &packet);
         if (ret == AVERROR(EAGAIN)) continue;
 
@@ -698,8 +698,6 @@ bool CvCapture_FFMPEG::grabFrame()
             if (count_errs > max_number_of_attempts)
                 break;
         }
-
-        av_free_packet (&packet);
     }
 
     if( valid && first_frame_number < 0 )


### PR DESCRIPTION
This is a fix for the bug
http://code.opencv.org/issues/1915

The problem was that avcodec_decode_video2 outputs an AVFrame that keeps a
reference to the packet's buffer if the input is a raw video (without a codec).
That leads to the case that av_free_packet (&packet); in line 702 corrupts the AVFrame picture and a segmentation fault occurs later when the function sws_scale() gets called.

This happend only on Linux Ubuntu when inputting a raw video file.