### PR TITLE
Fixing invalid opencv_test_ml calls

### DIFF
--- a/modules/ml/src/tree.cpp
+++ b/modules/ml/src/tree.cpp
@@ -286,7 +286,14 @@ int DTreesImpl::addTree(const vector<int>& sidx )
                 int ssize = getSubsetSize(split.varIdx);
                 split.subsetOfs = (int)subsets.size();
                 subsets.resize(split.subsetOfs + ssize);
-                memcpy(&subsets[split.subsetOfs], &w->wsubsets[wsplit.subsetOfs], ssize*sizeof(int));
+                // This check verifies that subsets index is in the correct range
+                // as in case ssize == 0 no real resize performed.
+                // Thus memory kept safe.
+                // Also this skips useless memcpy call when size parameter is zero
+                if(ssize > 0)
+                {
+                    memcpy(&subsets[split.subsetOfs], &w->wsubsets[wsplit.subsetOfs], ssize*sizeof(int));
+                }
             }
             node.split = (int)splits.size();
             splits.push_back(split);


### PR DESCRIPTION
Debug version of opencv_test_ml crashes on the following output:
[ RUN ] ML_DTree.regression

The reason is _ITERATION_DEBUG_LEVEL 2 suppose performing of numerous checks. There is working with element outside of the vector bounds that is not checked by Release mode and may cause undefined behavior.

This issue describes the related problem: https://github.com/MSOpenTech/opencv/issues/20