### PR TITLE
Doxygen: replaced @includelineno by @include to enable copy-pasting

### DIFF
--- a/doc/tutorials/core/file_input_output_with_xml_yml/file_input_output_with_xml_yml.markdown
+++ b/doc/tutorials/core/file_input_output_with_xml_yml/file_input_output_with_xml_yml.markdown
@@ -22,7 +22,7 @@ library.
 
 Here's a sample code of how to achieve all the stuff enumerated at the goal list.
 
-@includelineno cpp/tutorial_code/core/file_input_output/file_input_output.cpp
+@include cpp/tutorial_code/core/file_input_output/file_input_output.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/core/how_to_use_ippa_conversion/how_to_use_ippa_conversion.markdown
+++ b/doc/tutorials/core/how_to_use_ippa_conversion/how_to_use_ippa_conversion.markdown
@@ -18,7 +18,7 @@ You may also find the source code in the
 `samples/cpp/tutorial_code/core/ippasync/ippasync_sample.cpp` file of the OpenCV source library or
 download it from [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/core/ippasync/ippasync_sample.cpp).
 
-@includelineno cpp/tutorial_code/core/ippasync/ippasync_sample.cpp
+@include cpp/tutorial_code/core/ippasync/ippasync_sample.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/features2d/akaze_matching/akaze_matching.markdown
+++ b/doc/tutorials/features2d/akaze_matching/akaze_matching.markdown
@@ -31,7 +31,7 @@ You can find the images (*graf1.png*, *graf3.png*) and homography (*H1to3p.xml*)
 
 ### Source Code
 
-@includelineno cpp/tutorial_code/features2D/AKAZE_match.cpp
+@include cpp/tutorial_code/features2D/AKAZE_match.cpp
 
 ### Explanation
 

--- a/doc/tutorials/features2d/akaze_tracking/akaze_tracking.markdown
+++ b/doc/tutorials/features2d/akaze_tracking/akaze_tracking.markdown
@@ -36,7 +36,7 @@ To run the code you have to specify input and output video path and object bound
 Source Code
 -----------
 
-@includelineno cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
+@include cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/features2d/trackingmotion/generic_corner_detector/generic_corner_detector.markdown
+++ b/doc/tutorials/features2d/trackingmotion/generic_corner_detector/generic_corner_detector.markdown
@@ -22,7 +22,7 @@ Code
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/TrackingMotion/cornerDetector_Demo.cpp)
 
-@includelineno cpp/tutorial_code/TrackingMotion/cornerDetector_Demo.cpp
+@include cpp/tutorial_code/TrackingMotion/cornerDetector_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/highgui/raster-gdal/raster_io_gdal.markdown
+++ b/doc/tutorials/highgui/raster-gdal/raster_io_gdal.markdown
@@ -28,7 +28,7 @@ of the bay rise 10, 50, and 100 meters.
 Code
 ----
 
-@includelineno cpp/tutorial_code/HighGUI/GDAL_IO/gdal-image.cpp
+@include cpp/tutorial_code/HighGUI/GDAL_IO/gdal-image.cpp
 
 How to Read Raster Data using GDAL
 ----------------------------------

--- a/doc/tutorials/highgui/video-input-psnr-ssim/video_input_psnr_ssim.markdown
+++ b/doc/tutorials/highgui/video-input-psnr-ssim/video_input_psnr_ssim.markdown
@@ -25,7 +25,7 @@ version of it ](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutoria
 You may also find the source code and these video file in the
 `samples/cpp/tutorial_code/HighGUI/video-input-psnr-ssim/` folder of the OpenCV source library.
 
-@includelineno cpp/tutorial_code/HighGUI/video-input-psnr-ssim/video-input-psnr-ssim.cpp
+@include cpp/tutorial_code/HighGUI/video-input-psnr-ssim/video-input-psnr-ssim.cpp
 
 How to read a video stream (online-camera or offline-file)?
 -----------------------------------------------------------

--- a/doc/tutorials/highgui/video-write/video_write.markdown
+++ b/doc/tutorials/highgui/video-write/video_write.markdown
@@ -33,7 +33,7 @@ You may also find the source code and these video file in the
 `samples/cpp/tutorial_code/highgui/video-write/` folder of the OpenCV source library or [download it
 from here ](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/HighGUI/video-write/video-write.cpp).
 
-@includelineno cpp/tutorial_code/HighGUI/video-write/video-write.cpp
+@include cpp/tutorial_code/HighGUI/video-write/video-write.cpp
 
 The structure of a video
 ------------------------

--- a/doc/tutorials/imgproc/erosion_dilatation/erosion_dilatation.markdown
+++ b/doc/tutorials/imgproc/erosion_dilatation/erosion_dilatation.markdown
@@ -61,7 +61,7 @@ Code
 
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgProc/Morphology_1.cpp)
-@includelineno samples/cpp/tutorial_code/ImgProc/Morphology_1.cpp
+@include samples/cpp/tutorial_code/ImgProc/Morphology_1.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/histograms/back_projection/back_projection.markdown
+++ b/doc/tutorials/imgproc/histograms/back_projection/back_projection.markdown
@@ -80,7 +80,7 @@ Code
         in samples.
 
 -   **Code at glance:**
