### PR TITLE
Master

### DIFF
--- a/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
+++ b/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
@@ -28,7 +28,12 @@ void thresh_callback(int, void* );
 int main( int, char** argv )
 {
   /// Load source image
-  src = imread( argv[1], 1 );
+	string imageName("../data/stuff.jpg"); // by default
+	if (argv[1] != NULL)
+	{
+		imageName = argv[1];
+	}
+	src = imread(imageName, 1);
 
   /// Convert image to gray and blur it
   cvtColor( src, src_gray, COLOR_BGR2GRAY );

--- a/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
+++ b/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
@@ -28,12 +28,12 @@ void thresh_callback(int, void* );
 int main( int, char** argv )
 {
   /// Load source image
-	string imageName("../data/stuff.jpg"); // by default
-	if (argv[1] != NULL)
-	{
-		imageName = argv[1];
-	}
-	src = imread(imageName, 1);
+  string imageName("../data/stuff.jpg"); // by default
+  if (argv[1] != NULL)
+  {
+    imageName = argv[1];
+  }
+  src = imread(imageName, 1);
 
   /// Convert image to gray and blur it
   cvtColor( src, src_gray, COLOR_BGR2GRAY );

--- a/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
+++ b/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
@@ -27,7 +27,7 @@ void thresh_callback(int, void* );
  */
 int main( int, char** argv )
 {
-  /// Load source image and convert it to gray
+  /// Load source image
   src = imread( argv[1], 1 );
 
   /// Convert image to gray and blur it


### PR DESCRIPTION
findContours_demo.cpp
Error occurs when the argv[1] is null.
Load default Image when the argv[1] is null.