### PR TITLE
Fix for Bug#4240

### DIFF
--- a/modules/java/generator/src/cpp/utils.cpp
+++ b/modules/java/generator/src/cpp/utils.cpp
@@ -107,7 +107,7 @@ JNIEXPORT void JNICALL Java_org_opencv_android_Utils_nMatToBitmap2
                     cvtColor(src, tmp, COLOR_GRAY2RGBA);
                 } else if(src.type() == CV_8UC3){
                     LOGD("nMatToBitmap: CV_8UC3 -> RGBA_8888");
-                    cvtColor(src, tmp, COLOR_RGB2RGBA);
+                    cvtColor(src, tmp, COLOR_BGR2RGBA);
                 } else if(src.type() == CV_8UC4){
                     LOGD("nMatToBitmap: CV_8UC4 -> RGBA_8888");
                     if(needPremultiplyAlpha) cvtColor(src, tmp, COLOR_RGBA2mRGBA);


### PR DESCRIPTION
Should fix the bug. I am not sure about the case when ```src.type() == CV_8UC4``` as there is currently no option as ```COLOR_BGRA2mRGBA``` or ```COLOR_RGBA2mBGRA```. If needed, I can implement it.