-@includelineno samples/cpp/tutorial_code/Histograms_Matching/calcBackProject_Demo1.cpp
+@include samples/cpp/tutorial_code/Histograms_Matching/calcBackProject_Demo1.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/histograms/histogram_calculation/histogram_calculation.markdown
+++ b/doc/tutorials/imgproc/histograms/histogram_calculation/histogram_calculation.markdown
@@ -68,7 +68,7 @@ Code
 -   **Downloadable code**: Click
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/Histograms_Matching/calcHist_Demo.cpp)
 -   **Code at glance:**
-    @includelineno samples/cpp/tutorial_code/Histograms_Matching/calcHist_Demo.cpp
+    @include samples/cpp/tutorial_code/Histograms_Matching/calcHist_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/histograms/histogram_comparison/histogram_comparison.markdown
+++ b/doc/tutorials/imgproc/histograms/histogram_comparison/histogram_comparison.markdown
@@ -47,7 +47,7 @@ Code
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/Histograms_Matching/compareHist_Demo.cpp)
 -   **Code at glance:**
 
-@includelineno cpp/tutorial_code/Histograms_Matching/compareHist_Demo.cpp
+@include cpp/tutorial_code/Histograms_Matching/compareHist_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/histograms/histogram_equalization/histogram_equalization.markdown
+++ b/doc/tutorials/imgproc/histograms/histogram_equalization/histogram_equalization.markdown
@@ -64,7 +64,7 @@ Code
 -   **Downloadable code**: Click
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/Histograms_Matching/EqualizeHist_Demo.cpp)
 -   **Code at glance:**
-    @includelineno samples/cpp/tutorial_code/Histograms_Matching/EqualizeHist_Demo.cpp
+    @include samples/cpp/tutorial_code/Histograms_Matching/EqualizeHist_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/histograms/template_matching/template_matching.markdown
+++ b/doc/tutorials/imgproc/histograms/template_matching/template_matching.markdown
@@ -98,7 +98,7 @@ Code
 -   **Downloadable code**: Click
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp)
 -   **Code at glance:**
-    @includelineno samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
+    @include samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/canny_detector/canny_detector.markdown
+++ b/doc/tutorials/imgproc/imgtrans/canny_detector/canny_detector.markdown
@@ -75,7 +75,7 @@ Code
 
 -#  The tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/CannyDetector_Demo.cpp)
-    @includelineno samples/cpp/tutorial_code/ImgTrans/CannyDetector_Demo.cpp
+    @include samples/cpp/tutorial_code/ImgTrans/CannyDetector_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/copyMakeBorder/copyMakeBorder.markdown
+++ b/doc/tutorials/imgproc/imgtrans/copyMakeBorder/copyMakeBorder.markdown
@@ -47,7 +47,7 @@ Code
 
 -#  The tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/copyMakeBorder_demo.cpp)
-    @includelineno samples/cpp/tutorial_code/ImgTrans/copyMakeBorder_demo.cpp
+    @include samples/cpp/tutorial_code/ImgTrans/copyMakeBorder_demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/distance_transformation/distance_transform.markdown
+++ b/doc/tutorials/imgproc/imgtrans/distance_transformation/distance_transform.markdown
@@ -18,7 +18,7 @@ Code
 
 This tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/imageSegmentation.cpp).
-@includelineno samples/cpp/tutorial_code/ImgTrans/imageSegmentation.cpp
+@include samples/cpp/tutorial_code/ImgTrans/imageSegmentation.cpp
 
 Explanation / Result
 --------------------

