### PR TITLE
Fix python wrappers for inherited modules

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -255,20 +255,24 @@ class ClassInfo(object):
         self.methods = {}
         self.props = []
         self.consts = {}
+        self.base = None
         customname = False
 
         if decl:
-            self.bases = decl[1].split()[1:]
-            if len(self.bases) > 1:
+            bases = decl[1].split()[1:]
+            if len(bases) > 1:
                 print("Note: Class %s has more than 1 base class (not supported by Python C extensions)" % (self.name,))
-                print("      Bases: ", " ".join(self.bases))
+                print("      Bases: ", " ".join(bases))
                 print("      Only the first base class will be used")
-                self.bases = [self.bases[0].strip(",")]
                 #return sys.exit(-1)
-            if self.bases and self.bases[0].startswith("cv::"):
-                self.bases[0] = self.bases[0][4:]
-            if self.bases and self.bases[0] == "Algorithm":
-                self.isalgorithm = True
+            elif len(bases) == 1:
+                self.base = bases[0].strip(",")
+                if self.base.startswith("cv::"):
+                    self.base = self.base[4:]
+                if self.base == "Algorithm":
+                    self.isalgorithm = True
+                self.base = self.base.replace("::", "_")
+
             for m in decl[2]:
                 if m.startswith("="):
                     self.wname = m[1:]
@@ -285,8 +289,8 @@ class ClassInfo(object):
     def gen_map_code(self, all_classes):
         code = "static bool pyopencv_to(PyObject* src, %s& dst, const char* name)\n{\n    PyObject* tmp;\n    bool ok;\n" % (self.cname)
         code += "".join([gen_template_set_prop_from_map.substitute(propname=p.name,proptype=p.tp) for p in self.props])
-        if self.bases:
-            code += "\n    return pyopencv_to(src, (%s&)dst, name);\n}\n" % all_classes[self.bases[0].replace("::", "_")].cname
+        if self.base:
+            code += "\n    return pyopencv_to(src, (%s&)dst, name);\n}\n" % all_classes[self.base].cname
         else:
             code += "\n    return true;\n}\n"
         return code
@@ -330,8 +334,8 @@ class ClassInfo(object):
             methods_inits.write(m.get_tab_entry())
 
         baseptr = "NULL"
-        if self.bases and self.bases[0] in all_classes:
-            baseptr = "&pyopencv_" + all_classes[self.bases[0]].name + "_Type"
+        if self.base and self.base in all_classes:
+            baseptr = "&pyopencv_" + all_classes[self.base].name + "_Type"
 
         code = gen_template_type_impl.substitute(name=self.name, wname=self.wname, cname=self.cname,
             getset_code=getset_code.getvalue(), getset_inits=getset_inits.getvalue(),
@@ -753,17 +757,17 @@ class PythonWrapperGenerator(object):
             sys.exit(-1)
         self.classes[classinfo.name] = classinfo
 
-        if classinfo.bases:
-            chunks = classinfo.bases[0].split('::')
+        if classinfo.base:
+            chunks = classinfo.base.split('_')
             base = '_'.join(chunks)
             while base not in self.classes and len(chunks)>1:
                 del chunks[-2]
                 base = '_'.join(chunks)
             if base not in self.classes:
                 print("Generator error: unable to resolve base %s for %s"
-                    % (classinfo.bases[0], classinfo.name))
+                    % (classinfo.base, classinfo.name))
                 sys.exit(-1)
-            classinfo.bases[0] = "::".join(chunks)
+            classinfo.base = base
             classinfo.isalgorithm |= self.classes[base].isalgorithm
 
     def split_decl_name(self, name):

--- a/modules/python/test/test.py
+++ b/modules/python/test/test.py
@@ -145,6 +145,16 @@ class Hackathon244Tests(NewOpenCVTests):
         self.check_close_pairs(mc, mc0, 5)
         self.assertLessEqual(abs(mr - mr0), 5)
 
+    def test_inheritance(self):
+        bm = cv2.StereoBM_create()
+        bm.getPreFilterCap() # from StereoBM
+        bm.getBlockSize() # from SteroMatcher
+
+        boost = cv2.ml.Boost_create()
+        boost.getBoostType() # from ml::Boost
+        boost.getMaxDepth() # from ml::DTrees
+        boost.isClassifier() # from ml::StatModel
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='run OpenCV python tests')
     parser.add_argument('--repo', help='use sample image files from local git repository (path to folder), '


### PR DESCRIPTION
Should fix issue Itseez/opencv_contrib#184
Coupled with PR Itseez/opencv_contrib#197
Methods from base classes was not available in subclasses for objects put into nested namespaces.

- replaced `ClassInfo.bases` list with single `ClassInfo.base` value, since multiple base classes are not supported.
- store `_`-separated class name in `ClassInfo.base` field, because `::`-separated value is not used
- added test calling methods from different inherited classes to check their existence (`cv::StereoBM` and `cv::ml::Boost`)

__Note:__ the test should be split and moved to corresponding modules, but corresponding mechanism is not yet implemented for python wrappers, so it will be left as is for a while.