### PR TITLE
needlesmap.cpp uses cuda::cvtColor so it needs cudaimgproc

### DIFF
--- a/modules/cudalegacy/src/bm_fast.cpp
+++ b/modules/cudalegacy/src/bm_fast.cpp
@@ -45,7 +45,7 @@
 using namespace cv;
 using namespace cv::cuda;
 
-#if !defined HAVE_CUDA || defined(CUDA_DISABLER)
+#if !defined HAVE_CUDA || !defined(HAVE_OPENCV_CUDAARITHM) || defined(CUDA_DISABLER)
 
 void cv::cuda::FastOpticalFlowBM::operator ()(const GpuMat&, const GpuMat&, GpuMat&, GpuMat&, int, int, Stream&) { throw_no_cuda(); }
 

--- a/modules/cudalegacy/src/needle_map.cpp
+++ b/modules/cudalegacy/src/needle_map.cpp
@@ -45,7 +45,7 @@
 using namespace cv;
 using namespace cv::cuda;
 
-#if !defined (HAVE_CUDA) || defined (CUDA_DISABLER)
+#if !defined (HAVE_CUDA) || !defined(HAVE_OPENCV_CUDAIMGPROC) || defined (CUDA_DISABLER)
 
 void cv::cuda::createOpticalFlowNeedleMap(const GpuMat&, const GpuMat&, GpuMat&, GpuMat&) { throw_no_cuda(); }
 


### PR DESCRIPTION
if configuring with cudalegacy but not with cudaimgproc module needle_map.cpp (line 97) in the cudalegacy module will not compile right now.

Should we move the file to another module since cudalegacy should probably be standalone? Or is this ok?

@jet47 please review