### PR TITLE
resolve crash of haarclassifier when using a tilted feature [issue #4218]

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -555,6 +555,7 @@ HaarEvaluator::HaarEvaluator()
     localSize = Size(4, 2);
     lbufSize = Size(0, 0);
     nchannels = 0;
+    tofs = 0;
 }
 
 HaarEvaluator::~HaarEvaluator()

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -677,6 +677,10 @@ void HaarEvaluator::computeOptFeatures()
     copyVectorToUMat(*optfeatures_lbuf, ufbuf);
 }
 
+bool HaarEvaluator::setImage(InputArray _image, const std::vector<float>& _scales){
+    tofs = 0;
+    return FeatureEvaluator::setImage(_image, _scales);
+}
 
 bool HaarEvaluator::setWindow( Point pt, int scaleIdx )
 {

--- a/modules/objdetect/src/cascadedetect.hpp
+++ b/modules/objdetect/src/cascadedetect.hpp
@@ -347,6 +347,7 @@ public:
     virtual Ptr<FeatureEvaluator> clone() const;
     virtual int getFeatureType() const { return FeatureEvaluator::HAAR; }
 
+    virtual bool setImage(InputArray _image, const std::vector<float>& _scales);
     virtual bool setWindow(Point p, int scaleIdx);
     Rect getNormRect() const;
     int getSquaresOffset() const;


### PR DESCRIPTION
issue discussion: http://code.opencv.org/issues/4218
introduced in 92c8b94ba9c9ecf6a5b9ae7642251ae93d31fe53

I found an unitialized variable which lead to the crashes discussed. Glad i could found it.

Question is if this variable should be reset to 0 at some point of the code? FeatureEvaluator does not declare this variable so we cannot use the same point in the code as before the refactoring.

At the method FeatureEvaluator::setImage the variable is set at the method computeChannels which is called after the method computeOptFeatures where this variable is used.

I hope @vpisarev could maybe look over this.