### PR TITLE
extra camera specific information

### DIFF
--- a/samples/cpp/videocapture_pvapi.cpp
+++ b/samples/cpp/videocapture_pvapi.cpp
@@ -5,6 +5,23 @@
 // Succesfully tested on Prosilica and Manta series //
 //////////////////////////////////////////////////////
 
+// --------------------------------------------------------------------------------
+// Some remarks for ensuring the correct working of the interface between camera
+// and the pc from which you will capture data - Linux based settings. The settings
+// for Windows are the same, but edited in the graphical interface of the
+// network card.
+//
+// You have to be sure that OpenCV is built with the PvAPI interface enabled.
+//
+// FIRST CONFIGURE IP SETTINGS
+// - Change the IP address of your pc to 169.254.1.1
+// - Change the subnet mask of your pc to 255.255.0.0
+// - Change the gateway of your pc to 169.254.1.2
+//
+// CHANGE SOME NETWORK CARD SETTINGS
+// - sudo ifconfig eth0 mtu 9000 - or 9016 ideally if your card supports that
+// --------------------------------------------------------------------------------
+
 #include <iostream>
 #include "opencv2/opencv.hpp"
 


### PR DESCRIPTION
AVT camera requires specific IP configuration between camera and pc in order for this example to work properly.
Added that information to the sample!