--- a/doc/tutorials/imgproc/imgtrans/hough_circle/hough_circle.markdown
+++ b/doc/tutorials/imgproc/imgtrans/hough_circle/hough_circle.markdown
@@ -42,7 +42,7 @@ Code
 -#  The sample code that we will explain can be downloaded from [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/houghcircles.cpp).
     A slightly fancier version (which shows trackbars for
     changing the threshold values) can be found [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/HoughCircle_Demo.cpp).
-    @includelineno samples/cpp/houghcircles.cpp
+    @include samples/cpp/houghcircles.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/hough_lines/hough_lines.markdown
+++ b/doc/tutorials/imgproc/imgtrans/hough_lines/hough_lines.markdown
@@ -98,7 +98,7 @@ Code
 -#  The sample code that we will explain can be downloaded from [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/houghlines.cpp). A slightly fancier version
     (which shows both Hough standard and probabilistic with trackbars for changing the threshold
     values) can be found [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/HoughLines_Demo.cpp).
-    @includelineno samples/cpp/houghlines.cpp
+    @include samples/cpp/houghlines.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/laplace_operator/laplace_operator.markdown
+++ b/doc/tutorials/imgproc/imgtrans/laplace_operator/laplace_operator.markdown
@@ -52,7 +52,7 @@ Code
 
 -#  The tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/Laplace_Demo.cpp)
-    @includelineno samples/cpp/tutorial_code/ImgTrans/Laplace_Demo.cpp
+    @include samples/cpp/tutorial_code/ImgTrans/Laplace_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/remap/remap.markdown
+++ b/doc/tutorials/imgproc/imgtrans/remap/remap.markdown
@@ -53,7 +53,7 @@ Code
 
 -#  The tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/Remap_Demo.cpp)
-    @includelineno samples/cpp/tutorial_code/ImgTrans/Remap_Demo.cpp
+    @include samples/cpp/tutorial_code/ImgTrans/Remap_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/sobel_derivatives/sobel_derivatives.markdown
+++ b/doc/tutorials/imgproc/imgtrans/sobel_derivatives/sobel_derivatives.markdown
@@ -109,7 +109,7 @@ Code
 
 -#  The tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/Sobel_Demo.cpp)
-    @includelineno samples/cpp/tutorial_code/ImgTrans/Sobel_Demo.cpp
+    @include samples/cpp/tutorial_code/ImgTrans/Sobel_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/imgtrans/warp_affine/warp_affine.markdown
+++ b/doc/tutorials/imgproc/imgtrans/warp_affine/warp_affine.markdown
@@ -90,7 +90,7 @@ Code
 
 -#  The tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgTrans/Geometric_Transforms_Demo.cpp)
-    @includelineno samples/cpp/tutorial_code/ImgTrans/Geometric_Transforms_Demo.cpp
+    @include samples/cpp/tutorial_code/ImgTrans/Geometric_Transforms_Demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/morph_lines_detection/moprh_lines_detection.md
+++ b/doc/tutorials/imgproc/morph_lines_detection/moprh_lines_detection.md
@@ -49,7 +49,7 @@ Code
 ----
 
 This tutorial code's is shown lines below. You can also download it from [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgProc/Morphology_3.cpp).
-@includelineno samples/cpp/tutorial_code/ImgProc/Morphology_3.cpp
+@include samples/cpp/tutorial_code/ImgProc/Morphology_3.cpp
 
 Explanation / Result
 --------------------

--- a/doc/tutorials/imgproc/pyramids/pyramids.markdown
+++ b/doc/tutorials/imgproc/pyramids/pyramids.markdown
@@ -68,7 +68,7 @@ Code
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgProc/Pyramids.cpp)
 
-@includelineno samples/cpp/tutorial_code/ImgProc/Pyramids.cpp
+@include samples/cpp/tutorial_code/ImgProc/Pyramids.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/shapedescriptors/bounding_rects_circles/bounding_rects_circles.markdown
+++ b/doc/tutorials/imgproc/shapedescriptors/bounding_rects_circles/bounding_rects_circles.markdown
@@ -17,7 +17,7 @@ Code
 
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ShapeDescriptors/generalContours_demo1.cpp)
-@includelineno samples/cpp/tutorial_code/ShapeDescriptors/generalContours_demo1.cpp
+@include samples/cpp/tutorial_code/ShapeDescriptors/generalContours_demo1.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/shapedescriptors/bounding_rotated_ellipses/bounding_rotated_ellipses.markdown
+++ b/doc/tutorials/imgproc/shapedescriptors/bounding_rotated_ellipses/bounding_rotated_ellipses.markdown
@@ -17,7 +17,7 @@ Code
 
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ShapeDescriptors/generalContours_demo2.cpp)
-@includelineno samples/cpp/tutorial_code/ShapeDescriptors/generalContours_demo2.cpp
+@include samples/cpp/tutorial_code/ShapeDescriptors/generalContours_demo2.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/shapedescriptors/find_contours/find_contours.markdown
+++ b/doc/tutorials/imgproc/shapedescriptors/find_contours/find_contours.markdown
@@ -17,7 +17,7 @@ Code
 
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp)
-@includelineno samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
+@include samples/cpp/tutorial_code/ShapeDescriptors/findContours_demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/shapedescriptors/hull/hull.markdown
+++ b/doc/tutorials/imgproc/shapedescriptors/hull/hull.markdown
@@ -17,7 +17,7 @@ Code
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ShapeDescriptors/hull_demo.cpp)
 
