### PR TITLE
Modify findTransformECC to support a mask of pixels to consider

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -278,6 +278,7 @@ order to provide an image similar to templateImage, same type as temlateImage.
 criteria.epsilon defines the threshold of the increment in the correlation coefficient between two
 iterations (a negative criteria.epsilon makes criteria.maxcount the only termination criterion).
 Default values are shown in the declaration above.
+@param inputMask An optional mask to indicate valid values of inputImage.
 
 The function estimates the optimum transformation (warpMatrix) with respect to ECC criterion
 (@cite EP08), that is
@@ -309,7 +310,8 @@ estimateRigidTransform, findHomography
  */
 CV_EXPORTS_W double findTransformECC( InputArray templateImage, InputArray inputImage,
                                       InputOutputArray warpMatrix, int motionType = MOTION_AFFINE,
-                                      TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 50, 0.001));
+                                      TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 50, 0.001),
+                                      InputArray inputMask = noArray());
 
 /** @brief Kalman filter class.
 

--- a/modules/video/perf/perf_ecc.cpp
+++ b/modules/video/perf/perf_ecc.cpp
@@ -67,5 +67,5 @@ PERF_TEST_P(TransformationType, findTransformECC, /*testing::ValuesIn(MotionType
         findTransformECC(templateImage, img, warpMat, transform_type,
             TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 5, -1));
     }
-    SANITY_CHECK(warpMat, 1e-3);
+    SANITY_CHECK(warpMat, 3e-3);
 }


### PR DESCRIPTION
Tests of the mask are also included.

This is useful for registering a non-square image against a non-square template.