### PR TITLE
suppress -Wclobbered warning

### DIFF
--- a/modules/highgui/CMakeLists.txt
+++ b/modules/highgui/CMakeLists.txt
@@ -292,7 +292,7 @@ endif()
 set_target_properties(${the_module} PROPERTIES LINK_INTERFACE_LIBRARIES "")
 
 ocv_add_precompiled_headers(${the_module})
-ocv_warnings_disable(CMAKE_CXX_FLAGS -Wno-deprecated-declarations)
+ocv_warnings_disable(CMAKE_CXX_FLAGS -Wno-deprecated-declarations -Wno-clobbered)
 
 if(WIN32 AND WITH_FFMPEG)
   #copy ffmpeg dll to the output folder


### PR DESCRIPTION
```
/home/sandye51/Documents/Programming/git_repo/opencv/modules/highgui/src/grfmt_png.cpp: In member function 'virtual bool cv::PngEncoder::write(const cv::Mat&, const std::vector<int>&)':
/home/sandye51/Documents/Programming/git_repo/opencv/modules/highgui/src/grfmt_png.cpp:345:11: warning: variable 'f' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
     FILE* f = 0;
           ^
/home/sandye51/Documents/Programming/git_repo/opencv/modules/highgui/src/grfmt_png.cpp:348:10: warning: variable 'result' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
     bool result = false;
          ^
/home/sandye51/Documents/Programming/git_repo/opencv/modules/highgui/src/grfmt_png.cpp: In member function 'virtual bool cv::PngDecoder::readData(cv::Mat&)':
/home/sandye51/Documents/Programming/git_repo/opencv/modules/highgui/src/grfmt_png.cpp:227:10: warning: variable 'result' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
     bool result = false;
```