### PR TITLE
Fix a typo in template_matching.markdown

### DIFF
--- a/doc/tutorials/imgproc/histograms/template_matching/template_matching.markdown
+++ b/doc/tutorials/imgproc/histograms/template_matching/template_matching.markdown
@@ -74,7 +74,7 @@ available methods are 6:
 
 -#  **method=CV_TM_CCOEFF**
 
-    \f[R(x,y)= \sum _{x',y'} (T'(x',y')  \cdot I(x+x',y+y'))\f]
+    \f[R(x,y)= \sum _{x',y'} (T'(x',y')  \cdot I'(x+x',y+y'))\f]
 
     where
 


### PR DESCRIPTION
Fix a typo in first equation under method=CV_TM_CCOEFF.