### PR TITLE
Fix free space check in icvGrowSeq

### DIFF
--- a/modules/core/src/datastructs.cpp
+++ b/modules/core/src/datastructs.cpp
@@ -645,7 +645,7 @@ icvGrowSeq( CvSeq *seq, int in_front_of )
         /* If there is a free space just after last allocated block
            and it is big enough then enlarge the last block.
            This can happen only if the new block is added to the end of sequence: */
-        if( (unsigned)(ICV_FREE_PTR(storage) - seq->block_max) < CV_STRUCT_ALIGN &&
+        if( (size_t)(ICV_FREE_PTR(storage) - seq->block_max) < CV_STRUCT_ALIGN &&
             storage->free_space >= seq->elem_size && !in_front_of )
         {
             int delta = storage->free_space / elem_size;


### PR DESCRIPTION
A difference of two pointers was casted to unsigned which can lead to
overflow on 64-bit systems. 

This lead to segmentation violation on a 64-bit system when deserializing RandomTrees. The problem happened rarely due to address space randomization.