### PR TITLE
Added cmake option for abi descriptor generating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,7 @@ OCV_OPTION(ENABLE_NOISY_WARNINGS      "Show all warnings even if they are too no
 OCV_OPTION(OPENCV_WARNINGS_ARE_ERRORS "Treat warnings as errors"                                 OFF )
 OCV_OPTION(ANDROID_EXAMPLES_WITH_LIBS "Build binaries of Android examples with native libraries" OFF  IF ANDROID )
 OCV_OPTION(ENABLE_IMPL_COLLECTION     "Collect implementation data on function call"             OFF )
+OCV_OPTION(GENERATE_ABI_DESCRIPTOR    "Generate XML file for abi_compliance_checker tool" OFF IF UNIX)
 
 if(ENABLE_IMPL_COLLECTION)
   add_definitions(-DCV_COLLECT_IMPL_DATA)
@@ -638,6 +639,9 @@ include(cmake/OpenCVGenConfig.cmake)
 
 # Generate Info.plist for the IOS framework
 include(cmake/OpenCVGenInfoPlist.cmake)
+
+# Generate ABI descriptor
+include(cmake/OpenCVGenABI.cmake)
 
 # Generate environment setup file
 if(INSTALL_TESTS AND OPENCV_TEST_DATA_PATH)

--- a/cmake/OpenCVGenABI.cmake
+++ b/cmake/OpenCVGenABI.cmake
@@ -1,0 +1,29 @@
+if (NOT GENERATE_ABI_DESCRIPTOR)
+  return()
+endif()
+
+set(filename "opencv_abi.xml")
+set(path1 "${CMAKE_BINARY_DIR}/${filename}")
+
+set(modules "${OPENCV_MODULES_PUBLIC}")
+ocv_list_filterout(modules "opencv_ts")
+
+message(STATUS "Generating ABI compliance checker configuration: ${filename}")
+
+if (OPENCV_VCSVERSION AND NOT OPENCV_VCSVERSION STREQUAL "unknown")
+  set(OPENCV_ABI_VERSION "${OPENCV_VCSVERSION}")
+else()
+  set(OPENCV_ABI_VERSION "${OPENCV_VERSION}")
+endif()
+
+# Headers
+set(OPENCV_ABI_HEADERS "{RELPATH}/${OPENCV_INCLUDE_INSTALL_PATH}")
+
+# Libraries
+set(OPENCV_ABI_LIBRARIES "{RELPATH}/${OPENCV_LIB_INSTALL_PATH}")
+
+# Options
+set(OPENCV_ABI_GCC_OPTIONS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
+string(REGEX REPLACE "([^ ]) +([^ ])" "\\1\\n    \\2" OPENCV_ABI_GCC_OPTIONS "${OPENCV_ABI_GCC_OPTIONS}")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/opencv_abi.xml.in" "${path1}")

--- a/cmake/templates/opencv_abi.xml.in
+++ b/cmake/templates/opencv_abi.xml.in
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+
+    This file is auto-generated
+
+-->
+
+<descriptor>
+
+<version>
+    @OPENCV_ABI_VERSION@
+</version>
+
+<headers>
+    @OPENCV_ABI_HEADERS@
+</headers>
+
+<libs>
+    @OPENCV_ABI_LIBRARIES@
+</libs>
+
+<skip_headers>
+    opencv2/core/cuda*
+    opencv2/core/private*
+    opencv/cxeigen.hpp
+    opencv2/core/eigen.hpp
+    opencv2/flann/hdf5.h
+    opencv2/imgcodecs/ios.h
+    opencv2/videoio/cap_ios.h
+    opencv2/ts.hpp
+    opencv2/ts/*
+    opencv2/xobjdetect/private.hpp
+</skip_headers>
+
+<gcc_options>
+ @OPENCV_ABI_GCC_OPTIONS@
+</gcc_options>
+
+</descriptor>

--- a/include/opencv/cvaux.h
+++ b/include/opencv/cvaux.h
@@ -51,12 +51,6 @@
 #include "opencv2/photo/photo_c.h"
 #include "opencv2/video/tracking_c.h"
 #include "opencv2/objdetect/objdetect_c.h"
-#include "opencv2/contrib/compat.hpp"
-
-#include "opencv2/legacy.hpp"
-#include "opencv2/legacy/compat.hpp"
-#include "opencv2/legacy/blobtrack.hpp"
-
 
 #endif
 


### PR DESCRIPTION
Special cmake option `GENERATE_ABI_DESCRIPTOR` now allows to create xml-descriptor file for [abi-compliance-checker](http://ispras.linuxbase.org/index.php/ABI_compliance_checker) tool during cmake run. This file (`opencv_abi.xml`) will be put to the build root.
Example usage:
```.sh
cd build
cmake -DGENERATE_ABI_DESCRIPTOR=ON -DCMAKE_INSTALL_PREFIX=install ../opencv
make install
# create the packed dump file
abi-compliance-checker \
    -l opencv \
    -dump opencv_abi.xml \
    -dump-path my_dump.abi.tar.gz \
    -relpath install
# compare new packed dump with existing base dump
abi-compliance-checker \
    -l opencv \
    -old $STORAGE/base.abi.tar.gz \
    -new my_dump.abi.tar.gz
```

__Note:__ _abi-compliance-checker_ does not support gcc-4.8.\[1-3\] (installed in Ubuntu 14.04), so it is necessary to use different version (gcc-4.6 for example). Install different gcc version and pass the `--gcc-path=gcc-4.6` option to the checker if you see any related warnings.

__Note:__ it is also possible to compare two versions without making dumps:
```.sh
abi-compliance-checker \
    -lopencv \
    -old $build1 -relpath1 $install1 \
    -new $build2  -relpath2 $install2
```