### PR TITLE
Allow PYTHON_LIBRARY and PYTHON_INCLUDE_DIR to actually be overridden

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -75,10 +75,10 @@ function(find_python preferred_version min_version library_env include_dir_env
 
     if(NOT ANDROID AND NOT IOS)
       ocv_check_environment_variables(${library_env} ${include_dir_env})
-      if(${${library_env}})
+      if(NOT ${${library_env}} EQUAL "")
           set(PYTHON_LIBRARY "${${library_env}}")
       endif()
-      if(${${include_dir_env}})
+      if(NOT ${${include_dir_env}} EQUAL "")
           set(PYTHON_INCLUDE_DIR "${${include_dir_env}}")
       endif()
 


### PR DESCRIPTION
When using a brew installed Python 2 and 3 on OSX, I overrode the following variables:
```cmake
cmake .. \
<snip>
-DPYTHON2_INCLUDE_DIR=/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/include/python2.7 \
-DPYTHON2_LIBRARY=/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib \
-DPYTHON3_INCLUDE_DIR=/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/include/python3.4m \
-DPYTHON3_LIBRARY=/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/libpython3.4m.dylib \
```

These are passed into the `find_python` function in `OpenCVDetectPython.cmake`, and `PYTHON_INCLUDE_DIR` and `PYTHON_LIBRARY` are supposed to be set to each pair in turn. 

This wasn't working, and tracing through that function, I found that `PYTHON_LIBRARY` and `PYTHON_INCLUDE_DIR` were not actually getting set.

The old code assumed that any non-empty variable evaluated to true.  However, it seems that cmake only evaluates these to true for ["1, ON, YES, TRUE, Y, or a non-zero number"](http://www.cmake.org/cmake/help/v3.0/command/if.html).  

This patch makes these tests for non-emptiness more explicit.