### PR TITLE
Fixed windows build and one warning

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -388,6 +388,10 @@ macro(ocv_include_modules)
   include_directories(BEFORE "${OpenCV_INCLUDE_DIRS}")
 endmacro()
 
+macro(ocv_include_modules_recurse)
+  include_directories(BEFORE "${OpenCV_INCLUDE_DIRS}")
+endmacro()
+
 macro(ocv_target_link_libraries)
   target_link_libraries(${ARGN})
 endmacro()

--- a/modules/superres/src/frame_source.cpp
+++ b/modules/superres/src/frame_source.cpp
@@ -126,7 +126,7 @@ namespace
         else
         {
             // should never get here
-            CV_Assert(0);
+            CV_Error(Error::StsBadArg, "Failed to detect input frame kind" );
         }
     }
 


### PR DESCRIPTION
Building the test app with OpenCV failed, because generated _OpenCVConfig.cmake_ file had no macro defined:
```
CMake Error at cpp/CMakeLists.txt:18 (ocv_include_modules_recurse):
    Unknown CMake command "ocv_include_modules_recurse".
```

Also, should fix build warning:
```
...\superres\src\frame_source.cpp(129): 
    warning C4127: conditional expression is constant 
```