### PR TITLE
fixed error in hough lines tutorial

### DIFF
--- a/doc/tutorials/imgproc/imgtrans/hough_lines/hough_lines.rst
+++ b/doc/tutorials/imgproc/imgtrans/hough_lines/hough_lines.rst
@@ -57,7 +57,7 @@ How does it work?
 
    We consider only points such that :math:`r > 0` and :math:`0< \theta < 2 \pi`.
 
-#. We can do the same operation above for all the points in an image. If the curves of two different points intersect in the plane :math:`\theta` - :math:`r`, that means that both points belong to a same line. For instance, following with the example above and drawing the plot for two more points: :math:`x_{1} = 9`, :math:`y_{1} = 4` and :math:`x_{2} = 12`, :math:`y_{2} = 3`, we get:
+#. We can do the same operation above for all the points in an image. If the curves of two different points intersect in the plane :math:`\theta` - :math:`r`, that means that both points belong to a same line. For instance, following with the example above and drawing the plot for two more points: :math:`x_{1} = 4`, :math:`y_{1} = 9` and :math:`x_{2} = 12`, :math:`y_{2} = 3`, we get:
 
    .. image:: images/Hough_Lines_Tutorial_Theory_2.jpg
       :alt: Polar plot of the family of lines for three points


### PR DESCRIPTION
The second point (9,4) mentioned is not on the lines, but the point (4,9) is. Using this point will also correspond to the depicted graphic with the several sinusoid lines, so I think this was just a swapping mistake here.

Thank you for your time and efforts and I hope I did everything right.