### PR TITLE
Do not compare extra modules in ABI check

### DIFF
--- a/cmake/OpenCVGenABI.cmake
+++ b/cmake/OpenCVGenABI.cmake
@@ -22,6 +22,26 @@ set(OPENCV_ABI_HEADERS "{RELPATH}/${OPENCV_INCLUDE_INSTALL_PATH}")
 # Libraries
 set(OPENCV_ABI_LIBRARIES "{RELPATH}/${OPENCV_LIB_INSTALL_PATH}")
 
+set(OPENCV_ABI_SKIP_HEADERS "")
+set(OPENCV_ABI_SKIP_LIBRARIES "")
+foreach(mod ${OPENCV_MODULES_BUILD})
+  string(REGEX REPLACE "^opencv_" "" mod "${mod}")
+  if(NOT "${OPENCV_MODULE_opencv_${mod}_LOCATION}" STREQUAL "${OpenCV_SOURCE_DIR}/modules/${mod}")
+    # headers
+    foreach(h ${OPENCV_MODULE_opencv_${mod}_HEADERS})
+      file(RELATIVE_PATH h "${OPENCV_MODULE_opencv_${mod}_LOCATION}/include" "${h}")
+      list(APPEND OPENCV_ABI_SKIP_HEADERS "${h}")
+    endforeach()
+    # libraries
+    set(lib_name "")
+    get_target_property(lib_name opencv_${mod} LOCATION)
+    get_filename_component(lib_name "${lib_name}" NAME)
+    list(APPEND OPENCV_ABI_SKIP_LIBRARIES "${lib_name}")
+  endif()
+endforeach()
+string(REPLACE ";" "\n    " OPENCV_ABI_SKIP_HEADERS "${OPENCV_ABI_SKIP_HEADERS}")
+string(REPLACE ";" "\n    " OPENCV_ABI_SKIP_LIBRARIES "${OPENCV_ABI_SKIP_LIBRARIES}")
+
 # Options
 set(OPENCV_ABI_GCC_OPTIONS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
 string(REGEX REPLACE "([^ ]) +([^ ])" "\\1\\n    \\2" OPENCV_ABI_GCC_OPTIONS "${OPENCV_ABI_GCC_OPTIONS}")

--- a/cmake/templates/opencv_abi.xml.in
+++ b/cmake/templates/opencv_abi.xml.in
@@ -31,7 +31,12 @@
     opencv2/ts.hpp
     opencv2/ts/*
     opencv2/xobjdetect/private.hpp
+    @OPENCV_ABI_SKIP_HEADERS@
 </skip_headers>
+
+<skip_libs>
+    @OPENCV_ABI_SKIP_LIBRARIES@
+</skip_libs>
 
 <gcc_options>
  @OPENCV_ABI_GCC_OPTIONS@


### PR DESCRIPTION
__Note:__ python _cv2.so_ libraries are also excluded from comparison because module name (_python2_ and _python3_) differs from module folder (_python_)