### PR TITLE
fixing repeated command line argument (-h) in gen_pattern.py and adding checkerboard functionality

### DIFF
--- a/doc/pattern_tools/gen_pattern.py
+++ b/doc/pattern_tools/gen_pattern.py
@@ -6,8 +6,8 @@ To run:
 -T type of pattern, circles, acircles, checkerboard
 -s --square_size size of squares in pattern
 -u --units mm, inches, px, m
--w  page width in units
--h  page height in units
+-W  page width in units
+-H  page height in units
 """
 
 from svgfig import *
@@ -71,7 +71,7 @@ def makePattern(cols,rows,output,p_type,units,square_size,page_width,page_height
 def main():
     # parse command line options, TODO use argparse for better doc
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "ho:c:r:T:u:s:w:h:", ["help","output","columns","rows",
+        opts, args = getopt.getopt(sys.argv[1:], "ho:c:r:T:u:s:W:H:", ["help","output","columns","rows",
                                                                       "type","units","square_size","page_width",
                                                                       "page_height"])
     except getopt.error, msg:
@@ -103,9 +103,9 @@ def main():
             units = a
         elif o in ("-s", "--square_size"):
             square_size = float(a)
-        elif o in ("-w", "--page_width"):
+        elif o in ("-W", "--page_width"):
             page_width = float(a)
-        elif o in ("-h", "--page_height"):
+        elif o in ("-H", "--page_height"):
             page_height = float(a)
     pm = PatternMaker(columns,rows,output,units,square_size,page_width,page_height)
     #dict for easy lookup of pattern type

--- a/doc/pattern_tools/gen_pattern.py
+++ b/doc/pattern_tools/gen_pattern.py
@@ -46,7 +46,7 @@ class PatternMaker:
     r = spacing / 5.0
     for x in range(1,self.cols+1):
       for y in range(1,self.rows+1):
-	if(x%2 == y%2):
+        if(x%2 == y%2):
           dot = SVG("rect", x=x * spacing, y=y * spacing, width=spacing, height=spacing, fill="black", fill_opacity="1.", stroke_width="0.")
           self.g.append(dot)
   def save(self):

--- a/doc/pattern_tools/gen_pattern.py
+++ b/doc/pattern_tools/gen_pattern.py
@@ -46,9 +46,9 @@ class PatternMaker:
     r = spacing / 5.0
     for x in range(1,self.cols+1):
       for y in range(1,self.rows+1):
-        #TODO make a checkerboard pattern
-        dot = SVG("circle", cx=x * spacing, cy=y * spacing, r=r, fill="black")
-        self.g.append(dot)
+	if(x%2 == y%2):
+          dot = SVG("rect", x=x * spacing, y=y * spacing, width=spacing, height=spacing, fill="black", fill_opacity="1.", stroke_width="0.")
+          self.g.append(dot)
   def save(self):
     c = canvas(self.g,width="%d%s"%(self.width,self.units),height="%d%s"%(self.height,self.units),viewBox="0 0 %d %d"%(self.width,self.height))
     c.inkview(self.output)


### PR DESCRIPTION
In gen_pattern.py, command line parameter -h is used for both, getting help and specifying the page height.
Page height can only be specified using long parameter version (--page_height).
I have changed parameters -h and -w (page width) to capital letters (-H and -W), so now -h is only for help.

I have also added checkerboard functionality which was marked as TODO

