### PR TITLE
fixing all RGB instances to BGR where needed

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.markdown
+++ b/doc/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.markdown
@@ -34,7 +34,7 @@ Object Tracking
 ---------------
 
 Now we know how to convert BGR image to HSV, we can use this to extract a colored object. In HSV, it
-is more easier to represent a color than RGB color-space. In our application, we will try to extract
+is more easier to represent a color than in BGR color-space. In our application, we will try to extract
 a blue colored object. So here is the method:
 
 -   Take each frame of the video

--- a/doc/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.markdown
+++ b/doc/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.markdown
@@ -194,15 +194,15 @@ while(1):
     mag, ang = cv2.cartToPolar(flow[...,0], flow[...,1])
     hsv[...,0] = ang*180/np.pi/2
     hsv[...,2] = cv2.normalize(mag,None,0,255,cv2.NORM_MINMAX)
-    rgb = cv2.cvtColor(hsv,cv2.COLOR_HSV2BGR)
+    bgr = cv2.cvtColor(hsv,cv2.COLOR_HSV2BGR)
 
-    cv2.imshow('frame2',rgb)
+    cv2.imshow('frame2',bgr)
     k = cv2.waitKey(30) & 0xff
     if k == 27:
         break
     elif k == ord('s'):
         cv2.imwrite('opticalfb.png',frame2)
-        cv2.imwrite('opticalhsv.png',rgb)
+        cv2.imwrite('opticalhsv.png',bgr)
     prvs = next
 
 cap.release()

--- a/doc/tutorials/core/basic_geometric_drawing/basic_geometric_drawing.markdown
+++ b/doc/tutorials/core/basic_geometric_drawing/basic_geometric_drawing.markdown
@@ -35,13 +35,13 @@ Point pt =  Point(10, 8);
 
 -   Represents a 4-element vector. The type Scalar is widely used in OpenCV for passing pixel
     values.
--   In this tutorial, we will use it extensively to represent RGB color values (3 parameters). It is
+-   In this tutorial, we will use it extensively to represent BGR color values (3 parameters). It is
     not necessary to define the last argument if it is not going to be used.
 -   Let's see an example, if we are asked for a color argument and we give:
     @code{.cpp}
     Scalar( a, b, c )
     @endcode
-    We would be defining a RGB color such as: *Red = c*, *Green = b* and *Blue = a*
+    We would be defining a BGR color such as: *Blue = a*, *Green = b* and *Red = c*
 
 Code
 ----

--- a/doc/tutorials/core/basic_linear_transform/basic_linear_transform.markdown
+++ b/doc/tutorials/core/basic_linear_transform/basic_linear_transform.markdown
@@ -122,8 +122,8 @@ Explanation
     *image.size()* and *image.type()*
 
 -#  Now, to perform the operation \f$g(i,j) = \alpha \cdot f(i,j) + \beta\f$ we will access to each
