### PR TITLE
findcontour_example check image empty

### DIFF
--- a/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
+++ b/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
@@ -27,8 +27,13 @@ void thresh_callback(int, void* );
  */
 int main( int, char** argv )
 {
-  /// Load source image and convert it to gray
-  src = imread( argv[1], 1 );
+  /// Load source image
+  src = imread(argv[1]);
+  if (src.empty())
+  {
+    cerr << "No image supplied ..." << endl;
+    return -1;
+  }
 
   /// Convert image to gray and blur it
   cvtColor( src, src_gray, COLOR_BGR2GRAY );


### PR DESCRIPTION
when source image is null, occur error.
add check image empty.