### PR TITLE
Add link to old documentation format

### DIFF
--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -17,6 +17,7 @@
       <tab type="globals" visible="yes" title="Global objects" intro=""/>
     </tab>
     <tab type="examples" visible="yes" title="" intro=""/>
+    <tab type="user" url="/3.0-last-rst" title="Sphinx Documentation"/>
   </navindex>
 
   <!-- Layout definition for a class page -->


### PR DESCRIPTION
I've moved last generated rst-documentation to different folder http://docs.opencv.org/3.0-last-rst/ and made default `master` and `trunc` folders to point to doxygen variant.

This pull request adds a link to old documentation to each page of new variant. It looks like this:
![image](https://cloud.githubusercontent.com/assets/3304494/6825550/6c55e470-d30c-11e4-9330-00d7a26332bc.png)

I'm waiting to hear any opinions about the link placement and title.