-@includelineno samples/cpp/tutorial_code/ShapeDescriptors/hull_demo.cpp
+@include samples/cpp/tutorial_code/ShapeDescriptors/hull_demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/shapedescriptors/moments/moments.markdown
+++ b/doc/tutorials/imgproc/shapedescriptors/moments/moments.markdown
@@ -18,7 +18,7 @@ Code
 
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ShapeDescriptors/moments_demo.cpp)
-@includelineno samples/cpp/tutorial_code/ShapeDescriptors/moments_demo.cpp
+@include samples/cpp/tutorial_code/ShapeDescriptors/moments_demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/shapedescriptors/point_polygon_test/point_polygon_test.markdown
+++ b/doc/tutorials/imgproc/shapedescriptors/point_polygon_test/point_polygon_test.markdown
@@ -16,7 +16,7 @@ Code
 
 This tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ShapeDescriptors/pointPolygonTest_demo.cpp)
-@includelineno samples/cpp/tutorial_code/ShapeDescriptors/pointPolygonTest_demo.cpp
+@include samples/cpp/tutorial_code/ShapeDescriptors/pointPolygonTest_demo.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/imgproc/threshold/threshold.markdown
+++ b/doc/tutorials/imgproc/threshold/threshold.markdown
@@ -98,7 +98,7 @@ Code
 
 The tutorial code's is shown lines below. You can also download it from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ImgProc/Threshold.cpp)
-@includelineno samples/cpp/tutorial_code/ImgProc/Threshold.cpp
+@include samples/cpp/tutorial_code/ImgProc/Threshold.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/introduction/display_image/display_image.markdown
+++ b/doc/tutorials/introduction/display_image/display_image.markdown
@@ -16,7 +16,7 @@ Source Code
 Download the source code from
 [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/introduction/display_image/display_image.cpp).
 
-@includelineno cpp/tutorial_code/introduction/display_image/display_image.cpp
+@include cpp/tutorial_code/introduction/display_image/display_image.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/introduction/documenting_opencv/documentation_tutorial.markdown
+++ b/doc/tutorials/introduction/documenting_opencv/documentation_tutorial.markdown
@@ -415,7 +415,8 @@ you can manually specify it in curly braces:
 
 To include whole example file into documentation, _include_ and _includelineno_ commands are used.
 The file is searched in common samples locations, so you can specify just its name or short part of
-the path. The _includelineno_ version also shows line numbers.
+the path. The _includelineno_ version also shows line numbers but prevents copy-pasting since
+the line numbers are included.
 
 @verbatim
 @include samples/cpp/test.cpp