-    pixel in image. Since we are operating with RGB images, we will have three values per pixel (R,
-    G and B), so we will also access them separately. Here is the piece of code:
+    pixel in image. Since we are operating with BGR images, we will have three values per pixel (B,
+    G and R), so we will also access them separately. Here is the piece of code:
     @code{.cpp}
     for( int y = 0; y < image.rows; y++ ) {
         for( int x = 0; x < image.cols; x++ ) {

--- a/doc/tutorials/core/how_to_scan_images/how_to_scan_images.markdown
+++ b/doc/tutorials/core/how_to_scan_images/how_to_scan_images.markdown
@@ -57,7 +57,7 @@ the samples directory of OpenCV at the cpp tutorial code for the core section. I
 how_to_scan_images imageName.jpg intValueToReduce [G]
 @endcode
 The final argument is optional. If given the image will be loaded in gray scale format, otherwise
-the RGB color way is used. The first thing is to calculate the lookup table.
+the BGR color space is used. The first thing is to calculate the lookup table.
 
 @snippet how_to_scan_images.cpp dividewith
 
@@ -88,7 +88,7 @@ case of a gray scale image we have something like:
 ![](tutorial_how_matrix_stored_1.png)
 
 For multichannel images the columns contain as many sub columns as the number of channels. For
-example in case of an RGB color system:
+example in case of an BGR color system:
 
 ![](tutorial_how_matrix_stored_2.png)
 

--- a/doc/tutorials/core/interoperability_with_OpenCV_1/interoperability_with_OpenCV_1.markdown
+++ b/doc/tutorials/core/interoperability_with_OpenCV_1/interoperability_with_OpenCV_1.markdown
@@ -101,7 +101,7 @@ possible to use the old functions and in the end just transform the result to a 
 
 @snippet interoperability_with_OpenCV_1.cpp new
 
-Because, we want to mess around with the images luma component we first convert from the default RGB
+Because, we want to mess around with the images luma component we first convert from the default BGR
 to the YUV color space and then split the result up into separate planes. Here the program splits:
 in the first example it processes each plane using one of the three major image scanning algorithms
 in OpenCV (C [] operator, iterator, individual element access). In a second variant we add to the

--- a/doc/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.markdown
+++ b/doc/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.markdown
@@ -118,8 +118,8 @@ added.
 
 There are, however, many other color systems each with their own advantages:
 
--   RGB is the most common as our eyes use something similar, our display systems also compose
-    colors using these.
+-   RGB is the most common as our eyes use something similar, however keep in mind that OpenCV standard display
+    system composes colors using the BGR color space (a switch of the red and blue channel).
 -   The HSV and HLS decompose colors into their hue, saturation and value/luminance components,
     which is a more natural way for us to describe colors. You might, for example, dismiss the last
     component, making your algorithm less sensible to the light conditions of the input image.

--- a/doc/tutorials/highgui/video-write/video_write.markdown
+++ b/doc/tutorials/highgui/video-write/video_write.markdown
@@ -12,7 +12,7 @@ class, designed for this.
 -   What type of video files you can create with OpenCV
 -   How to extract a given color channel from a video
 
-As a simple demonstration I'll just extract one of the RGB color channels of an input video file
+As a simple demonstration I'll just extract one of the BGR color channels of an input video file
 into a new video. You can control the flow of the application from its console line arguments:
 
 -   The first argument points to the video file to work on
@@ -134,7 +134,7 @@ the object with success you can send the frames of the video in a sequential ord
 outputVideo.write(res);  //or
 outputVideo << res;
 @endcode
-Extracting a color channel from an RGB image means to set to zero the RGB values of the other
+Extracting a color channel from an BGR image means to set to zero the BGR values of the other
 channels. You can either do this with image scanning operations or by using the split and merge
 operations. You first split the channels up into different images, set the other channels to zero
 images of the same size and type and finally merge them back:

--- a/doc/tutorials/imgproc/erosion_dilatation/erosion_dilatation.markdown
+++ b/doc/tutorials/imgproc/erosion_dilatation/erosion_dilatation.markdown
@@ -69,7 +69,7 @@ Explanation
 -#  Most of the stuff shown is known by you (if you have any doubt, please refer to the tutorials in
     previous sections). Let's check the general structure of the program:
 
-    -   Load an image (can be RGB or grayscale)
+    -   Load an image (can be BGR or grayscale)
     -   Create two windows (one for dilation output, the other for erosion)
     -   Create a set of 02 Trackbars for each operation:
         -   The first trackbar "Element" returns either **erosion_elem** or **dilation_elem**

--- a/doc/tutorials/imgproc/histograms/histogram_comparison/histogram_comparison.markdown
+++ b/doc/tutorials/imgproc/histograms/histogram_comparison/histogram_comparison.markdown
@@ -53,7 +53,7 @@ Explanation
 -----------
 
 -#  Declare variables such as the matrices to store the base image and the two other images to
-    compare ( RGB and HSV )
+    compare ( BGR and HSV )
     @code{.cpp}
     Mat src_base, hsv_base;
     Mat src_test1, hsv_test1;

--- a/doc/tutorials/imgproc/morph_lines_detection/moprh_lines_detection.md
+++ b/doc/tutorials/imgproc/morph_lines_detection/moprh_lines_detection.md
@@ -21,7 +21,7 @@ Morphology is a set of image processing operations that process images based on 
 
 Two of the most basic morphological operations are dilation and erosion. Dilation adds pixels to the boundaries of the object in an image, while erosion does exactly the opposite. The amount of pixels added or removed, respectively depends on the size and shape of the structuring element used to process the image. In general the rules followed from these two operations have as follows:
 
--   __Dilation__: The value of the output pixel is the <b><em>maximum</em></b> value of all the pixels that fall within the structuring element's size and shape. For example in a binary image, if any of the pixels of the input image falling within the range of the kernel is set to the value 1, the corresponding pixel of the output image will be set to 1 as well. The latter applies to any type of image (e.g. grayscale, rgb, etc).
+-   __Dilation__: The value of the output pixel is the <b><em>maximum</em></b> value of all the pixels that fall within the structuring element's size and shape. For example in a binary image, if any of the pixels of the input image falling within the range of the kernel is set to the value 1, the corresponding pixel of the output image will be set to 1 as well. The latter applies to any type of image (e.g. grayscale, bgr, etc).
 
     ![Dilation on a Binary Image](images/morph21.gif)
 

--- a/doc/tutorials/imgproc/threshold/threshold.markdown
+++ b/doc/tutorials/imgproc/threshold/threshold.markdown
@@ -104,13 +104,13 @@ Explanation
 -----------
 
 -#  Let's check the general structure of the program:
-    -   Load an image. If it is RGB we convert it to Grayscale. For this, remember that we can use
+    -   Load an image. If it is BGR we convert it to Grayscale. For this, remember that we can use
         the function @ref cv::cvtColor :
         @code{.cpp}
         src = imread( argv[1], 1 );
 
         /// Convert the image to Gray
-        cvtColor( src, src_gray, COLOR_RGB2GRAY );
+        cvtColor( src, src_gray, COLOR_BGR2GRAY );
         @endcode
     -   Create a window to display the result
         @code{.cpp}

--- a/doc/tutorials/introduction/load_save_image/load_save_image.markdown
+++ b/doc/tutorials/introduction/load_save_image/load_save_image.markdown
@@ -56,7 +56,7 @@ Explanation
 -----------
 
 -#  We begin by loading an image using @ref cv::imread , located in the path given by *imageName*.
-    For this example, assume you are loading a RGB image.
+    For this example, assume you are loading a BGR image.
 -#  Now we are going to convert our image from BGR to Grayscale format. OpenCV has a really nice
     function to do this kind of transformations:
     @code{.cpp}

--- a/doc/user_guide/ug_highgui.markdown
+++ b/doc/user_guide/ug_highgui.markdown
@@ -2,7 +2,7 @@ Using Kinect and other OpenNI compatible depth sensors {#tutorial_ug_highgui}
 ======================================================
 
 Depth sensors compatible with OpenNI (Kinect, XtionPRO, ...) are supported through VideoCapture
-class. Depth map, RGB image and some other formats of output can be retrieved by using familiar
+class. Depth map, BGR image and some other formats of output can be retrieved by using familiar
 interface of VideoCapture.
 
 In order to use depth sensor with OpenCV you should do the following preliminary steps:
@@ -46,7 +46,7 @@ VideoCapture can retrieve the following data:
     -   CAP_OPENNI_VALID_DEPTH_MASK - mask of valid pixels (not ocluded, not shaded etc.)
         (CV_8UC1)
 
--#  data given from RGB image generator:
+-#  data given from BGR image generator:
     -   CAP_OPENNI_BGR_IMAGE - color image (CV_8UC3)
     -   CAP_OPENNI_GRAY_IMAGE - gray image (CV_8UC1)
 


### PR DESCRIPTION
There are many places in documentation where we still tell people that opencv reads in RGB images which is simply incorrect. We then slap those same readers with BGR conversion functions at their faces, so I tried to change it all to be identical. These are pure documentation fixes!