### PR TITLE
Fix a bug that impede to set the trackbar pos using the Qt control panel

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -406,13 +406,14 @@ static CvBar* icvFindBarByName(QBoxLayout* layout, QString name_bar, typeBar typ
 static CvTrackbar* icvFindTrackBarByName(const char* name_trackbar, const char* name_window, QBoxLayout* layout = NULL)
 {
     QString nameQt(name_trackbar);
+    QString nameWinQt(name_window);
 
-    if (!name_window && global_control_panel) //window name is null and we have a control panel
+    if (nameWinQt.isEmpty() && global_control_panel) //window name is null and we have a control panel
         layout = global_control_panel->myLayout;
 
     if (!layout)
     {
-        QPointer<CvWindow> w = icvFindWindowByName(QLatin1String(name_window));
+        QPointer<CvWindow> w = icvFindWindowByName(nameWinQt);
 
         if (!w)
             CV_Error(CV_StsNullPtr, "NULL window handler");


### PR DESCRIPTION
This commit fix a bug that I observed recently. When using the Qt backend and the control panel window that you can open with Ctrl+P, it's impossible to set the trackbar position explicitly with setTrackbarPos; it throws an exception.

I know that I could set the initial value of param1 to the desired trackbar position, but sometimes the number/position of the trackbar doesn't match with the meaning of the value of the variables you want to use. In that cases it's useful to be able to set the value manually with the setTrackbarPos function (as it is indicated in the OpenCV reference manual).

This is a code snippet that can reproduce the problem before applying the changes I commited. 

```cpp
#include <opencv2/highgui/highgui.hpp>
#include <iostream>

static void onTrackbarParam1(int trackerPos, void* );

int param1=0;

int main()
{
	cv::Mat img(400, 400, CV_8UC1, cv::Scalar::all(255));

	cv::namedWindow("img", cv::WINDOW_NORMAL | CV_WINDOW_KEEPRATIO);
	cv::moveWindow("img", 0, 0);

	cv::displayOverlay("img", "Press Ctrl+P for displaying the control panel", 1000);
	cv::createTrackbar("param1", std::string(), &param1, 10, onTrackbarParam1);
	cv::setTrackbarPos("param1", std::string(), 5);

	cv::waitKey();	
	return EXIT_SUCCESS;
}

static void onTrackbarParam1(int trackerPos , void* )
{
	std::cout << "trackerPos: " << trackerPos << std::endl;
}
```