### PR TITLE
Fix compilation on MSVS2010

### DIFF
--- a/samples/cpp/tutorial_code/ml/introduction_to_pca/introduction_to_pca.cpp
+++ b/samples/cpp/tutorial_code/ml/introduction_to_pca/introduction_to_pca.cpp
@@ -23,7 +23,7 @@ void drawAxis(Mat& img, Point p, Point q, Scalar colour, const float scale = 0.2
     double angle;
     double hypotenuse;
     angle = atan2( (double) p.y - q.y, (double) p.x - q.x ); // angle in radians
-    hypotenuse = sqrt( (p.y - q.y) * (p.y - q.y) + (p.x - q.x) * (p.x - q.x));
+    hypotenuse = sqrt( (double) (p.y - q.y) * (p.y - q.y) + (p.x - q.x) * (p.x - q.x));
 //    double degrees = angle * 180 / CV_PI; // convert radians to degrees (0-180 range)
 //    cout << "Degrees: " << abs(degrees - 180) << endl; // angle in 0-360 degrees range
 


### PR DESCRIPTION
```
introduction_to_pca.cpp(26): error C2668: 'sqrt' : ambiguous call to overloaded function 
                 C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\math.h(589): could be 'long double sqrt(long double)'
                 C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\math.h(541): or       'float sqrt(float)'
                 C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\math.h(127): or       'double sqrt(double)'
```