### PR TITLE
Fix build with GCC 4.6

### DIFF
--- a/modules/photo/src/fast_nlmeans_denoising_invoker.hpp
+++ b/modules/photo/src/fast_nlmeans_denoising_invoker.hpp
@@ -224,9 +224,9 @@ void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& ra
 
             // calc weights
             IT estimation[pixelInfo<T>::channels], weights_sum[pixelInfo<WT>::channels];
-            for (size_t channel_num = 0; channel_num < pixelInfo<T>::channels; channel_num++)
+            for (int channel_num = 0; channel_num < pixelInfo<T>::channels; channel_num++)
                 estimation[channel_num] = 0;
-            for (size_t channel_num = 0; channel_num < pixelInfo<WT>::channels; channel_num++)
+            for (int channel_num = 0; channel_num < pixelInfo<WT>::channels; channel_num++)
                 weights_sum[channel_num] = 0;
 
             for (int y = 0; y < search_window_size_; y++)

--- a/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp
+++ b/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp
@@ -66,7 +66,7 @@ template <typename ET, int n> struct pixelInfo_<Vec<ET, n> >
 
 template <typename T> struct pixelInfo: public pixelInfo_<T>
 {
-    using typename pixelInfo_<T>::sampleType;
+    typedef typename pixelInfo_<T>::sampleType sampleType;
 
     static inline sampleType sampleMax()
     {


### PR DESCRIPTION
Ubuntu 12.04
GCC 4.6

```
In file included from /home/build/opencv/modules/photo/src/fast_nlmeans_denoising_invoker.hpp:48:0,
                 from /home/build/opencv/modules/photo/src/denoising.cpp:44:
/home/build/opencv/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp:71:19: error: ‘sampleType’ does not name a type
/home/build/opencv/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp:71:19: note: (perhaps ‘typename pixelInfo_<T>::sampleType’ was intended)
/home/build/opencv/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp:76:19: error: ‘sampleType’ does not name a type
/home/build/opencv/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp:76:19: note: (perhaps ‘typename pixelInfo_<T>::sampleType’ was intended)

/home/build/opencv/modules/photo/src/fast_nlmeans_multi_denoising_invoker.hpp:247:39: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
/home/build/opencv/modules/photo/src/fast_nlmeans_multi_denoising_invoker.hpp:249:39: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
```