### PR TITLE
Cuda unused functions

### DIFF
--- a/modules/gpu/src/generalized_hough.cpp
+++ b/modules/gpu/src/generalized_hough.cpp
@@ -675,28 +675,6 @@ namespace
     /////////////////////////////////////////
     // POSITION & SCALE & ROTATION
 
-    double toRad(double a)
-    {
-        return a * CV_PI / 180.0;
-    }
-
-    double clampAngle(double a)
-    {
-        double res = a;
-
-        while (res > 360.0)
-            res -= 360.0;
-        while (res < 0)
-            res += 360.0;
-
-        return res;
-    }
-
-    bool angleEq(double a, double b, double eps = 1.0)
-    {
-        return (fabs(clampAngle(a - b)) <= eps);
-    }
-
     class GHT_Guil_Full : public GHT_Pos
     {
     public:


### PR DESCRIPTION
```
/home/sandye51/Documents/Programming/git_repo/opencv/modules/gpu/src/generalized_hough.cpp:678:12: warning: 'double {anonymous}::toRad(double)' defined but not used [-Wunused-function]
     double toRad(double a)
            ^
/home/sandye51/Documents/Programming/git_repo/opencv/modules/gpu/src/generalized_hough.cpp:695:10: warning: 'bool {anonymous}::angleEq(double, double, double)' defined but not used [-Wunused-function]
     bool angleEq(double a, double b, double eps = 1.0)
          ^
```