### PR TITLE
Fix bug #3989: fitEllipse bounding boxes too small

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -446,9 +446,8 @@ cv::RotatedRect cv::fitEllipse( InputArray _points )
 
     // store angle and radii
     rp[4] = -0.5 * atan2(gfp[2], gfp[1] - gfp[0]); // convert from APP angle usage
-    t = sin(-2.0 * rp[4]);
-    if( fabs(t) > min_eps )
-        t = gfp[2]/t;
+    if( fabs(gfp[2]) > min_eps )
+        t = gfp[2]/sin(-2.0 * rp[4]);
     else // ellipse is rotated by an integer multiple of pi/2
         t = gfp[1] - gfp[0];
     rp[2] = fabs(gfp[0] + gfp[1] - t);

--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -447,9 +447,9 @@ cv::RotatedRect cv::fitEllipse( InputArray _points )
     // store angle and radii
     rp[4] = -0.5 * atan2(gfp[2], gfp[1] - gfp[0]); // convert from APP angle usage
     t = sin(-2.0 * rp[4]);
-    if( fabs(t) > fabs(gfp[2])*min_eps )
+    if( fabs(t) > min_eps )
         t = gfp[2]/t;
-    else
+    else // ellipse is rotated by an integer multiple of pi/2
         t = gfp[1] - gfp[0];
     rp[2] = fabs(gfp[0] + gfp[1] - t);
     if( rp[2] > min_eps )


### PR DESCRIPTION
If I have understood correctly, at [this point](https://github.com/Itseez/opencv/blob/master/modules/imgproc/src/shapedescr.cpp#L450) in the fitEllipse algorithm, if the ellipse has its axes parallel to the xy axes (i.e. rotated by n\*pi/2) then **both** gfp[2] and t are ~0. Thus for the example in [bug 3989](http://code.opencv.org/issues/3989), the 'else' is not entered into as gfp[2] = -1.56545e-19 and t = -1.22465e-16.

I have changed the condition to just test for t, but testing for gfp[2] as well/instead are also valid solutions I believe.