--- a/doc/tutorials/introduction/windows_visual_studio_Opencv/windows_visual_studio_Opencv.markdown
+++ b/doc/tutorials/introduction/windows_visual_studio_Opencv/windows_visual_studio_Opencv.markdown
@@ -193,7 +193,7 @@ Now to try this out download our little test [source code
 or get it from the sample code folder of the OpenCV sources. Add this to your project and build it.
 Here's its content:
 
-@includelineno cpp/tutorial_code/introduction/windows_visual_studio_Opencv/introduction_windows_vs.cpp
+@include cpp/tutorial_code/introduction/windows_visual_studio_Opencv/introduction_windows_vs.cpp
 
 You can start a Visual Studio build from two places. Either inside from the *IDE* (keyboard
 combination: Control-F5) or by navigating to your build directory and start the application with a

--- a/doc/tutorials/ml/introduction_to_pca/introduction_to_pca.markdown
+++ b/doc/tutorials/ml/introduction_to_pca/introduction_to_pca.markdown
@@ -93,7 +93,7 @@ Source Code
 
 This tutorial code's is shown lines below. You can also download it from
     [here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ml/introduction_to_pca/introduction_to_pca.cpp).
-@includelineno cpp/tutorial_code/ml/introduction_to_pca/introduction_to_pca.cpp
+@include cpp/tutorial_code/ml/introduction_to_pca/introduction_to_pca.cpp
 
 @note Another example using PCA for dimensionality reduction while maintaining an amount of variance can be found at [opencv_source_code/samples/cpp/pca.cpp](https://github.com/Itseez/opencv/tree/master/samples/cpp/pca.cpp)
 

--- a/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.markdown
+++ b/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.markdown
@@ -94,7 +94,7 @@ the weight vector \f$\beta\f$ and the bias \f$\beta_{0}\f$ of the optimal hyperp
 Source Code
 -----------
 
-@includelineno cpp/tutorial_code/ml/introduction_to_svm/introduction_to_svm.cpp
+@include cpp/tutorial_code/ml/introduction_to_svm/introduction_to_svm.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
+++ b/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
@@ -89,7 +89,7 @@ Source Code
 You may also find the source code in `samples/cpp/tutorial_code/ml/non_linear_svms` folder of the OpenCV source library or
 [download it from here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ml/non_linear_svms/non_linear_svms.cpp).
 
-@includelineno cpp/tutorial_code/ml/non_linear_svms/non_linear_svms.cpp
+@include cpp/tutorial_code/ml/non_linear_svms/non_linear_svms.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/photo/hdr_imaging/hdr_imaging.markdown
+++ b/doc/tutorials/photo/hdr_imaging/hdr_imaging.markdown
@@ -31,7 +31,7 @@ Exposure sequence
 Source Code
 -----------
 
-@includelineno cpp/tutorial_code/photo/hdr_imaging/hdr_imaging.cpp
+@include cpp/tutorial_code/photo/hdr_imaging/hdr_imaging.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/video/background_subtraction/background_subtraction.markdown
+++ b/doc/tutorials/video/background_subtraction/background_subtraction.markdown
@@ -47,7 +47,7 @@ Two different methods are used to generate two foreground masks:
 The results as well as the input data are shown on the screen.
 The source file can be downloaded [here ](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/video/bg_sub.cpp).
 
-@includelineno samples/cpp/tutorial_code/video/bg_sub.cpp
+@include samples/cpp/tutorial_code/video/bg_sub.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/viz/creating_widgets/creating_widgets.markdown
+++ b/doc/tutorials/viz/creating_widgets/creating_widgets.markdown
@@ -13,7 +13,7 @@ Code
 ----
 
 You can download the code from [here ](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/viz/creating_widgets.cpp).
-@includelineno samples/cpp/tutorial_code/viz/creating_widgets.cpp
+@include samples/cpp/tutorial_code/viz/creating_widgets.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/viz/launching_viz/launching_viz.markdown
+++ b/doc/tutorials/viz/launching_viz/launching_viz.markdown
@@ -15,7 +15,7 @@ Code
 ----
 
 You can download the code from [here ](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/viz/launching_viz.cpp).
-@includelineno samples/cpp/tutorial_code/viz/launching_viz.cpp
+@include samples/cpp/tutorial_code/viz/launching_viz.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/viz/transformations/transformations.markdown
+++ b/doc/tutorials/viz/transformations/transformations.markdown
@@ -14,7 +14,7 @@ Code
 ----
 
 You can download the code from [here ](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/viz/transformations.cpp).
-@includelineno samples/cpp/tutorial_code/viz/transformations.cpp
+@include samples/cpp/tutorial_code/viz/transformations.cpp
 
 Explanation
 -----------

--- a/doc/tutorials/viz/widget_pose/widget_pose.markdown
+++ b/doc/tutorials/viz/widget_pose/widget_pose.markdown
@@ -14,7 +14,7 @@ Code
 ----
 
 You can download the code from [here ](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/viz/widget_pose.cpp).
-@includelineno samples/cpp/tutorial_code/viz/widget_pose.cpp
+@include samples/cpp/tutorial_code/viz/widget_pose.cpp
 
 Explanation
 -----------


### PR DESCRIPTION
The line numbers in code examples lead to a better readability but completely disable copy-pasting since the line numbers are included into the selection.

Copy-pasting is crucial to coding tutorials, so I would prefer this functionality to the readability.