### PR TITLE
Update Python script

### DIFF
--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -854,7 +854,7 @@ if __name__ == "__main__":
     test_args = [a for a in sys.argv if a.startswith("--perf_") or a.startswith("--gtest_")]
     argv =      [a for a in sys.argv if not(a.startswith("--perf_") or a.startswith("--gtest_"))]
 
-    parser = OptionParser()
+    parser = OptionParser(usage="run.py [options] build_path")
     parser.add_option("-t", "--tests", dest="tests", help="comma-separated list of modules to test", metavar="SUITS", default="")
     parser.add_option("-w", "--cwd", dest="cwd", help="working directory for tests", metavar="PATH", default=".")
     parser.add_option("-a", "--accuracy", dest="accuracy", help="look for accuracy tests instead of performance tests", action="store_true", default=False)
@@ -879,7 +879,7 @@ if __name__ == "__main__":
     run_args = getRunArgs(args[1:] or ['.'])
 
     if len(run_args) == 0:
-        print >> sys.stderr, "Usage:", os.path.basename(sys.argv[0]), "[options] [build_path]"
+        print >> sys.stderr, "Usage:", os.path.basename(sys.argv[0]), "[options] build_path"
         exit(1)
 
     options.android_env = {}

--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -850,12 +850,51 @@ def getRunArgs(args):
             path = npath
     return run_args
 
+if hostos == "nt":
+    def moveTests(instance, destination):
+        src = os.path.dirname(instance.tests_dir)
+        # new binaries path
+        newBinPath = os.path.join(destination, "bin")
+
+        try:
+            # copy binaries and CMakeCache.txt to the specified destination
+            shutil.copytree(src, newBinPath)
+            shutil.copy(os.path.join(instance.path, "CMakeCache.txt"), os.path.join(destination, "CMakeCache.txt"))
+        except Exception, e:
+            print "Copying error occurred:", str(e)
+            exit(e.errno)
+
+        # pattern of CMakeCache.txt string to be replaced
+        replacePattern = re.compile("EXECUTABLE_OUTPUT_PATH:PATH=(.+)")
+
+        with open(os.path.join(destination, "CMakeCache.txt"), "r") as cachefile:
+            try:
+                cachedata = cachefile.read()
+                if hostos == 'nt':
+                    # fix path slashes on nt systems
+                    newBinPath = re.sub(r"\\", r"/", newBinPath)
+                # replace old binaries path in CMakeCache.txt
+                cachedata = re.sub(re.search(replacePattern, cachedata).group(1), newBinPath, cachedata)
+            except Exception, e:
+                print "Reading error occurred:", str(e)
+                exit(e.errno)
+
+        with open(os.path.join(destination, "CMakeCache.txt"), "w") as cachefile:
+            try:
+                cachefile.write(cachedata)
+            except Exception, e:
+                print "Writing error occurred:", str(e)
+                exit(e.errno)
+        exit()
+
 if __name__ == "__main__":
     test_args = [a for a in sys.argv if a.startswith("--perf_") or a.startswith("--gtest_")]
     argv =      [a for a in sys.argv if not(a.startswith("--perf_") or a.startswith("--gtest_"))]
 
-    parser = OptionParser(usage="run.py [options] build_path")
+    parser = OptionParser(usage="run.py [options] [build_path]", description="Note: build_path is required if running not from CMake build directory")
     parser.add_option("-t", "--tests", dest="tests", help="comma-separated list of modules to test", metavar="SUITS", default="")
+    if hostos == "nt":
+        parser.add_option("-m", "--move_tests", dest="move", help="location to move current tests build", metavar="PATH", default="")
     parser.add_option("-w", "--cwd", dest="cwd", help="working directory for tests", metavar="PATH", default=".")
     parser.add_option("-a", "--accuracy", dest="accuracy", help="look for accuracy tests instead of performance tests", action="store_true", default=False)
     parser.add_option("-l", "--longname", dest="useLongNames", action="store_true", help="generate log files with long names", default=False)
@@ -879,7 +918,8 @@ if __name__ == "__main__":
     run_args = getRunArgs(args[1:] or ['.'])
 
     if len(run_args) == 0:
-        print >> sys.stderr, "Usage:", os.path.basename(sys.argv[0]), "[options] build_path"
+        print >> sys.stderr, "Usage:", os.path.basename(sys.argv[0]), "[options] [build_path]"
+        print >> sys.stderr, "Please specify build_path or run script from CMake build directory"
         exit(1)
 
     options.android_env = {}
@@ -906,6 +946,10 @@ if __name__ == "__main__":
     test_list = []
     for path in run_args:
         suite = TestSuite(options, path)
+
+        if hostos == "nt":
+            if(options.move):
+                moveTests(suite, options.move)
         #print vars(suite),"\n"
         if options.list:
             test_list.extend(suite.tests)


### PR DESCRIPTION
1. #### Fixing help messages
Message shown by the --help option and message shown while starting run.py w/o (or with wrong) parameters are different, e. g. w/ and w/o "[build_path]" in the end. As "build_path" is required, removing square brackets.

2. #### Extending functionality:

Developer may wish to back up some test binaries to compare their behavior with modified version later or just pass current version to QA team.

**Expected:** can start from backed up sources using run.py script

**Actual:** run.py looks for an old binaries path from CMakeCache.txt and tests are used from the old location (if exists)

Adding of *--move_tests* option allows to specify new location, create back up and run tests from it. Command line should look like the following:

```>> run.py --move_tests "new location" "current location"```

This command copies test binaries and CMakeCache.txt file (that file is required by the script) and updates CMakeCache.txt with a new binaries path value.

After that you may start run.py for the new location with "**Expected**" result