### PR TITLE
Update to load() to handle missing/bad file

### DIFF
--- a/modules/ml/src/inner_functions.cpp
+++ b/modules/ml/src/inner_functions.cpp
@@ -90,7 +90,7 @@ void CvStatModel::load( const char* filename, const char* name )
 
     CV_CALL( fs = cvOpenFileStorage( filename, 0, CV_STORAGE_READ ));
     if( !fs )
-        EXIT;
+        CV_ERROR( CV_StsError, "Could not open the file storage. Check the path and permissions" ); 
 
     if( name )
         model_node = cvGetFileNodeByName( fs, 0, name );


### PR DESCRIPTION
If a file was missing or unreadable due to permissions, CvStatModel::load() would __EXIT__ the function without reporting an error.  Copied CV_ERROR() from CvStatModel::save()

Without this fix, using load() with CvANN_MLP or other CvStatModel, no error is returned if a file is unreadable, and your program/code will continue and then perform unexpectedly.  This matches the behavior of the save() function in such a situation. 