### PR TITLE
Don't explicitly link Python on OS X

### DIFF
--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -50,7 +50,11 @@ ocv_add_library(${the_module} SHARED ${PYTHON_SOURCE_DIR}/src2/cv2.cpp ${cv2_gen
 if(PYTHON_DEBUG_LIBRARIES AND NOT PYTHON_LIBRARIES MATCHES "optimized.*debug")
   ocv_target_link_libraries(${the_module} debug ${PYTHON_DEBUG_LIBRARIES} optimized ${PYTHON_LIBRARIES})
 else()
-  ocv_target_link_libraries(${the_module} ${PYTHON_LIBRARIES})
+  if(APPLE)
+    set_target_properties(${the_module} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  else()
+    ocv_target_link_libraries(${the_module} ${PYTHON_LIBRARIES})
+  endif()
 endif()
 ocv_target_link_libraries(${the_module} ${OPENCV_MODULE_${the_module}_DEPS})
 


### PR DESCRIPTION
Explicitly linking to a Python framework on OS X prevents modules from
being built against one Python (i.e. system python) and imported from
another (i.e. Homebrew python); the interpreter segfaults if there's a
linkage to a foreign Python. Building the module with `-undefined
dynamic_lookup` instead of an explicit link allows the symbols to be
resolved at load time from a compatible python.