### PR TITLE
Fix generating of OpenCV.mk

### DIFF
--- a/cmake/OpenCVGenAndroidMK.cmake
+++ b/cmake/OpenCVGenAndroidMK.cmake
@@ -43,33 +43,16 @@ if(ANDROID)
   endforeach()
 
   # build the list of opencv libs and dependencies for all modules
-  set(OPENCV_MODULES_CONFIGMAKE "")
-  set(OPENCV_EXTRA_COMPONENTS_CONFIGMAKE "")
-  set(OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE "")
-  foreach(m ${OPENCV_MODULES_PUBLIC})
-    list(INSERT OPENCV_MODULES_CONFIGMAKE 0 ${${m}_MODULE_DEPS_${ocv_optkind}} ${m})
-    if(${m}_EXTRA_DEPS_${ocv_optkind})
-      list(INSERT OPENCV_EXTRA_COMPONENTS_CONFIGMAKE 0 ${${m}_EXTRA_DEPS_${ocv_optkind}})
-    endif()
-  endforeach()
+  ocv_get_all_libs(OPENCV_MODULES_CONFIGMAKE OPENCV_EXTRA_COMPONENTS_CONFIGMAKE OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE)
 
-  # split 3rdparty libs and modules
-  foreach(mod ${OPENCV_MODULES_CONFIGMAKE})
-    if(NOT mod MATCHES "^opencv_.+$")
-      list(INSERT OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE 0 ${mod})
-    endif()
-  endforeach()
-  if(OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE)
-    list(REMOVE_ITEM OPENCV_MODULES_CONFIGMAKE ${OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE})
-  endif()
+  # list -> string
+  string(REPLACE ";" " " OPENCV_MODULES_CONFIGMAKE "${OPENCV_MODULES_CONFIGMAKE}")
+  string(REPLACE ";" " " OPENCV_EXTRA_COMPONENTS_CONFIGMAKE "${OPENCV_EXTRA_COMPONENTS_CONFIGMAKE}")
+  string(REPLACE ";" " " OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE "${OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE}")
 
-  # convert CMake lists to makefile literals
-  foreach(lst OPENCV_MODULES_CONFIGMAKE OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE OPENCV_EXTRA_COMPONENTS_CONFIGMAKE)
-    ocv_list_unique(${lst})
-    ocv_list_reverse(${lst})
-    string(REPLACE ";" " " ${lst} "${${lst}}")
-  endforeach()
+  # replace 'opencv_<module>' -> '<module>''
   string(REPLACE "opencv_" "" OPENCV_MODULES_CONFIGMAKE "${OPENCV_MODULES_CONFIGMAKE}")
+
 
   # prepare 3rd-party component list without TBB for armeabi and mips platforms. TBB is useless there.
   set(OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE_NO_TBB ${OPENCV_3RDPARTY_COMPONENTS_CONFIGMAKE})

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -415,31 +415,6 @@ function(status text)
 endfunction()
 
 
-# splits cmake libraries list of format "general;item1;debug;item2;release;item3" to two lists
-macro(ocv_split_libs_list lst lstdbg lstopt)
-  set(${lstdbg} "")
-  set(${lstopt} "")
-  set(perv_keyword "")
-  foreach(word ${${lst}})
-    if(word STREQUAL "debug" OR word STREQUAL "optimized")
-      set(perv_keyword ${word})
-    elseif(word STREQUAL "general")
-      set(perv_keyword "")
-    elseif(perv_keyword STREQUAL "debug")
-      list(APPEND ${lstdbg} "${word}")
-      set(perv_keyword "")
-    elseif(perv_keyword STREQUAL "optimized")
-      list(APPEND ${lstopt} "${word}")
-      set(perv_keyword "")
-    else()
-      list(APPEND ${lstdbg} "${word}")
-      list(APPEND ${lstopt} "${word}")
-      set(perv_keyword "")
-    endif()
-  endforeach()
-endmacro()
-
-
 # remove all matching elements from the list
 macro(ocv_list_filterout lst regex)
   foreach(item ${${lst}})
@@ -810,3 +785,35 @@ function(ocv_add_library target)
 
   _ocv_append_target_includes(${target})
 endfunction()
+
+# build the list of opencv libs and dependencies for all modules
+#  _modules - variable to hold list of all modules
+#  _extra - variable to hold list of extra dependencies
+#  _3rdparty - variable to hold list of prebuilt 3rdparty libraries
+macro(ocv_get_all_libs _modules _extra _3rdparty)
+  set(${_modules} "")
+  set(${_extra} "")
+  set(${_3rdparty} "")
+  foreach(m ${OPENCV_MODULES_PUBLIC})
+    get_target_property(deps ${m} INTERFACE_LINK_LIBRARIES)
+    list(INSERT ${_modules} 0 ${deps} ${m})
+    foreach (dep ${deps} ${OPENCV_LINKER_LIBS})
+      if (TARGET ${dep})
+        list(INSERT ${_3rdparty} 0 ${dep})
+      else()
+        list(INSERT ${_extra} 0 ${dep})
+      endif()
+    endforeach()
+  endforeach()
+
+  # split 3rdparty libs and modules
+  ocv_list_filterout(${_3rdparty} "^opencv_.+$")
+  ocv_list_filterout(${_extra} "^opencv_.+$")
+  list(REMOVE_ITEM ${_modules} ${${_3rdparty}} ${${_extra}})
+
+  # convert CMake lists to makefile literals
+  foreach(lst ${_modules} ${_3rdparty} ${_extra})
+    ocv_list_unique(${lst})
+    ocv_list_reverse(${lst})
+  endforeach()
+endmacro()

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -798,17 +798,17 @@ macro(ocv_get_all_libs _modules _extra _3rdparty)
     get_target_property(deps ${m} INTERFACE_LINK_LIBRARIES)
     list(INSERT ${_modules} 0 ${deps} ${m})
     foreach (dep ${deps} ${OPENCV_LINKER_LIBS})
-      if (TARGET ${dep})
-        list(INSERT ${_3rdparty} 0 ${dep})
-      else()
-        list(INSERT ${_extra} 0 ${dep})
+      if (NOT DEFINED OPENCV_MODULE_${dep}_LOCATION)
+        if (TARGET ${dep})
+          list(INSERT ${_3rdparty} 0 ${dep})
+        else()
+          list(INSERT ${_extra} 0 ${dep})
+        endif()
       endif()
     endforeach()
   endforeach()
 
   # split 3rdparty libs and modules
-  ocv_list_filterout(${_3rdparty} "^opencv_.+$")
-  ocv_list_filterout(${_extra} "^opencv_.+$")
   list(REMOVE_ITEM ${_modules} ${${_3rdparty}} ${${_extra}})
 
   # convert CMake lists to makefile literals


### PR DESCRIPTION
cmake variables `<module>_MODULE_DEPS_<suffix>` and `<module>_EXTRA_DEPS_<suffix>` are not used in 3.0, this leads to generating _OpenCV.mk_ file with some extra libraries missing.

- added `ocv_get_all_libs` cmake macro to generate 3 lists of libraries
  - modules (_opencv_core_, _opencv_imgproc_, ...)
  - 3rd-party libraries delivered with OpenCV in some cases (_libjpeg_, _libwebp_, ...)
  - other libraries (_z_, _dl_, ...)
- removed unused `ocv_split_libs_list` cmake macro
- fixed `.mk` configuration file generation.