### PR TITLE
CTest-based dashboard testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ if(DEFINED CMAKE_BUILD_TYPE)
   set_property( CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${CMAKE_CONFIGURATION_TYPES} )
 endif()
 
+enable_testing()
+
 project(OpenCV CXX C)
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ OCV_OPTION(OPENCV_WARNINGS_ARE_ERRORS "Treat warnings as errors"                
 OCV_OPTION(ANDROID_EXAMPLES_WITH_LIBS "Build binaries of Android examples with native libraries" OFF  IF ANDROID )
 OCV_OPTION(ENABLE_IMPL_COLLECTION     "Collect implementation data on function call"             OFF )
 OCV_OPTION(GENERATE_ABI_DESCRIPTOR    "Generate XML file for abi_compliance_checker tool" OFF IF UNIX)
+OCV_OPTION(ENABLE_CTEST               "Enable CTest-based testing"                               OFF )
 
 if(ENABLE_IMPL_COLLECTION)
   add_definitions(-DCV_COLLECT_IMPL_DATA)
@@ -1200,3 +1201,11 @@ endif()
 # ----------------------------------------------------------------------------
 
 include(cmake/OpenCVPackaging.cmake)
+
+# ----------------------------------------------------------------------------
+# CTest
+# ----------------------------------------------------------------------------
+
+if(ENABLE_CTEST)
+  add_subdirectory(ctest)
+endif()

--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -995,6 +995,12 @@ function(ocv_add_perf_tests)
       if(NOT BUILD_opencv_world)
         _ocv_add_precompiled_headers(${the_target})
       endif()
+
+      ocv_add_test_from_target("${the_target}" "Performance" "${the_target}")
+      ocv_add_test_from_target("opencv_sanity_${name}" "Sanity" "${the_target}"
+                               "--perf_min_samples=1"
+                               "--perf_force_samples=1"
+                               "--perf_verify_sanity")
     else(OCV_DEPENDENCIES_FOUND)
       # TODO: warn about unsatisfied dependencies
     endif(OCV_DEPENDENCIES_FOUND)
@@ -1055,21 +1061,11 @@ function(ocv_add_accuracy_tests)
         set_target_properties(${the_target} PROPERTIES FOLDER "tests accuracy")
       endif()
 
-      enable_testing()
-      get_target_property(LOC ${the_target} LOCATION)
-      add_test(${the_target} "${LOC}")
-
-      if(WINRT)
-        # removing APPCONTAINER from tests to run from console
-        # look for detailed description inside of ocv_create_module macro above
-        add_custom_command(TARGET "opencv_test_${name}"
-                           POST_BUILD
-                           COMMAND link.exe /edit /APPCONTAINER:NO $(TargetPath))
-      endif()
-
       if(NOT BUILD_opencv_world)
         _ocv_add_precompiled_headers(${the_target})
       endif()
+
+      ocv_add_test_from_target("${the_target}" "Accuracy" "${the_target}")
     else(OCV_DEPENDENCIES_FOUND)
       # TODO: warn about unsatisfied dependencies
     endif(OCV_DEPENDENCIES_FOUND)

--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -26,6 +26,7 @@
 
 # To control the setup of the module you could also set:
 # the_description - text to be used as current module description
+# the_label - label for current module
 # OPENCV_MODULE_TYPE - STATIC|SHARED - set to force override global settings for current module
 # OPENCV_MODULE_IS_PART_OF_WORLD - ON|OFF (default ON) - should the module be added to the opencv_world?
 # BUILD_${the_module}_INIT - ON|OFF (default ON) - initial value for BUILD_${the_module}
@@ -188,6 +189,15 @@ macro(ocv_add_module _name)
     else()
       set(OPENCV_MODULE_${the_module}_IS_PART_OF_WORLD OFF CACHE INTERNAL "")
     endif()
+
+    if(NOT DEFINED the_label)
+      if(OPENCV_PROCESSING_EXTRA_MODULES)
+        set(the_label "Extra")
+      else()
+        set(the_label "Main")
+      endif()
+    endif()
+    set(OPENCV_MODULE_${the_module}_LABEL "${the_label};${the_module}" CACHE INTERNAL "")
 
     if(BUILD_${the_module})
       set(OPENCV_MODULES_BUILD ${OPENCV_MODULES_BUILD} "${the_module}" CACHE INTERNAL "List of OpenCV modules included into the build")
@@ -753,6 +763,10 @@ macro(_ocv_create_module)
   unset(sub_links)
   unset(cuda_objs)
 
+  set_target_properties(${the_module} PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};Module")
+  set_source_files_properties(${OPENCV_MODULE_${the_module}_HEADERS} ${OPENCV_MODULE_${the_module}_SOURCES} ${${the_module}_pch}
+    PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};Module")
+
   ocv_target_link_libraries(${the_module} ${OPENCV_MODULE_${the_module}_DEPS_TO_LINK})
   ocv_target_link_libraries(${the_module} LINK_INTERFACE_LIBRARIES ${OPENCV_MODULE_${the_module}_DEPS_TO_LINK})
   ocv_target_link_libraries(${the_module} ${OPENCV_MODULE_${the_module}_DEPS_EXT} ${OPENCV_LINKER_LIBS} ${IPP_LIBS} ${ARGN})
@@ -957,6 +971,10 @@ function(ocv_add_perf_tests)
       ocv_target_link_libraries(${the_target} ${perf_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS})
       add_dependencies(opencv_perf_tests ${the_target})
 
+      set_target_properties(${the_target} PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};PerfTest")
+      set_source_files_properties(${OPENCV_PERF_${the_module}_SOURCES} ${${the_target}_pch}
+        PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};PerfTest")
+
       # Additional target properties
       set_target_properties(${the_target} PROPERTIES
         DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
@@ -1023,6 +1041,10 @@ function(ocv_add_accuracy_tests)
       ocv_target_link_libraries(${the_target} ${test_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS})
       add_dependencies(opencv_tests ${the_target})
 
+      set_target_properties(${the_target} PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};AccuracyTest")
+      set_source_files_properties(${OPENCV_TEST_${the_module}_SOURCES} ${${the_target}_pch}
+        PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};AccuracyTest")
+
       # Additional target properties
       set_target_properties(${the_target} PROPERTIES
         DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
@@ -1079,6 +1101,10 @@ function(ocv_add_samples)
         ocv_target_include_modules(${the_target} ${samples_deps})
         ocv_target_link_libraries(${the_target} ${samples_deps})
         set_target_properties(${the_target} PROPERTIES PROJECT_LABEL "(sample) ${name}")
+
+        set_target_properties(${the_target} PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};Sample")
+        set_source_files_properties("${source}"
+          PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};Sample")
 
         if(ENABLE_SOLUTION_FOLDERS)
           set_target_properties(${the_target} PROPERTIES

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -836,3 +836,32 @@ macro(ocv_get_all_libs _modules _extra _3rdparty)
     ocv_list_reverse(${lst})
   endforeach()
 endmacro()
+
+function(ocv_add_test_from_target test_name test_kind the_target)
+  if(CMAKE_VERSION VERSION_GREATER "2.8" AND NOT CMAKE_CROSSCOMPILING)
+    if(NOT "${test_kind}" MATCHES "^(Accuracy|Performance|Sanity)$")
+      message(FATAL_ERROR "Unknown test kind : ${test_kind}")
+    endif()
+    if(NOT TARGET "${the_target}")
+      message(FATAL_ERROR "${the_target} is not a CMake target")
+    endif()
+
+    string(TOLOWER "${test_kind}" test_kind_lower)
+    set(test_report_dir "${CMAKE_BINARY_DIR}/test-reports/${test_kind_lower}")
+    file(MAKE_DIRECTORY "${test_report_dir}")
+
+    add_test(NAME "${test_name}"
+      COMMAND "${the_target}"
+              "--gtest_output=xml:${the_target}.xml"
+              ${ARGN})
+
+    set_tests_properties("${test_name}" PROPERTIES
+      LABELS "${OPENCV_MODULE_${the_module}_LABEL};${test_kind}"
+      WORKING_DIRECTORY "${test_report_dir}")
+
+    if(OPENCV_TEST_DATA_PATH)
+      set_tests_properties("${test_name}" PROPERTIES
+        ENVIRONMENT "OPENCV_TEST_DATA_PATH=${OPENCV_TEST_DATA_PATH}")
+    endif()
+  endif()
+endfunction()

--- a/ctest/CMakeLists.txt
+++ b/ctest/CMakeLists.txt
@@ -1,0 +1,50 @@
+# CTEST_TARGET_SYSTEM
+
+if(ANDROID)
+    set(TARGET_SYSTEM_INIT "Android")
+else()
+    set(TARGET_SYSTEM_INIT "${CMAKE_SYSTEM}")
+endif()
+if(CMAKE_CROSSCOMPILING AND NOT ANDROID) # Android is always cross-compiled
+    set(TARGET_SYSTEM_INIT "${TARGET_SYSTEM_INIT}-cross")
+endif()
+set(CTEST_TARGET_SYSTEM "${TARGET_SYSTEM_INIT}" CACHE STRING "Target system for CTest submission")
+
+# CTEST_SITE
+
+site_name(CTEST_SITE)
+
+# CTEST_BUILD_NAME
+
+set(CTEST_BUILD_NAME "${CTEST_TARGET_SYSTEM}" CACHE STRING "Build name for CTest submission")
+
+# CTEST_BUILD_FLAGS
+
+set(CTEST_BUILD_FLAGS "" CACHE STRING "Build flags (like -j5) for CTest submission")
+
+# CTEST_EXTRA_ARGS
+
+set(CTEST_EXTRA_ARGS "" CACHE STRING "Extra flags for CTest tool")
+
+# Targets
+
+file(COPY "CTestCustom.cmake" DESTINATION "${CMAKE_BINARY_DIR}")
+file(COPY "opencv_test.cmake" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+file(COPY "ctest-ext" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+
+function(add_ctest_target NAME MODEL)
+    set(script_file "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.cmake")
+    configure_file("template.build.cmake" "${script_file}" @ONLY)
+
+    file(GLOB scripts "*.cmake")
+
+    add_custom_target("${NAME}"
+        COMMAND "${CMAKE_CTEST_COMMAND}" -VV -S "${script_file}" ${CTEST_EXTRA_ARGS}
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        SOURCES ${scripts})
+
+    set_property(TARGET "${NAME}" PROPERTY FOLDER "CTestDashboardTargets")
+endfunction()
+
+add_ctest_target(Experimental "Experimental")
+add_ctest_target(Performance "Performance")

--- a/ctest/CTestCustom.cmake
+++ b/ctest/CTestCustom.cmake
@@ -1,0 +1,3 @@
+set(CTEST_CUSTOM_WARNING_EXCEPTION
+    ${CTEST_CUSTOM_WARNING_EXCEPTION}
+    "citelist:[0-9]+: warning: Unexpected new line character")

--- a/ctest/README.md
+++ b/ctest/README.md
@@ -1,0 +1,338 @@
+# OpenCV Dashboard Testing
+
+--------------------------------------------------------------------------
+
+## Table of Contents
+
+- [1. Quick Start](#1-quick-start)
+- [2. Configuration](#2-configuration)
+    - [2.1. Target system](#21-target-system)
+    - [2.2. Testing model](#22-testing-model)
+    - [2.3. Configure the testing script](#23-configure-the-testing-script)
+- [3. Available options](#3-available-options)
+    - [3.1. Mandatory testing options](#31-mandatory-testing-options)
+    - [3.2. Repository settings](#32-repository-settings)
+    - [3.3. OpenCV specific settings](#33-opencv-specific-settings)
+    - [3.4. Optional testing settings](#34-optional-testing-settings)
+- [4. Usage from build tree](#4-usage-from-build-tree)
+
+--------------------------------------------------------------------------
+
+## 1. Quick Start
+
+1. Download OpenCV Testing script from [SCRIPT_LINK].
+
+2. Put the OpenCV Testing script to a dashboard directory
+(for example, `~/Dashboards/opencv` or `c:/Dashboards/opencv`).
+
+3. Run CTest tool from a command line:
+
+        $ ctest -VV -DCTEST_WITH_UPDATE=TRUE -S ~/Dashboards/opencv/opencv_test.cmake
+
+4. Add the above command to a scheduler (for example, `cron`) or
+   to a CI system (like buildbot or jenkins).
+
+For CTest tool command line options please refer to [CTEST].
+
+For detailed explanation about testing process please refer to [CTEST_EXT_DOCS].
+
+--------------------------------------------------------------------------
+
+## 2. Configuration
+
+The OpenCV testing script uses **Target system** and **Testing model** notations to
+perform different tests.
+
+### 2.1. Target system
+
+The **Target system** describes the target OS, version, architecture, etc.
+This parameter allows the testing script to choose appropriate configuration for CMake and build tools.
+
+The generic format for the **Target system** option is `<KIND>[-<NAME>][-<ARCH>]`, where
+
+* `<KIND>` is one of **Linux**, **Windows**, **MacOS**, **Android**.
+* `<NAME>` is an optional OS name and version, for example **Ubuntu-14.04**, **Vista**.
+* `<ARCH>` is an optional architecture description, for example **x86_64**, **ARM**, **ARM-Tegra5**.
+
+### 2.2. Testing model
+
+The **Testing model** notation describes the intention of the testing and
+allows the testing script to choose appropriate set of tests.
+
+Currently the following models are supported:
+
+* *Experimental* - performs custom testing.
+* *Nightly* - performs full and clean nightly testing.
+* *Continuous* - performs quick testing, only if there were updates in the remote repository.
+* *Release* - builds release packages.
+* *Performance* - collects benchmarking results.
+* *MemCheck* - performs dynamic analysis.
+* *Documentation* - builds documentation.
+
+### 2.3. Configure the testing script
+
+The testing script can be configured to perform special testing.
+It has several variables, like `CTEST_MODEL`, which can be overwritten.
+
+There are three ways to overwrite default values for all options:
+
+1. Create another script (for example, `my_opencv_test.cmake`) with code of the following form:
+
+        set(CTEST_TARGET_SYSTEM "Linux-Ubuntu-14.04-x64")
+        set(CTEST_MODEL         "Performance")
+        include("${CTEST_SCRIPT_DIRECTORY}/opencv_test.cmake")
+
+   and use it for the CTest command:
+
+        $ ctest -VV -S ~/Dashboards/opencv/my_opencv_test.cmake
+
+2. Pass the options with CTest command line:
+
+        $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake \
+            -DCTEST_TARGET_SYSTEM="Linux-Ubuntu-14.04-x64" \
+            -DCTEST_MODEL="Nightly"
+
+3. Define the options as environment variables before launching CTest command:
+
+        $ export CTEST_TARGET_SYSTEM="Linux-Ubuntu-14.04-x64"
+        $ export CTEST_MODEL="Nightly"
+        $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake
+
+--------------------------------------------------------------------------
+
+## 3. Available options
+
+### 3.1. Mandatory testing options
+
+The following options are mandatory and must be defined.
+
+##### CTEST_TARGET_SYSTEM
+
+This option describes the target platform for the testing.
+By default it is equal to `${CMAKE_SYSTEM}-${CMAKE_SYSTEM_PROCESSOR}`.
+
+See [CMAKE_SYSTEM] and [CMAKE_SYSTEM_PROCESSOR].
+
+##### CTEST_MODEL
+
+The testing model (default - *Experimental*).
+
+##### CTEST_SITE
+
+Site name for submission. By default is equal to the host name.
+
+##### CTEST_BUILD_NAME
+
+Build name for submission. By default is equal to `${CTEST_TARGET_SYSTEM}-${CTEST_MODEL}`.
+
+##### CTEST_DASHBOARD_ROOT
+
+Root folder for the testing.
+
+The testing script will use this folder to create temporary files,
+so it should have write access and should be unique for different scripts.
+
+By default is equal to `${CTEST_SCRIPT_DIRECTORY}/${CTEST_TARGET_SYSTEM}/${CTEST_MODEL}`.
+
+##### CTEST_SOURCE_DIRECTORY
+
+Directory with OpenCV sources. By default is equal to `${CTEST_DASHBOARD_ROOT}/source`.
+
+If the folder doesn't exist the testing script will clone it from the remote OpenCV repository
+(see the next section).
+
+##### CTEST_BINARY_DIRECTORY
+
+Build folder. By default is equal to `${CTEST_DASHBOARD_ROOT}/build`.
+
+
+
+### 3.2. Repository settings
+
+The following options are mandatory if the testing script must support clone and update steps.
+
+##### CTEST_WITH_UPDATE
+
+Update source folder to latest state in remote repository. The option is enabled by default.
+
+**Note:** This operation will reset current source folder state and will discard all not committed changes.
+
+##### CTEST_GIT_COMMAND
+
+Path to the `git` command line tool.
+
+##### CTEST_PROJECT_GIT_URL
+
+OpenCV project repository URL.
+
+##### CTEST_PROJECT_GIT_BRANCH
+
+Branch for testing.
+
+
+
+### 3.3. OpenCV specific settings
+
+The following options are optional and might be undefined.
+In that case the testing script will use default values, depending on **Target system** and **Testing model**.
+
+##### OPENCV_TEST_DATA_PATH
+
+Path to OpenCV test data. If not set the testing script will clone `opencv_extra` repository
+and will use test data from there.
+
+##### OPENCV_EXTRA_SOURCE_DIRECTORY
+
+Path to `opencv_extra` local repository. By default is equal to `${CTEST_DASHBOARD_ROOT}/extra`.
+If `OPENCV_TEST_DATA_PATH` is not set, the testing script will clone the `opencv_extra` repository to the
+`OPENCV_EXTRA_SOURCE_DIRECTORY` folder.
+
+##### OPENCV_EXTRA_GIT_URL
+
+`opencv_extra` repository URL. By default is equal to `git@github.com:Itseez/opencv_extra.git`.
+
+##### OPENCV_EXTRA_GIT_BRANCH
+
+`opencv_extra` branch for testing. By default is equal to `master`.
+
+##### OPENCV_EXTRA_MODULES
+
+List of OpenCV extra modules. For each extra module the following variables must be provided:
+
+* `OPENCV_<module>_SOURCE_DIRECTORY` - path to source directory.
+* `OPENCV_<module>_MODULES_DIRECTORY` - path to modules directory (eg. `modules` sub-folder of the source directory).
+* `OPENCV_<module>_GIT_URL` - git repo URL.
+* `OPENCV_<module>_GIT_BRANCH` - git branch.
+
+By default `contrib` modules is included into the list with the following default values:
+
+* `OPENCV_contrib_SOURCE_DIRECTORY` : `${CTEST_DASHBOARD_ROOT}/contrib`
+* `OPENCV_contrib_MODULES_DIRECTORY` : `${CTEST_DASHBOARD_ROOT}/contrib/modules`
+* `OPENCV_contrib_GIT_URL` : `git@github.com:Itseez/opencv_contrib.git`
+* `OPENCV_contrib_GIT_BRANCH` : `master`
+
+##### OPENCV_EXTRA_MODULES_PATH
+
+Optional list with extra modules, which are located on local file system.
+For example:
+
+```CMake
+set(OPENCV_EXTRA_MODULES_PATH "/home/user/my_module")
+```
+
+##### OPENCV_BUILD_SHARED_LIBS
+
+Build shared libraries instead of static.
+
+##### OPENCV_BUILD_EXAMPLES
+
+Enable/disable samples compilation.
+
+##### OPENCV_FEATURES_ONLY
+
+List of features, which should be enabled. All other features will be disabled.
+For example:
+
+```CMake
+set(OPENCV_FEATURES_ONLY TBB FFMPEG GTK)
+```
+
+##### OPENCV_FEATURES_ENABLE
+
+List of features, which should be enabled. The list will be combined with default settings.
+For example:
+
+```CMake
+set(OPENCV_FEATURES_ENABLE OPENGL)
+```
+
+##### OPENCV_FEATURES_DISABLE
+
+List of features, which should be disabled. The list will be combined with default settings.
+For example:
+
+```CMake
+set(OPENCV_FEATURES_DISABLE CUDA)
+```
+
+
+
+### 3.4. Optional testing settings
+
+##### CTEST_UPDATE_CMAKE_CACHE
+
+True, if the testing script should overwrite CMake cache on each launch.
+
+##### CTEST_EMPTY_BINARY_DIRECTORY
+
+True, if the testing script should clean build directory on each launch.
+
+##### CTEST_WITH_TESTS
+
+Enable/disable test launching.
+
+##### CTEST_TEST_TIMEOUT
+
+Timeout in seconds for single test execution.
+
+##### CTEST_WITH_MEMCHECK
+
+Enable/disable memory check analysis.
+
+##### CTEST_WITH_COVERAGE
+
+Enable/disable CTest-based code coverage analysis.
+
+##### CTEST_WITH_SUBMIT
+
+Enable/disable submission to remote server.
+
+##### CTEST_CMAKE_GENERATOR
+
+CMake generator.
+
+##### CTEST_CONFIGURATION_TYPE
+
+CMake configuration type (eg. Release, Debug).
+
+##### CTEST_BUILD_FLAGS
+
+Extra options for build command. For example:
+
+    set(CTEST_BUILD_FLAGS "-j7")
+
+--------------------------------------------------------------------------
+
+## 4. Usage from build tree
+
+The same testing script can be used from OpenCV build tree.
+
+To enable it, turn on `ENABLE_CTEST` option in CMake configuration.
+It will add new targets, which will call CTest tool with appropriate configuration:
+
+* `$ make Experimental`
+* `$ make Performance`
+
+--------------------------------------------------------------------------
+
+## 5. Usage with CI systems
+
+The testing script can be used with CI systems, like buildbot, Jenkins, etc.
+The CI system might call the same CTest command to perform project configuration, build and testing.
+
+The testing script supports step-by-step mode, to split all steps on CI system. For example:
+
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,Start
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,Configure
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,Build
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,Test
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,Coverage
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,MemCheck
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,Submit
+    $ ctest -VV -S ~/Dashboards/opencv/opencv_test.cmake,Extra
+
+--------------------------------------------------------------------------
+
+[SCRIPT_LINK]: <https://raw.githubusercontent.com/jet47/opencv/ctest-dashboard-testing/ctest/opencv_test.cmake>
+[CTEST]: <http://www.cmake.org/cmake/help/v3.0/manual/ctest.1.html>
+[CTEST_EXT_DOCS]: <http://ctest-ext.readthedocs.org/en/latest/>

--- a/ctest/ctest-ext/ctest_ext.cmake
+++ b/ctest/ctest-ext/ctest_ext.cmake
@@ -1,0 +1,540 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2014-2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# The CTest Extension module is a set of additional functions for CTest scripts.
+# The main goal of the CTest Extension module is to provide uniform testing approach
+# for CMake projects.
+#
+# The CTest Extension module supports the following functionality:
+#
+#   - clone/update git repository;
+#   - configure CMake project;
+#   - build CMake project;
+#   - run project's tests;
+#   - build coverage report (in CTest format and in gcovr format);
+#   - run dynamic analysis (like valgrind);
+#   - upload testing results to remote server (eg. CDash web server).
+#
+
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
+if(DEFINED CTEST_EXT_INCLUDED)
+    return()
+endif()
+set(CTEST_EXT_INCLUDED TRUE)
+set(CTEST_EXT_VERSION  0.6.1)
+
+#
+# Auxiliary modules
+#
+
+include(CMakeParseArguments)
+
+set(CTEST_EXT_MODULES_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
+
+include("${CTEST_EXT_MODULES_PATH}/vars.cmake")
+include("${CTEST_EXT_MODULES_PATH}/logging.cmake")
+include("${CTEST_EXT_MODULES_PATH}/system.cmake")
+include("${CTEST_EXT_MODULES_PATH}/git_repo.cmake")
+include("${CTEST_EXT_MODULES_PATH}/cmake_config.cmake")
+include("${CTEST_EXT_MODULES_PATH}/gcovr.cmake")
+include("${CTEST_EXT_MODULES_PATH}/lcov.cmake")
+
+#
+# ctest_ext_init()
+#
+#   Initializes CTest Ext module for dashboard testing.
+#
+#   The function sets dashboard settings to default values (if they were not defined prior the call)
+#   and performs project repository checkout/update if needed.
+#
+
+macro(ctest_ext_init)
+    check_vars_def(CTEST_PROJECT_NAME)
+
+    #
+    # Initialize settings from environment variables
+    #
+
+    set_from_env(
+        CTEST_TARGET_SYSTEM
+        CTEST_MODEL)
+
+    set_from_env(
+        CTEST_SITE
+        CTEST_BUILD_NAME)
+
+    set_from_env(
+        CTEST_DASHBOARD_ROOT
+        CTEST_SOURCE_DIRECTORY
+        CTEST_BINARY_DIRECTORY
+        CTEST_NOTES_LOG_FILE)
+
+    set_from_env(
+        CTEST_WITH_UPDATE
+        CTEST_SCM_TOOL
+        CTEST_GIT_COMMAND
+        CTEST_PROJECT_GIT_URL
+        CTEST_PROJECT_GIT_BRANCH)
+
+    set_from_env(
+        CTEST_UPDATE_CMAKE_CACHE
+        CTEST_EMPTY_BINARY_DIRECTORY)
+
+    set_from_env(
+        CTEST_CMAKE_GENERATOR
+        CTEST_CONFIGURATION_TYPE
+        CTEST_INITIAL_CACHE
+        CTEST_CMAKE_EXTRA_OPTIONS
+        CTEST_BUILD_FLAGS)
+
+    set_from_env(
+        CTEST_WITH_TESTS
+        CTEST_TEST_TIMEOUT)
+
+    set_from_env(
+        CTEST_WITH_COVERAGE
+        CTEST_COVERAGE_TOOL)
+
+    set_from_env(
+        CTEST_GCOVR_EXECUTABLE
+        CTEST_GCOVR_XML
+        CTEST_GCOVR_HTML
+        CTEST_GCOVR_FILTER
+        CTEST_GCOVR_OUTPUT_BASE_NAME
+        CTEST_GCOVR_XML_DIR
+        CTEST_GCOVR_HTML_DIR
+        CTEST_GCOVR_EXTRA_OPTIONS)
+
+    set_from_env(
+        CTEST_LCOV_EXECUTABLE
+        CTEST_GENHTML_EXECUTABLE
+        CTEST_LCOV_BRANCH_COVERAGE
+        CTEST_LCOV_FUNCTION_COVERAGE
+        CTEST_LCOV_SKIP_HTML
+        CTEST_LCOV_OUTPUT_LCOV_DIR
+        CTEST_LCOV_OUTPUT_REPORT_NAME
+        CTEST_LCOV_OUTPUT_HTML_DIR
+        CTEST_LCOV_EXTRACT
+        CTEST_LCOV_REMOVE
+        CTEST_LCOV_EXTRA_LCOV_OPTIONS
+        CTEST_LCOV_EXTRA_GENTHML_OPTIONS)
+
+    set_from_env(
+        CTEST_COVERAGE_COMMAND
+        CTEST_COVERAGE_EXTRA_FLAGS)
+
+    set_from_env(
+        CTEST_WITH_DYNAMIC_ANALYSIS
+        CTEST_DYNAMIC_ANALYSIS_TOOL
+        CTEST_MEMORYCHECK_COMMAND
+        CTEST_MEMORYCHECK_SUPPRESSIONS_FILE
+        CTEST_MEMORYCHECK_COMMAND_OPTIONS)
+
+    set_from_env(
+        CTEST_WITH_SUBMIT
+        CTEST_NOTES_FILES
+        CTEST_UPLOAD_FILES)
+
+    set_from_env(
+        CTEST_TRACK
+        CTEST_TMP_BASE_DIR)
+
+    #
+    # Set dashboard setting to default values
+    #
+
+    set_ifndef(CTEST_TARGET_SYSTEM      "${CMAKE_SYSTEM}-${CMAKE_SYSTEM_PROCESSOR}")
+    set_ifndef(CTEST_MODEL              "Experimental")
+
+    if(NOT DEFINED CTEST_SITE)
+        site_name(CTEST_SITE)
+    endif()
+    set_ifndef(CTEST_BUILD_NAME         "${CTEST_TARGET_SYSTEM}-${CTEST_MODEL}")
+
+    set_ifndef(CTEST_DASHBOARD_ROOT     "${CTEST_SCRIPT_DIRECTORY}/${CTEST_TARGET_SYSTEM}/${CTEST_MODEL}")
+    set_ifndef(CTEST_SOURCE_DIRECTORY   "${CTEST_DASHBOARD_ROOT}/source")
+    set_ifndef(CTEST_BINARY_DIRECTORY   "${CTEST_DASHBOARD_ROOT}/build")
+    set_ifndef(CTEST_NOTES_LOG_FILE     "${CTEST_DASHBOARD_ROOT}/ctest_ext_notes_log.txt")
+
+    set_ifndef(CTEST_WITH_UPDATE        FALSE)
+    if(EXISTS "${CTEST_SOURCE_DIRECTORY}/.git" OR DEFINED CTEST_PROJECT_GIT_URL)
+        set_ifndef(CTEST_SCM_TOOL       "GIT")
+    endif()
+
+    #
+    # Locate tools
+    #
+
+    if(NOT DEFINED CTEST_GIT_COMMAND)
+        find_package(Git QUIET)
+        if(GIT_FOUND)
+            ctest_ext_info("Found git : ${GIT_EXECUTABLE} (version ${GIT_VERSION_STRING})")
+            set_ifndef(CTEST_GIT_COMMAND "${GIT_EXECUTABLE}")
+        endif()
+    endif()
+
+    if(NOT DEFINED CTEST_GCOVR_EXECUTABLE)
+        find_program(CTEST_GCOVR_EXECUTABLE NAMES gcovr)
+        if(CTEST_GCOVR_EXECUTABLE)
+            ctest_ext_info("Found gcovr : ${CTEST_GCOVR_EXECUTABLE}")
+        endif()
+    endif()
+
+    if(NOT DEFINED CTEST_LCOV_EXECUTABLE)
+        find_program(CTEST_LCOV_EXECUTABLE NAMES lcov)
+        if(CTEST_LCOV_EXECUTABLE)
+            ctest_ext_info("Found lcov : ${CTEST_LCOV_EXECUTABLE}")
+        endif()
+    endif()
+
+    if(NOT DEFINED CTEST_GENHTML_EXECUTABLE)
+        find_program(CTEST_GENHTML_EXECUTABLE NAMES genhtml)
+        if(CTEST_GENHTML_EXECUTABLE)
+            ctest_ext_info("Found genhtml : ${CTEST_GENHTML_EXECUTABLE}")
+        endif()
+    endif()
+
+    if(NOT DEFINED CTEST_COVERAGE_COMMAND)
+        find_program(CTEST_COVERAGE_COMMAND NAMES gcov)
+        if(CTEST_COVERAGE_COMMAND)
+            ctest_ext_info("Found gcov : ${CTEST_COVERAGE_COMMAND}")
+        endif()
+    endif()
+
+    if(NOT DEFINED CTEST_MEMORYCHECK_COMMAND)
+        find_program(CTEST_MEMORYCHECK_COMMAND NAMES valgrind)
+        if(CTEST_MEMORYCHECK_COMMAND)
+            ctest_ext_info("Found valgrind : ${CTEST_MEMORYCHECK_COMMAND}")
+        endif()
+    endif()
+
+    #
+    # Determine current stage
+    #
+
+    set_ifndef(CTEST_STAGE "${CTEST_SCRIPT_ARG}")
+    if(NOT CTEST_STAGE)
+        set(CTEST_STAGE "Start;Configure;Build;Test;Coverage;DynamicAnalysis;Submit;Extra")
+    endif()
+
+    #
+    # Initialize sources
+    #
+
+    set(HAVE_UPDATES TRUE)
+
+    if(CTEST_STAGE MATCHES "Start")
+        ctext_ext_log_stage("Initialize testing for MODEL ${CTEST_MODEL}")
+
+        if(NOT EXISTS "${CTEST_SOURCE_DIRECTORY}")
+            if(NOT DEFINED CTEST_CHECKOUT_COMMAND)
+                if(CTEST_SCM_TOOL MATCHES "GIT")
+                    check_vars_exist(CTEST_GIT_COMMAND)
+                    check_vars_def(CTEST_PROJECT_GIT_URL)
+
+                    if(CTEST_PROJECT_GIT_BRANCH)
+                        set(CTEST_CHECKOUT_COMMAND "${CTEST_GIT_COMMAND} clone -b ${CTEST_PROJECT_GIT_BRANCH} -- ${CTEST_PROJECT_GIT_URL} ${CTEST_SOURCE_DIRECTORY}")
+                    else()
+                        set(CTEST_CHECKOUT_COMMAND "${CTEST_GIT_COMMAND} clone ${CTEST_PROJECT_GIT_URL} ${CTEST_SOURCE_DIRECTORY}")
+                    endif()
+                else()
+                    message(FATAL_ERROR "CTEST_SOURCE_DIRECTORY = ${CTEST_SOURCE_DIRECTORY} is not exist and no SCM configuration is provided")
+                endif()
+            endif()
+
+            ctest_ext_info("Source directory (${CTEST_SOURCE_DIRECTORY}) is not exist, checkout it with [${CTEST_CHECKOUT_COMMAND}] command")
+        endif()
+
+        ctest_ext_info("Initial start and checkout")
+        ctest_start("${CTEST_MODEL}")
+
+        if(CTEST_WITH_UPDATE)
+            if(NOT DEFINED CTEST_UPDATE_COMMAND)
+                if(CTEST_SCM_TOOL MATCHES "GIT")
+                    check_vars_exist(CTEST_GIT_COMMAND)
+
+                    set(CTEST_UPDATE_COMMAND "${CTEST_GIT_COMMAND}")
+                else()
+                    message(FATAL_ERROR "Unsupported SCM tool : ${CTEST_SCM_TOOL}")
+                endif()
+            endif()
+
+            ctest_ext_info("Repository update")
+            ctest_update(RETURN_VALUE count)
+
+            set(HAVE_UPDATES FALSE)
+            if(count GREATER 0)
+                set(HAVE_UPDATES TRUE)
+            endif()
+        endif()
+    endif()
+endmacro()
+
+#
+# ctest_ext_start()
+#
+#   Starts dashboard testing.
+#
+#   The function sets testing settings to default values (if they were not defined prior the call)
+#   and initializes logging mechanism.
+#
+
+macro(ctest_ext_start)
+    #
+    # Set unspecified options to default values
+    #
+
+    set_ifndef(CTEST_UPDATE_CMAKE_CACHE         TRUE)
+    set_ifndef(CTEST_EMPTY_BINARY_DIRECTORY     TRUE)
+    set_ifndef(CTEST_CMAKE_GENERATOR            "Unix Makefiles")
+    set_ifndef(CTEST_CONFIGURATION_TYPE         "Debug")
+
+    set_ifndef(CTEST_WITH_TESTS                 TRUE)
+    set_ifndef(CTEST_TEST_TIMEOUT               600)
+
+    set_ifndef(CTEST_WITH_COVERAGE              FALSE)
+
+    set_ifndef(CTEST_WITH_DYNAMIC_ANALYSIS      FALSE)
+
+    set_ifndef(CTEST_WITH_SUBMIT                FALSE)
+    list(APPEND CTEST_NOTES_FILES   "${CTEST_NOTES_LOG_FILE}")
+    list(APPEND CTEST_UPLOAD_FILES  "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt")
+
+    set_ifndef(CTEST_TRACK "${CTEST_MODEL}")
+
+    #
+    # Start
+    #
+
+    ctext_ext_log_stage("Start testing MODEL ${CTEST_MODEL} TRACK ${CTEST_TRACK}")
+
+    ctest_start("${CTEST_MODEL}" TRACK "${CTEST_TRACK}" APPEND)
+
+    if(CTEST_STAGE MATCHES "Start")
+        file(REMOVE "${CTEST_NOTES_LOG_FILE}")
+        ctest_ext_dump_notes()
+    endif()
+endmacro()
+
+#
+# ctest_ext_configure()
+#
+#   Configures CMake project.
+#
+#   To configure CMake cache variables use `add_cmake_cache_entry` command.
+#
+
+macro(ctest_ext_configure)
+    if(CTEST_STAGE MATCHES "Configure")
+        ctext_ext_log_stage("Configure")
+
+        if(CTEST_EMPTY_BINARY_DIRECTORY)
+            ctest_ext_info("Clean binary directory : ${CTEST_BINARY_DIRECTORY}")
+
+            if(EXISTS "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt")
+                ctest_empty_binary_directory("${CTEST_BINARY_DIRECTORY}")
+            else()
+                file(REMOVE_RECURSE "${CTEST_BINARY_DIRECTORY}")
+            endif()
+        endif()
+
+        if(NOT EXISTS "${CTEST_BINARY_DIRECTORY}")
+            ctest_ext_info("Create binary directory : ${CTEST_BINARY_DIRECTORY}")
+            file(MAKE_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
+        endif()
+
+        if(CTEST_UPDATE_CMAKE_CACHE)
+            ctest_ext_info("Rewrite CMake cache : ${CTEST_INITIAL_CACHE}")
+            file(WRITE "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt" ${CTEST_INITIAL_CACHE})
+        endif()
+
+        ctest_configure(OPTIONS "${CTEST_CMAKE_EXTRA_OPTIONS}")
+    endif()
+
+    ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
+endmacro()
+
+#
+# ctest_ext_build([TARGET <target>] [TARGETS <target1> <target2> ...])
+#
+#   Builds CMake project.
+#
+
+function(ctest_ext_build)
+    set(options "")
+    set(oneValueArgs "TARGET")
+    set(multiValueArgs "TARGETS")
+    cmake_parse_arguments(BUILD "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(CTEST_STAGE MATCHES "Build")
+        ctext_ext_log_stage("Build")
+
+        if(BUILD_TARGET)
+            ctest_ext_info("Build target : " ${BUILD_TARGET})
+            ctest_build(TARGET "${BUILD_TARGET}")
+        elseif(BUILD_TARGETS)
+            ctest_ext_info("Build targets : " ${BUILD_TARGETS})
+
+            # ctest_build doesn't support multiple target, emulate them with CMake script
+            set(BUILD_SCRIPT "${CTEST_BINARY_DIRECTORY}/ctest_ext_build.cmake")
+            file(REMOVE "${BUILD_SCRIPT}")
+
+            foreach(target ${BUILD_TARGETS})
+                file(APPEND "${BUILD_SCRIPT}" "message(STATUS \"Build target : ${target}\") \n")
+
+                set(BUILD_COMMAND "execute_process(COMMAND \"${CMAKE_COMMAND}\"")
+                set(BUILD_COMMAND "${BUILD_COMMAND} --build \"${CTEST_BINARY_DIRECTORY}\"")
+                if(NOT target MATCHES "^(all|ALL)$")
+                    set(BUILD_COMMAND "${BUILD_COMMAND} --target \"${target}\"")
+                endif()
+                set(BUILD_COMMAND "${BUILD_COMMAND} --config \"${CTEST_CONFIGURATION_TYPE}\"")
+                if(CTEST_BUILD_FLAGS)
+                    set(BUILD_COMMAND "${BUILD_COMMAND} -- ${CTEST_BUILD_FLAGS}")
+                endif()
+
+                set(BUILD_COMMAND "${BUILD_COMMAND} WORKING_DIRECTORY \"${CTEST_BINARY_DIRECTORY}\")")
+
+                file(APPEND "${BUILD_SCRIPT}" "${BUILD_COMMAND} \n")
+            endforeach()
+
+            set(CTEST_BUILD_COMMAND "${CMAKE_COMMAND} -P ${BUILD_SCRIPT}")
+            ctest_build()
+        else()
+            ctest_ext_info("Build target : ALL")
+            ctest_build()
+        endif()
+    endif()
+endfunction()
+
+#
+# ctest_ext_test(<arguments>)
+#
+#   Runs tests.
+#
+#   The function will pass its arguments to `ctest_test` as is.
+#
+
+function(ctest_ext_test)
+    if(CTEST_WITH_TESTS AND CTEST_STAGE MATCHES "Test")
+        ctext_ext_log_stage("Test")
+
+        ctest_ext_info("ctest_test parameters : " ${ARGN})
+        ctest_test(${ARGN})
+    endif()
+endfunction()
+
+#
+# ctest_ext_coverage(
+#       [GCOVR <options for run_gcovr>]
+#       [LCOV <options for run_lcov>]
+#       [CDASH <options for ctest_coverage>])
+#
+#   Collects coverage reports.
+#
+#   The function passes own arguments to `run_gcovr`, `run_lcov` and `ctest_coverage` as is.
+#
+
+function(ctest_ext_coverage)
+    set(options "")
+    set(oneValueArgs "")
+    set(multiValueArgs "GCOVR" "LCOV" "CDASH")
+    cmake_parse_arguments(COVERAGE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(CTEST_WITH_COVERAGE AND CTEST_STAGE MATCHES "Coverage")
+        ctext_ext_log_stage("Coverage")
+
+        if(CTEST_COVERAGE_TOOL MATCHES "GCOVR")
+            ctest_ext_info("Generate GCOVR coverage report")
+
+            ctest_ext_info("run_gcovr parameters : " ${COVERAGE_GCOVR})
+            run_gcovr(${COVERAGE_GCOVR})
+        endif()
+
+        if(CTEST_COVERAGE_TOOL MATCHES "LCOV")
+            ctest_ext_info("Generate LCOV coverage report")
+
+            ctest_ext_info("run_lcov parameters : " ${COVERAGE_LCOV})
+            run_lcov(${COVERAGE_LCOV})
+        endif()
+
+        if(CTEST_COVERAGE_TOOL MATCHES "CDASH")
+            check_vars_def(CTEST_COVERAGE_COMMAND)
+
+            ctest_ext_info("Generate CDASH coverage report")
+
+            ctest_ext_info("ctest_coverage parameters : " ${COVERAGE_CDASH})
+            ctest_coverage(${COVERAGE_CDASH})
+        endif()
+    endif()
+endfunction()
+
+#
+# ctest_ext_dynamic_analysis(
+#       [CDASH <options for ctest_memcheck>])
+#
+#   Runs dynamic analysis testing.
+#
+#   The function will pass its arguments to `ctest_memcheck` as is.
+#
+
+function(ctest_ext_dynamic_analysis)
+    set(options "")
+    set(oneValueArgs "")
+    set(multiValueArgs "CDASH")
+    cmake_parse_arguments(DYNAMIC_ANALYSIS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(CTEST_WITH_DYNAMIC_ANALYSIS AND CTEST_STAGE MATCHES "DynamicAnalysis")
+        ctext_ext_log_stage("Dynamic analysis")
+
+        if(CTEST_DYNAMIC_ANALYSIS_TOOL MATCHES "CDASH")
+            check_vars_def(CTEST_MEMORYCHECK_COMMAND)
+
+            ctest_ext_info("Generate CDASH dynamic analysis report")
+
+            ctest_ext_info("ctest_memcheck parameters : " ${ARGN})
+            ctest_memcheck(${DYNAMIC_ANALYSIS_CDASH})
+        endif()
+    endif()
+endfunction()
+
+#
+# ctest_ext_submit()
+#
+#   Submits testing results to remote server.
+#
+
+function(ctest_ext_submit)
+    if(CTEST_WITH_SUBMIT AND CTEST_STAGE MATCHES "Submit")
+        ctext_ext_log_stage("Submit")
+
+        if(CTEST_UPLOAD_FILES)
+            ctest_ext_info("Upload files : " ${CTEST_UPLOAD_FILES})
+            ctest_upload(FILES ${CTEST_UPLOAD_FILES})
+        endif()
+
+        ctest_submit()
+    endif()
+endfunction()

--- a/ctest/ctest-ext/modules/cmake_config.cmake
+++ b/ctest/ctest-ext/modules/cmake_config.cmake
@@ -1,0 +1,52 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# CMake configuration commands
+#
+
+#
+# add_cmake_cache_entry(<name> <value> [TYPE <type>] [FORCE])
+#
+#   Adds new CMake cache entry.
+#
+
+function(add_cmake_cache_entry OPTION_NAME)
+    set(options "FORCE")
+    set(oneValueArgs "TYPE")
+    set(multiValueArgs "")
+    cmake_parse_arguments(OPTION "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set_ifndef(OPTION_TYPE "STRING")
+
+    if(CTEST_INITIAL_CACHE MATCHES "${OPTION_NAME}.*\n")
+        if(NOT OPTION_FORCE)
+            return()
+        else()
+            string(REGEX REPLACE "${OPTION_NAME}.*\n" "" CTEST_INITIAL_CACHE "${CTEST_INITIAL_CACHE}")
+        endif()
+    endif()
+
+    set(CTEST_INITIAL_CACHE "${CTEST_INITIAL_CACHE}${OPTION_NAME}:${OPTION_TYPE}=${OPTION_UNPARSED_ARGUMENTS}\n" PARENT_SCOPE)
+endfunction()

--- a/ctest/ctest-ext/modules/gcovr.cmake
+++ b/ctest/ctest-ext/modules/gcovr.cmake
@@ -1,0 +1,130 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# gcovr coverage report commands
+#
+
+#
+# run_gcovr([XML] [HTML]
+#           [FILTER <filter>]
+#           [OUTPUT_BASE_NAME <output_dir>]
+#           [XML_DIR <xml output dir>]
+#           [HTML_DIR <html output dir>]
+#           [EXTRA_OPTIONS <option1> <option2> ...])
+#
+#   Runs gcovr command to generate coverage report.
+#
+#   This is an internal function, which is used in `ctest_ext_coverage`.
+#
+#   The gcovr command is run in `CTEST_BINARY_DIRECTORY` directory relatively to `CTEST_SOURCE_DIRECTORY` directory.
+#   The binaries must be built with gcov coverage support.
+#   The gcovr command must be run after all tests.
+#
+#   Coverage reports will be generated in:
+#
+#     - <XML_DIR>/<OUTPUT_BASE_NAME>.xml
+#     - <HTML_DIR>/<OUTPUT_BASE_NAME>.html
+#
+#   `XML` and `HTML` options choose coverage report format (both can be specified).
+#
+#   `FILTER` options is used to specify file filter for report.
+#   If not specified `${CTEST_SOURCE_DIRECTORY}/*` will be used.
+#
+#   `OUTPUT_BASE_NAME` specifies base name for output reports.
+#   If not specified `coverage` will be used.
+#
+#   `XML_DIR` specifies base directory for XML reports.
+#   If not specified `${CTEST_BINARY_DIRECTORY}/coverage-gcovr/xml` will be used.
+#
+#   `HTML_DIR` specifies base directory for HTML reports.
+#   If not specified `${CTEST_BINARY_DIRECTORY}/coverage-gcovr/html` will be used.
+#
+#   `EXTRA_OPTIONS` specifies additional options for gcovr command line.
+#
+#   If `CTEST_GCOVR_<option_name>` variable if defined, it will override the value of
+#   `<option_name>` option.
+#
+#   `CTEST_GCOVR_EXECUTABLE` variable must be defined and must point to gcovr command.
+#
+
+function(run_gcovr)
+    set(options "XML" "HTML")
+    set(oneValueArgs "FILTER" "OUTPUT_BASE_NAME" "XML_DIR" "HTML_DIR")
+    set(multiValueArgs "EXTRA_OPTIONS")
+    cmake_parse_arguments(GCOVR "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    override_from_ctest_vars(
+        GCOVR_XML
+        GCOVR_HTML
+        GCOVR_FILTER
+        GCOVR_OUTPUT_BASE_NAME
+        GCOVR_XML_DIR
+        GCOVR_HTML_DIR
+        GCOVR_EXTRA_OPTIONS)
+
+    check_vars_exist(CTEST_GCOVR_EXECUTABLE)
+
+    set_ifndef(GCOVR_FILTER "${CTEST_SOURCE_DIRECTORY}/*")
+    set_ifndef(GCOVR_OUTPUT_BASE_NAME "coverage")
+    set_ifndef(GCOVR_XML_DIR "${CTEST_BINARY_DIRECTORY}/coverage-gcovr/xml")
+    set_ifndef(GCOVR_HTML_DIR "${CTEST_BINARY_DIRECTORY}/coverage-gcovr/html")
+
+    set(GCOVR_BASE_COMMAND_LINE
+        "${CTEST_GCOVR_EXECUTABLE}"
+        "${CTEST_BINARY_DIRECTORY}"
+        "-r" "${CTEST_SOURCE_DIRECTORY}"
+        "-f" "${GCOVR_FILTER}"
+        ${GCOVR_EXTRA_OPTIONS})
+
+    if(GCOVR_XML)
+        if(EXISTS "${GCOVR_XML_DIR}")
+            file(REMOVE_RECURSE "${GCOVR_XML_DIR}")
+        endif()
+        file(MAKE_DIRECTORY "${GCOVR_XML_DIR}")
+
+        set(GCOVR_XML_COMMAND_LINE
+            ${GCOVR_BASE_COMMAND_LINE}
+            "--xml" "--xml-pretty"
+            "-o" "${GCOVR_OUTPUT_BASE_NAME}.xml")
+
+        ctest_ext_info("Generate XML gcovr report : ${GCOVR_XML_COMMAND_LINE}")
+        execute_process(COMMAND ${GCOVR_XML_COMMAND_LINE} WORKING_DIRECTORY "${GCOVR_XML_DIR}")
+    endif()
+
+    if(GCOVR_HTML)
+        if(EXISTS "${GCOVR_HTML_DIR}")
+            file(REMOVE_RECURSE "${GCOVR_HTML_DIR}")
+        endif()
+        file(MAKE_DIRECTORY "${GCOVR_HTML_DIR}")
+
+        set(GCOVR_HTML_COMMAND_LINE
+            ${GCOVR_BASE_COMMAND_LINE}
+            "--html" "--html-details"
+            "-o" "${GCOVR_OUTPUT_BASE_NAME}.html")
+
+        ctest_ext_info("Generate HTML gcovr report : ${GCOVR_HTML_COMMAND_LINE}")
+        execute_process(COMMAND ${GCOVR_HTML_COMMAND_LINE} WORKING_DIRECTORY "${GCOVR_HTML_DIR}")
+    endif()
+endfunction()

--- a/ctest/ctest-ext/modules/git_repo.cmake
+++ b/ctest/ctest-ext/modules/git_repo.cmake
@@ -1,0 +1,123 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# GIT repository control commands
+#
+
+#
+# clone_git_repo(<git url> <destination> [BRANCH <branch>])
+#
+#   Clones git repository from <git url> to <destination> directory.
+#
+#   Optionally <branch> name can be specified.
+#
+#   `CTEST_GIT_COMMAND` variable must be defined and must point to git command.
+#
+
+function(clone_git_repo GIT_URL GIT_DEST_DIR)
+    set(options "")
+    set(oneValueArgs "BRANCH")
+    set(multiValueArgs "")
+    cmake_parse_arguments(GIT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    check_vars_exist(CTEST_GIT_COMMAND)
+
+    if(GIT_BRANCH)
+        ctest_ext_info("Clone git repository ${GIT_URL} (branch ${GIT_BRANCH}) to ${GIT_DEST_DIR}")
+        execute_process(COMMAND "${CTEST_GIT_COMMAND}" clone -b ${GIT_BRANCH} -- ${GIT_URL} ${GIT_DEST_DIR})
+    else()
+        ctest_ext_info("Clone git repository ${GIT_URL} to ${GIT_DEST_DIR}")
+        execute_process(COMMAND "${CTEST_GIT_COMMAND}" clone ${GIT_URL} ${GIT_DEST_DIR})
+    endif()
+endfunction()
+
+#
+# update_git_repo(<directory> [REMOTE <remote>] [BRANCH <branch>] [UPDATE_COUNT_OUTPUT <output variable>])
+#
+#   Updates local git repository in <directory> to latest state from remote repository.
+#
+#   <remote> specifies remote repository name, `origin` by default.
+#
+#   <branch> specifies remote branch name, `master` by default.
+#
+#   <output variable> specifies optional output variable to store update count.
+#   If it is zero, local repository already was in latest state.
+#
+#   `CTEST_GIT_COMMAND` variable must be defined and must point to git command.
+#
+
+function(update_git_repo GIT_REPO_DIR)
+    set(options "")
+    set(oneValueArgs "REMOTE" "BRANCH" "UPDATE_COUNT_OUTPUT")
+    set(multiValueArgs "")
+    cmake_parse_arguments(GIT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # TODO : use FETCH_HEAD
+    set_ifndef(GIT_REMOTE "origin")
+    set_ifndef(GIT_BRANCH "master")
+
+    check_vars_exist(CTEST_GIT_COMMAND GIT_REPO_DIR)
+
+    ctest_ext_info("Fetch git remote repository ${GIT_REMOTE} in ${GIT_REPO_DIR}")
+    execute_process(COMMAND "${CTEST_GIT_COMMAND}" fetch
+        WORKING_DIRECTORY "${GIT_REPO_DIR}")
+
+    if(GIT_UPDATE_COUNT_OUTPUT)
+        ctest_ext_info("Compare git local repository with ${GIT_REMOTE}/${GIT_BRANCH} state in ${GIT_REPO_DIR}")
+        execute_process(COMMAND "${CTEST_GIT_COMMAND}" diff HEAD "${GIT_REMOTE}/${GIT_BRANCH}"
+            WORKING_DIRECTORY "${GIT_REPO_DIR}"
+            OUTPUT_VARIABLE diff_output)
+
+        string(LENGTH "${diff_output}" update_count)
+        set(${GIT_UPDATE_COUNT_OUTPUT} "${update_count}" PARENT_SCOPE)
+    endif()
+
+    ctest_ext_info("Reset git local repository to ${GIT_REMOTE}/${GIT_BRANCH} state in ${GIT_REPO_DIR}")
+    execute_process(COMMAND "${CTEST_GIT_COMMAND}" reset --hard "${GIT_REMOTE}/${GIT_BRANCH}"
+        WORKING_DIRECTORY "${GIT_REPO_DIR}")
+endfunction()
+
+#
+# get_git_repo_info(<repository> <branch output variable> <revision output variable>)
+#
+#   Gets information about local git repository (branch name and revision).
+#
+
+function(get_git_repo_info GIT_REPO_DIR BRANCH_OUT_VAR REVISION_OUT_VAR)
+    check_vars_exist(CTEST_GIT_COMMAND)
+
+    execute_process(COMMAND "${CTEST_GIT_COMMAND}" rev-parse --abbrev-ref HEAD
+        WORKING_DIRECTORY "${GIT_REPO_DIR}"
+        OUTPUT_VARIABLE branch
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    execute_process(COMMAND "${CTEST_GIT_COMMAND}" rev-parse HEAD
+        WORKING_DIRECTORY "${GIT_REPO_DIR}"
+        OUTPUT_VARIABLE revision
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    set(${BRANCH_OUT_VAR} ${branch} PARENT_SCOPE)
+    set(${REVISION_OUT_VAR} ${revision} PARENT_SCOPE)
+endfunction()

--- a/ctest/ctest-ext/modules/lcov.cmake
+++ b/ctest/ctest-ext/modules/lcov.cmake
@@ -1,0 +1,164 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# run_lcov([BRANCH_COVERAGE] [FUNCTION_COVERAGE]
+#          [SKIP_HTML]
+#          [OUTPUT_LCOV_DIR <output_lcov_dir>]
+#          [OUTPUT_HTML_DIR <output_html_dir>]
+#          [EXTRACT] <extract patterns>
+#          [REMOVE] <remove patterns>
+#          [EXTRA_LCOV_OPTIONS <lcov extra options>]
+#          [EXTRA_GENTHML_OPTIONS <genhtml extra options>])
+#
+#   Runs `lcov` and `genthml` commands to generate coverage report.
+#
+#   This is an internal function, which is used in `ctest_ext_coverage`.
+#
+#   `BRANCH_COVERAGE` and `FUNCTION_COVERAGE` options turn on branch and function coverage analysis.
+#
+#   `SKIP_HTML` disables html report generation.
+#
+#   The `lcov` command is run in `CTEST_BINARY_DIRECTORY` directory relatively to `CTEST_SOURCE_DIRECTORY` directory.
+#   The binaries must be built with `gcov` coverage support.
+#   The `lcov` command must be run after all tests.
+#
+#   If `CTEST_LCOV_<option_name>` variable if defined, it will override the value of
+#   `<option_name>` option.
+#
+#   `CTEST_LCOV_EXECUTABLE` variable must be defined and must point to `lcov` command.
+#   `CTEST_GENHTML_EXECUTABLE` variable must be defined and must point to `genhtml` command.
+#
+
+function(run_lcov)
+    set(options "BRANCH_COVERAGE" "FUNCTION_COVERAGE" "SKIP_HTML")
+    set(oneValueArgs "OUTPUT_LCOV_DIR" "OUTPUT_REPORT_NAME" "OUTPUT_HTML_DIR")
+    set(multiValueArgs "EXTRACT" "REMOVE" "EXTRA_LCOV_OPTIONS" "EXTRA_GENTHML_OPTIONS")
+    cmake_parse_arguments(LCOV "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    override_from_ctest_vars(
+        LCOV_BRANCH_COVERAGE
+        LCOV_FUNCTION_COVERAGE
+        LCOV_SKIP_HTML
+        LCOV_OUTPUT_LCOV_DIR
+        LCOV_OUTPUT_REPORT_NAME
+        LCOV_OUTPUT_HTML_DIR
+        LCOV_EXTRACT
+        LCOV_REMOVE
+        LCOV_EXTRA_LCOV_OPTIONS
+        LCOV_EXTRA_GENTHML_OPTIONS)
+
+    check_vars_exist(CTEST_LCOV_EXECUTABLE)
+    if(NOT LCOV_SKIP_HTML)
+        check_vars_exist(CTEST_GENHTML_EXECUTABLE)
+    endif()
+
+    set_ifndef(LCOV_OUTPUT_LCOV_DIR "${CTEST_BINARY_DIRECTORY}/coverage-lcov/plain")
+    set_ifndef(LCOV_OUTPUT_REPORT_NAME "coverage.info")
+    set_ifndef(LCOV_OUTPUT_HTML_DIR "${CTEST_BINARY_DIRECTORY}/coverage-lcov/html")
+
+    set(LCOV_OPTIONS "--quiet")
+    set(LCOV_GENTHML_OPTIONS "--demangle-cpp")
+    if(LCOV_BRANCH_COVERAGE)
+        list(APPEND LCOV_OPTIONS "--rc" "lcov_branch_coverage=1")
+        list(APPEND LCOV_GENTHML_OPTIONS "--branch-coverage")
+    else()
+        list(APPEND LCOV_OPTIONS "--rc" "lcov_branch_coverage=0")
+        list(APPEND LCOV_GENTHML_OPTIONS "--no-branch-coverage")
+    endif()
+    if(LCOV_FUNCTION_COVERAGE)
+        list(APPEND LCOV_OPTIONS "--rc" "lcov_function_coverage=1")
+        list(APPEND LCOV_GENTHML_OPTIONS "--function-coverage" "--demangle-cpp")
+    else()
+        list(APPEND LCOV_OPTIONS "--rc" "lcov_function_coverage=0")
+        list(APPEND LCOV_GENTHML_OPTIONS "--no-function-coverage")
+    endif()
+
+    if(EXISTS "${LCOV_OUTPUT_LCOV_DIR}")
+        file(REMOVE_RECURSE "${LCOV_OUTPUT_LCOV_DIR}")
+    endif()
+    if(EXISTS "${LCOV_OUTPUT_HTML_DIR}")
+        file(REMOVE_RECURSE "${LCOV_OUTPUT_HTML_DIR}")
+    endif()
+
+    set(LCOV_COMMAND_LINE
+        "${CTEST_LCOV_EXECUTABLE}"
+        "--capture" "--no-external"
+        "--directory" "${CTEST_BINARY_DIRECTORY}"
+        "--base-directory" "${CTEST_SOURCE_DIRECTORY}"
+        "--output-file" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}"
+        ${LCOV_OPTIONS}
+        ${LCOV_EXTRA_LCOV_OPTIONS})
+    ctest_ext_info("Generate LCOV trace file : ${LCOV_COMMAND_LINE}")
+    execute_process(COMMAND ${LCOV_COMMAND_LINE} WORKING_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
+
+    if(LCOV_EXTRACT)
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}.tmp"
+            WORKING_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
+
+        set(LCOV_COMMAND_LINE
+            "${CTEST_LCOV_EXECUTABLE}"
+            "--extract" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}.tmp"
+            ${LCOV_EXTRACT}
+            "--output-file" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}"
+            ${LCOV_OPTIONS}
+            ${LCOV_EXTRA_LCOV_OPTIONS})
+        ctest_ext_info("Extract pattern from LCOV report : ${LCOV_COMMAND_LINE}")
+        execute_process(COMMAND ${LCOV_COMMAND_LINE} WORKING_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
+
+        file(REMOVE "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}.tmp")
+    endforeach()
+
+    if(LCOV_REMOVE)
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}.tmp"
+            WORKING_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
+
+        set(LCOV_COMMAND_LINE
+            "${CTEST_LCOV_EXECUTABLE}"
+            "--remove" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}.tmp"
+            ${LCOV_REMOVE}
+            "--output-file" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}"
+            ${LCOV_OPTIONS}
+            ${LCOV_EXTRA_LCOV_OPTIONS})
+        ctest_ext_info("Remove pattern from LCOV report : ${LCOV_COMMAND_LINE}")
+        execute_process(COMMAND ${LCOV_COMMAND_LINE} WORKING_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
+
+        file(REMOVE "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}.tmp")
+    endforeach()
+
+    if(NOT LCOV_SKIP_HTML)
+        set(GENHTML_COMMAND_LINE
+            "${CTEST_GENHTML_EXECUTABLE}" "${LCOV_OUTPUT_LCOV_DIR}/${LCOV_OUTPUT_REPORT_NAME}"
+            "--prefix" "${CTEST_SOURCE_DIRECTORY}"
+            "--output-directory" "${LCOV_OUTPUT_HTML_DIR}"
+            ${LCOV_OPTIONS}
+            ${LCOV_EXTRA_LCOV_OPTIONS}
+            ${LCOV_GENTHML_OPTIONS}
+            ${LCOV_EXTRA_GENTHML_OPTIONS})
+        ctest_ext_info("Convert LCOV report to HTML : ${GENHTML_COMMAND_LINE}")
+        execute_process(COMMAND ${GENHTML_COMMAND_LINE} WORKING_DIRECTORY "${CTEST_BINARY_DIRECTORY}")
+    endif()
+endfunction()

--- a/ctest/ctest-ext/modules/logging.cmake
+++ b/ctest/ctest-ext/modules/logging.cmake
@@ -1,0 +1,219 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# Logging commands
+#
+
+set_from_env(
+    CTEST_EXT_COLOR_OUTPUT
+)
+
+if(CTEST_EXT_COLOR_OUTPUT)
+    string(ASCII 27 CTEST_EXT_TEXT_STYLE_ESC)
+
+    set_ifndef(CTEST_EXT_TEXT_STYLE_RESET          "${CTEST_EXT_TEXT_STYLE_ESC}[m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLD           "${CTEST_EXT_TEXT_STYLE_ESC}[1m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_RED            "${CTEST_EXT_TEXT_STYLE_ESC}[31m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_GREEN          "${CTEST_EXT_TEXT_STYLE_ESC}[32m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_YELLOW         "${CTEST_EXT_TEXT_STYLE_ESC}[33m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BLUE           "${CTEST_EXT_TEXT_STYLE_ESC}[34m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_MAGENTA        "${CTEST_EXT_TEXT_STYLE_ESC}[35m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_CYAN           "${CTEST_EXT_TEXT_STYLE_ESC}[36m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_WHITE          "${CTEST_EXT_TEXT_STYLE_ESC}[37m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLDRED        "${CTEST_EXT_TEXT_STYLE_ESC}[1;31m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLD_GREEN     "${CTEST_EXT_TEXT_STYLE_ESC}[1;32m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLD_YELLOW    "${CTEST_EXT_TEXT_STYLE_ESC}[1;33m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLD_BLUE      "${CTEST_EXT_TEXT_STYLE_ESC}[1;34m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLD_MAGENTA   "${CTEST_EXT_TEXT_STYLE_ESC}[1;35m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLD_CYAN      "${CTEST_EXT_TEXT_STYLE_ESC}[1;36m")
+    set_ifndef(CTEST_EXT_TEXT_STYLE_BOLD_WHITE     "${CTEST_EXT_TEXT_STYLE_ESC}[1;37m")
+endif()
+
+#
+# ctest_ext_info(<message>)
+#
+#   Prints `<message>` to standard output with `[CTEST EXT INFO]` prefix for better visibility.
+#
+
+function(ctest_ext_info MSG)
+    message("${CTEST_EXT_TEXT_STYLE_BOLD_BLUE}[CTEST EXT INFO] ${MSG}${CTEST_EXT_TEXT_STYLE_RESET}")
+endfunction()
+
+#
+# ctext_ext_log_stage(<message>)
+#
+#   Log new stage start.
+#
+
+function(ctext_ext_log_stage MSG)
+    message("${CTEST_EXT_TEXT_STYLE_BOLD_CYAN}[CTEST EXT STAGE] ==========================================================================${CTEST_EXT_TEXT_STYLE_RESET}")
+    message("${CTEST_EXT_TEXT_STYLE_BOLD_CYAN}[CTEST EXT STAGE] ${MSG}")
+    message("${CTEST_EXT_TEXT_STYLE_BOLD_CYAN}[CTEST EXT STAGE] ==========================================================================${CTEST_EXT_TEXT_STYLE_RESET}")
+endfunction()
+
+#
+# ctest_ext_note(<message>)
+#
+#   Writes `<message>` both to console and to note file.
+#   The function appends `[CTEST EXT NOTE]` prefix to console output for better visibility.
+#   The note file is used in submit command.
+#
+#   The command will be available after `ctest_ext_start` call.
+#
+#   `CTEST_NOTES_LOG_FILE` variable must be defined.
+#
+
+function(ctest_ext_note MSG)
+    check_vars_def(CTEST_NOTES_LOG_FILE)
+
+    message("${CTEST_EXT_TEXT_STYLE_BOLD_MAGENTA}[CTEST EXT NOTE] ${MSG}${CTEST_EXT_TEXT_STYLE_RESET}")
+    file(APPEND "${CTEST_NOTES_LOG_FILE}" "${MSG}\n")
+endfunction()
+
+#
+# ctest_ext_dump_notes()
+#
+#   Dumps all CTest Ext launch options to note file.
+#   This is an internal function, which is used by `ctest_ext_start`.
+#
+
+function(ctest_ext_dump_notes)
+    check_vars_exist(CTEST_SOURCE_DIRECTORY)
+
+    if(CTEST_SCM_TOOL MATCHES "GIT")
+        get_git_repo_info("${CTEST_SOURCE_DIRECTORY}" GIT_CURRENT_BRANCH GIT_CURRENT_REVISION)
+    endif()
+
+    ctest_ext_note("CTest Ext configuration information:")
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_EXT_VERSION                       : ${CTEST_EXT_VERSION}")
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_PROJECT_NAME                      : ${CTEST_PROJECT_NAME}")
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_TARGET_SYSTEM                     : ${CTEST_TARGET_SYSTEM}")
+    ctest_ext_note("CTEST_MODEL                             : ${CTEST_MODEL}")
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_SITE                              : ${CTEST_SITE}")
+    ctest_ext_note("CTEST_BUILD_NAME                        : ${CTEST_BUILD_NAME}")
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_DASHBOARD_ROOT                    : ${CTEST_DASHBOARD_ROOT}")
+    ctest_ext_note("CTEST_SOURCE_DIRECTORY                  : ${CTEST_SOURCE_DIRECTORY}")
+    ctest_ext_note("CTEST_BINARY_DIRECTORY                  : ${CTEST_BINARY_DIRECTORY}")
+    ctest_ext_note("CTEST_NOTES_LOG_FILE                    : ${CTEST_NOTES_LOG_FILE}")
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_WITH_UPDATE                       : ${CTEST_WITH_UPDATE}")
+    if(CTEST_SCM_TOOL MATCHES "GIT")
+        if(CTEST_WITH_UPDATE)
+            ctest_ext_note("CTEST_GIT_COMMAND                       : ${CTEST_GIT_COMMAND}")
+            ctest_ext_note("CTEST_PROJECT_GIT_URL                   : ${CTEST_PROJECT_GIT_URL}")
+            ctest_ext_note("CTEST_PROJECT_GIT_BRANCH                : ${CTEST_PROJECT_GIT_BRANCH}")
+        endif()
+        ctest_ext_note("GIT_CURRENT_BRANCH                      : ${GIT_CURRENT_BRANCH}")
+        ctest_ext_note("GIT_CURRENT_REVISION                    : ${GIT_CURRENT_REVISION}")
+    endif()
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_UPDATE_CMAKE_CACHE                : ${CTEST_UPDATE_CMAKE_CACHE}")
+    ctest_ext_note("CTEST_EMPTY_BINARY_DIRECTORY            : ${CTEST_EMPTY_BINARY_DIRECTORY}")
+    ctest_ext_note("")
+
+    if(CTEST_UPDATE_CMAKE_CACHE)
+        ctest_ext_note("CTEST_CMAKE_GENERATOR                   : ${CTEST_CMAKE_GENERATOR}")
+        ctest_ext_note("CTEST_CONFIGURATION_TYPE                : ${CTEST_CONFIGURATION_TYPE}")
+        ctest_ext_note("CTEST_INITIAL_CACHE                     : ${CTEST_INITIAL_CACHE}")
+        ctest_ext_note("CTEST_CMAKE_EXTRA_OPTIONS               : ${CTEST_CMAKE_EXTRA_OPTIONS}")
+    endif()
+    ctest_ext_note("CTEST_BUILD_FLAGS                       : ${CTEST_BUILD_FLAGS}")
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_WITH_TESTS                        : ${CTEST_WITH_TESTS}")
+    if(CTEST_WITH_TESTS)
+        ctest_ext_note("CTEST_TEST_TIMEOUT                      : ${CTEST_TEST_TIMEOUT}")
+    endif()
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_WITH_COVERAGE                     : ${CTEST_WITH_COVERAGE}")
+    if(CTEST_WITH_COVERAGE)
+        ctest_ext_note("CTEST_COVERAGE_TOOL                     : ${CTEST_COVERAGE_TOOL}")
+        if(CTEST_COVERAGE_TOOL MATCHES "GCOVR")
+            ctest_ext_note("CTEST_GCOVR_EXECUTABLE                  : ${CTEST_GCOVR_EXECUTABLE}")
+            ctest_ext_note("CTEST_GCOVR_XML                         : ${CTEST_GCOVR_XML}")
+            ctest_ext_note("CTEST_GCOVR_HTML                        : ${CTEST_GCOVR_HTML}")
+            ctest_ext_note("CTEST_GCOVR_FILTER                      : ${CTEST_GCOVR_FILTER}")
+            ctest_ext_note("CTEST_GCOVR_OUTPUT_BASE_NAME            : ${CTEST_GCOVR_OUTPUT_BASE_NAME}")
+            ctest_ext_note("CTEST_GCOVR_XML_DIR                     : ${CTEST_GCOVR_XML_DIR}")
+            ctest_ext_note("CTEST_GCOVR_HTML_DIR                    : ${CTEST_GCOVR_HTML_DIR}")
+            ctest_ext_note("CTEST_GCOVR_EXTRA_OPTIONS               : ${CTEST_GCOVR_EXTRA_OPTIONS}")
+        endif()
+        if(CTEST_COVERAGE_TOOL MATCHES "LCOV")
+            ctest_ext_note("CTEST_LCOV_EXECUTABLE                   : ${CTEST_LCOV_EXECUTABLE}")
+            ctest_ext_note("CTEST_GENHTML_EXECUTABLE                : ${CTEST_GENHTML_EXECUTABLE}")
+            ctest_ext_note("CTEST_LCOV_BRANCH_COVERAGE              : ${CTEST_LCOV_BRANCH_COVERAGE}")
+            ctest_ext_note("CTEST_LCOV_FUNCTION_COVERAGE            : ${CTEST_LCOV_FUNCTION_COVERAGE}")
+            ctest_ext_note("CTEST_LCOV_SKIP_HTML                    : ${CTEST_LCOV_SKIP_HTML}")
+            ctest_ext_note("CTEST_LCOV_OUTPUT_LCOV_DIR              : ${CTEST_LCOV_OUTPUT_LCOV_DIR}")
+            ctest_ext_note("CTEST_LCOV_OUTPUT_REPORT_NAME           : ${CTEST_LCOV_OUTPUT_REPORT_NAME}")
+            ctest_ext_note("CTEST_LCOV_OUTPUT_HTML_DIR              : ${CTEST_LCOV_OUTPUT_HTML_DIR}")
+            ctest_ext_note("CTEST_LCOV_EXTRACT                      : ${CTEST_LCOV_EXTRACT}")
+            ctest_ext_note("CTEST_LCOV_REMOVE                       : ${CTEST_LCOV_REMOVE}")
+            ctest_ext_note("CTEST_LCOV_EXTRA_LCOV_OPTIONS           : ${CTEST_LCOV_EXTRA_LCOV_OPTIONS}")
+            ctest_ext_note("CTEST_LCOV_EXTRA_GENTHML_OPTIONS        : ${CTEST_LCOV_EXTRA_GENTHML_OPTIONS}")
+        endif()
+        if(CTEST_COVERAGE_TOOL MATCHES "CDASH")
+            ctest_ext_note("CTEST_COVERAGE_COMMAND                  : ${CTEST_COVERAGE_COMMAND}")
+            ctest_ext_note("CTEST_COVERAGE_EXTRA_FLAGS              : ${CTEST_COVERAGE_EXTRA_FLAGS}")
+        endif()
+    endif()
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_WITH_DYNAMIC_ANALYSIS             : ${CTEST_WITH_DYNAMIC_ANALYSIS}")
+    if(CTEST_WITH_DYNAMIC_ANALYSIS)
+        ctest_ext_note("CTEST_DYNAMIC_ANALYSIS_TOOL             : ${CTEST_DYNAMIC_ANALYSIS_TOOL}")
+        if(CTEST_DYNAMIC_ANALYSIS_TOOL MATCHES "CDASH")
+            ctest_ext_note("CTEST_MEMORYCHECK_COMMAND               : ${CTEST_MEMORYCHECK_COMMAND}")
+            ctest_ext_note("CTEST_MEMORYCHECK_SUPPRESSIONS_FILE     : ${CTEST_MEMORYCHECK_SUPPRESSIONS_FILE}")
+            ctest_ext_note("CTEST_MEMORYCHECK_COMMAND_OPTIONS       : ${CTEST_MEMORYCHECK_COMMAND_OPTIONS}")
+        endif()
+    endif()
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_WITH_SUBMIT                       : ${CTEST_WITH_SUBMIT}")
+    if(CTEST_WITH_SUBMIT)
+        ctest_ext_note("CTEST_NOTES_FILES                       : ${CTEST_NOTES_FILES}")
+        ctest_ext_note("CTEST_UPLOAD_FILES                      : ${CTEST_UPLOAD_FILES}")
+    endif()
+    ctest_ext_note("")
+
+    ctest_ext_note("CTEST_TRACK                             : ${CTEST_TRACK}")
+    ctest_ext_note("CTEST_TMP_BASE_DIR                      : ${CTEST_TMP_BASE_DIR}")
+    ctest_ext_note("CTEST_EXT_COLOR_OUTPUT                  : ${CTEST_EXT_COLOR_OUTPUT}")
+    ctest_ext_note("")
+endfunction()

--- a/ctest/ctest-ext/modules/system.cmake
+++ b/ctest/ctest-ext/modules/system.cmake
@@ -1,0 +1,68 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# System commands
+#
+
+#
+# create_tmp_dir(<output_variable> [BASE_DIR <path to base temp directory>])
+#
+#   Creates temporary directory and returns path to it via `<output_variable>`.
+#
+#   `BASE_DIR` can be used to specify location for base temporary path,
+#   if it is not defined `TEMP`, `TMP` or `TMPDIR` environment variables will be used.
+#
+
+function(create_tmp_dir OUT_VAR)
+    set(options "")
+    set(oneValueArgs "BASE_DIR")
+    set(multiValueArgs "")
+    cmake_parse_arguments(TMP "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    override_from_ctest_vars(TMP_BASE_DIR)
+
+    if(NOT DEFINED TMP_BASE_DIR)
+        foreach(dir "$ENV{TEMP}" "$ENV{TMP}" "$ENV{TMPDIR}" "/tmp")
+            if (EXISTS "${dir}")
+                set(TMP_BASE_DIR "${dir}")
+            endif()
+        endforeach()
+    endif()
+
+    check_vars_exist(TMP_BASE_DIR)
+
+    # TODO : find better way to avoid collisions.
+    string(RANDOM rand_name)
+    while(EXISTS "${TMP_BASE_DIR}/${rand_name}")
+        string(RANDOM rand_name)
+    endwhile()
+
+    set(tmp_dir "${TMP_BASE_DIR}/${rand_name}")
+
+    ctest_ext_info("Creating temporary directory : ${tmp_dir}")
+    file(MAKE_DIRECTORY "${tmp_dir}")
+
+    set(${OUT_VAR} "${tmp_dir}" PARENT_SCOPE)
+endfunction()

--- a/ctest/ctest-ext/modules/vars.cmake
+++ b/ctest/ctest-ext/modules/vars.cmake
@@ -1,0 +1,140 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vladislav Vinogradov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+#
+# Variables management commands
+#
+
+#
+# set_ifndef(<variable> <value>)
+#
+#   Sets `<variable>` to the `<value>`, only if the `<variable>` is not defined.
+#
+
+function(set_ifndef VAR)
+    if(NOT DEFINED ${VAR})
+        set(${VAR} "${ARGN}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+#
+# set_from_env(<variable1> <variable2> ...)
+#
+#   Sets `<variableN>` to the value of environment variable with the same name,
+#   only if the `<variableN>` is not defined and the environment variable is defined.
+#
+
+function(set_from_env)
+    foreach(var ${ARGN})
+        if(NOT DEFINED ${var} AND DEFINED ENV{${var}})
+            set(${var} "$ENV{${var}}" PARENT_SCOPE)
+        endif()
+    endforeach()
+endfunction()
+
+#
+# override_from_ctest_vars(<variable1> <variable2> ...)
+#
+#   Overrides all variables from `CTEST_<var_name>` values, if they are defined.
+#
+
+function(override_from_ctest_vars)
+    foreach(var ${ARGN})
+        if(DEFINED CTEST_${var})
+            set(${var} "${CTEST_${var}}" PARENT_SCOPE)
+        endif()
+    endforeach()
+endfunction()
+
+#
+# check_vars_def(<variable1> <variable2> ...)
+#
+#   Checks that all variables are defined.
+#
+
+function(check_vars_def)
+    foreach(var ${ARGN})
+        if(NOT DEFINED ${var})
+            message(FATAL_ERROR "${var} is not defined")
+        endif()
+    endforeach()
+endfunction()
+
+#
+# check_vars_exist(<variable1> <variable2> ...)
+#
+#   Checks that all variables are defined and point to existed file/directory.
+#
+
+function(check_vars_exist)
+    check_vars_def(${ARGN})
+
+    foreach(var ${ARGN})
+        if(NOT EXISTS "${${var}}")
+            message(FATAL_ERROR "${var} = ${${var}} is not exist")
+        endif()
+    endforeach()
+endfunction()
+
+#
+# check_if_matches(<variable> <regexp1> <regexp2> ...)
+#
+#   Checks that `<variable>` matches one of the regular expression from the input list.
+#
+
+function(check_if_matches VAR)
+    check_vars_def(${VAR})
+
+    set(found FALSE)
+    foreach(regexp ${ARGN})
+        if(${VAR} MATCHES "${regexp}")
+            set(found TRUE)
+            break()
+        endif()
+    endforeach()
+
+    if(NOT found)
+        message(FATAL_ERROR "${VAR}=${${VAR}} must match one from ${ARGN} list")
+    endif()
+endfunction()
+
+#
+# list_filter_out(<list> <regexp1> <regexp2> ...)
+#
+#   Filter out all items in the `<list>`, which match one of the regular expression from the input list.
+#
+
+function(list_filter_out LST_VAR)
+    set(tmp_lst ${${LST_VAR}})
+
+    foreach(item ${tmp_lst})
+        foreach(regex ${ARGN})
+            if(item MATCHES "${regex}")
+                list(REMOVE_ITEM tmp_lst "${item}")
+            endif()
+        endforeach()
+    endforeach()
+
+    set(${LST_VAR} "${tmp_lst}" PARENT_SCOPE)
+endfunction()

--- a/ctest/opencv_test.cmake
+++ b/ctest/opencv_test.cmake
@@ -1,0 +1,64 @@
+#
+# Include CTest Ext module
+#
+
+if(NOT CTEST_EXT_INCLUDED)
+    function(download_ctest_ext)
+        message("Download latest version of CTest Extension module")
+
+        find_package(Git QUIET)
+
+        set(repo_url "https://github.com/jet47/ctest-ext.git")
+        set(repo_dir "${CMAKE_CURRENT_LIST_DIR}/ctest-ext")
+        set(tmp_dir "${CMAKE_CURRENT_LIST_DIR}/ctest-ext-tmp")
+
+        if(NOT EXISTS "${repo_dir}")
+            set(CTEST_CHECKOUT_COMMAND "${GIT_EXECUTABLE} clone ${repo_url} ${repo_dir}")
+        endif()
+        set(CTEST_UPDATE_COMMAND "${GIT_EXECUTABLE}")
+
+        ctest_start("CTestExt" "${repo_dir}" "${tmp_dir}")
+        ctest_update(SOURCE "${repo_dir}")
+
+        file(REMOVE_RECURSE "${tmp_dir}")
+
+        set(CTEST_EXT_MODULE_PATH "${repo_dir}" PARENT_SCOPE)
+    endfunction()
+
+    if(NOT DEFINED CTEST_EXT_MODULE_PATH)
+        if(DEFINED ENV{CTEST_EXT_MODULE_PATH} AND EXISTS "$ENV{CTEST_EXT_MODULE_PATH}/ctest_ext.cmake")
+            set(CTEST_EXT_MODULE_PATH "$ENV{CTEST_EXT_MODULE_PATH}")
+        elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/ctest-ext/ctest_ext.cmake")
+            set(CTEST_EXT_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ctest-ext")
+        else()
+            download_ctest_ext()
+        endif()
+    endif()
+
+    include("${CTEST_EXT_MODULE_PATH}/ctest_ext.cmake")
+endif()
+
+#
+# Repository settings
+#
+
+set_ifndef(CTEST_PROJECT_NAME           "OpenCV 3.0")
+
+set_ifndef(CTEST_SCM_TOOL               "GIT")
+set_ifndef(CTEST_PROJECT_GIT_URL        "https://github.com/Itseez/opencv.git")
+set_ifndef(CTEST_PROJECT_GIT_BRANCH     "master")
+set_ifndef(CTEST_WITH_UPDATE            FALSE)
+
+#
+# Initialize testing
+#
+
+ctest_ext_init()
+
+#
+# Include main testing script from project source tree
+#
+
+set_ifndef(OPENCV_INTERNAL_TEST_SCRIPT  "${CTEST_SOURCE_DIRECTORY}/ctest/opencv_test_internal.cmake")
+
+include("${OPENCV_INTERNAL_TEST_SCRIPT}")

--- a/ctest/opencv_test_internal.cmake
+++ b/ctest/opencv_test_internal.cmake
@@ -1,0 +1,362 @@
+#
+# Check supported targets and models
+#
+
+check_if_matches(CTEST_TARGET_SYSTEM    "^Linux" "^Windows" "^Android" "^MacOS")
+check_if_matches(CTEST_MODEL            "^Nightly$" "^Experimental$" "^Continuous$" "^Release$" "^Performance$" "^MemCheck$" "^Documentation$")
+
+#
+# Configure the testing model
+#
+
+if(CTEST_MODEL MATCHES "Continuous")
+    set_ifndef(CTEST_EMPTY_BINARY_DIRECTORY FALSE)
+endif()
+
+if(CTEST_TARGET_SYSTEM MATCHES "(Android|cross)" OR CTEST_MODEL MATCHES "(MemCheck|Documentation)")
+    set_ifndef(CTEST_WITH_TESTS FALSE)
+endif()
+
+if(CTEST_MODEL MATCHES "(Performance|MemCheck)")
+    # 4 hours
+    set_ifndef(CTEST_TEST_TIMEOUT   14400)
+else()
+    # 1 hour
+    set_ifndef(CTEST_TEST_TIMEOUT   3600)
+endif()
+
+if(CTEST_MODEL MATCHES "Nightly")
+    if(CTEST_COVERAGE_COMMAND)
+        set_ifndef(CTEST_WITH_COVERAGE  TRUE)
+        set_ifndef(CTEST_COVERAGE_TOOL  "CDASH")
+    endif()
+endif()
+
+if(CTEST_MODEL MATCHES "MemCheck")
+    set_ifndef(CTEST_WITH_DYNAMIC_ANALYSIS  TRUE)
+    set_ifndef(CTEST_DYNAMIC_ANALYSIS_TOOL  "CDASH")
+endif()
+
+#
+# Configure extra/contrib repositories
+#
+
+if(NOT OPENCV_TEST_DATA_PATH)
+    set_ifndef(OPENCV_EXTRA_SOURCE_DIRECTORY    "${CTEST_DASHBOARD_ROOT}/extra")
+    set_ifndef(OPENCV_EXTRA_GIT_URL             "https://github.com/Itseez/opencv_extra.git")
+    set_ifndef(OPENCV_EXTRA_GIT_BRANCH          "master")
+    set_ifndef(OPENCV_TEST_DATA_PATH            "${OPENCV_EXTRA_SOURCE_DIRECTORY}/testdata")
+endif()
+
+set_ifndef(OPENCV_contrib_GIT_URL               "https://github.com/Itseez/opencv_contrib.git")
+set_ifndef(OPENCV_contrib_GIT_BRANCH            "master")
+
+#
+# Configure OpenCV options
+#
+
+if(CTEST_TARGET_SYSTEM MATCHES "Android")
+    set_ifndef(OPENCV_BUILD_SHARED_LIBS FALSE)
+else()
+    set_ifndef(OPENCV_BUILD_SHARED_LIBS TRUE)
+endif()
+
+if(CTEST_MODEL MATCHES "Nightly")
+    set_ifndef(OPENCV_BUILD_EXAMPLES TRUE)
+else()
+    set_ifndef(OPENCV_BUILD_EXAMPLES FALSE)
+endif()
+
+if(OPENCV_FEATURES_ONLY)
+    list(REMOVE_DUPLICATES OPENCV_FEATURES_ONLY)
+
+    set(OPENCV_FEATURES_ENABLE "")
+    set(OPENCV_FEATURES_DISABLE "")
+
+    set(ALL_WITH_OPTIONS "")
+    file(STRINGS "${CTEST_SOURCE_DIRECTORY}/CMakeLists.txt" cmake_lists)
+    foreach(line ${cmake_lists})
+        string(REGEX MATCH "OCV_OPTION\\(WITH_([A-Z0-9_]+) " output ${line})
+        if(output)
+            list(APPEND ALL_WITH_OPTIONS "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+
+    foreach(item ${ALL_WITH_OPTIONS})
+        if(item MATCHES "${OPENCV_FEATURES_ONLY}")
+            list(APPEND OPENCV_FEATURES_ENABLE "${item}")
+        else()
+            list(APPEND OPENCV_FEATURES_DISABLE "${item}")
+        endif()
+    endforeach()
+else()
+    if(CTEST_TARGET_SYSTEM MATCHES "cross")
+        list(APPEND OPENCV_FEATURES_DISABLE "VTK")
+    endif()
+
+    if(OPENCV_FEATURES_ENABLE)
+        list(REMOVE_DUPLICATES OPENCV_FEATURES_ENABLE)
+    endif()
+    if(OPENCV_FEATURES_DISABLE)
+        list(REMOVE_DUPLICATES OPENCV_FEATURES_DISABLE)
+    endif()
+    foreach(item ${OPENCV_FEATURES_DISABLE})
+        if(OPENCV_FEATURES_ENABLE MATCHES "${item}")
+            list(REMOVE_ITEM OPENCV_FEATURES_ENABLE "${item}")
+        endif()
+    endforeach()
+endif()
+
+#
+# Checkout/update opencv_extra and opencv_contrib if needed
+#
+
+if(OPENCV_EXTRA_SOURCE_DIRECTORY)
+    ctext_ext_log_stage("Checkout/update testdata")
+
+    if(NOT EXISTS "${OPENCV_EXTRA_SOURCE_DIRECTORY}")
+        check_vars_def(OPENCV_EXTRA_GIT_URL OPENCV_EXTRA_GIT_BRANCH)
+
+        clone_git_repo("${OPENCV_EXTRA_GIT_URL}" "${OPENCV_EXTRA_SOURCE_DIRECTORY}"
+            BRANCH "${OPENCV_EXTRA_GIT_BRANCH}")
+
+        set(HAVE_UPDATES TRUE)
+    elseif(CTEST_WITH_UPDATE AND CTEST_STAGE MATCHES "Start")
+        check_vars_def(OPENCV_EXTRA_GIT_BRANCH)
+
+        update_git_repo("${OPENCV_EXTRA_SOURCE_DIRECTORY}"
+            BRANCH "${OPENCV_EXTRA_GIT_BRANCH}"
+            UPDATE_COUNT_OUTPUT update_count)
+
+        if(update_count GREATER "0")
+            set(HAVE_UPDATES TRUE)
+        endif()
+    endif()
+endif()
+
+if(OPENCV_EXTRA_MODULES)
+    ctext_ext_log_stage("Checkout/update extra modules")
+
+    foreach(module ${OPENCV_EXTRA_MODULES})
+        ctest_ext_info("Module: ${module}")
+
+        set_ifndef(OPENCV_${module}_SOURCE_DIRECTORY "${CTEST_DASHBOARD_ROOT}/${module}")
+        set_ifndef(OPENCV_${module}_MODULES_DIRECTORY "${OPENCV_${module}_SOURCE_DIRECTORY}/modules")
+
+        list(APPEND OPENCV_EXTRA_MODULES_PATH "${OPENCV_${module}_MODULES_DIRECTORY}")
+
+        if(NOT EXISTS "${OPENCV_${module}_SOURCE_DIRECTORY}")
+            check_vars_def(OPENCV_${module}_GIT_URL OPENCV_${module}_GIT_BRANCH)
+
+            clone_git_repo("${OPENCV_${module}_GIT_URL}" "${OPENCV_${module}_SOURCE_DIRECTORY}"
+                BRANCH "${OPENCV_${module}_GIT_BRANCH}")
+
+            set(HAVE_UPDATES TRUE)
+        elseif(CTEST_WITH_UPDATE AND CTEST_STAGE MATCHES "Start")
+            check_vars_def(OPENCV_${module}_GIT_BRANCH)
+
+            update_git_repo("${OPENCV_${module}_SOURCE_DIRECTORY}"
+                BRANCH "${OPENCV_${module}_GIT_BRANCH}"
+                UPDATE_COUNT_OUTPUT update_count)
+
+            if(update_count GREATER "0")
+                set(HAVE_UPDATES TRUE)
+            endif()
+        endif()
+    endforeach()
+endif()
+
+#
+# Checks for Continuous model
+#
+
+set(IS_CONTINUOUS FALSE)
+if(CTEST_MODEL MATCHES "Continuous")
+    set(IS_CONTINUOUS TRUE)
+endif()
+
+set(IS_BINARY_EMPTY FALSE)
+if(NOT EXISTS "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt")
+    set(IS_BINARY_EMPTY TRUE)
+endif()
+
+if(IS_CONTINUOUS AND NOT IS_BINARY_EMPTY AND NOT HAVE_UPDATES)
+    ctest_ext_info("Continuous model : no updates")
+    return()
+endif()
+
+#
+# Set CMake options
+#
+
+if(CTEST_TARGET_SYSTEM MATCHES "Windows")
+    if(CTEST_TARGET_SYSTEM MATCHES "64")
+        set_ifndef(CTEST_CMAKE_GENERATOR "Visual Studio 12 Win64")
+    else()
+        set_ifndef(CTEST_CMAKE_GENERATOR "Visual Studio 12")
+    endif()
+else()
+    set_ifndef(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+endif()
+
+if(CTEST_MODEL MATCHES "(Release|Performance)")
+    set_ifndef(CTEST_CONFIGURATION_TYPE "Release")
+else()
+    set_ifndef(CTEST_CONFIGURATION_TYPE "Debug")
+endif()
+
+if(CTEST_TARGET_SYSTEM MATCHES "Android")
+    add_cmake_cache_entry("CMAKE_TOOLCHAIN_FILE" TYPE "FILEPATH" "${CTEST_SOURCE_DIRECTORY}/platforms/android/android.toolchain.cmake")
+elseif(CTEST_TARGET_SYSTEM MATCHES "Linux.*ARMHF-cross")
+    add_cmake_cache_entry("CMAKE_TOOLCHAIN_FILE" TYPE "FILEPATH" "${CTEST_SOURCE_DIRECTORY}/platforms/linux/arm-gnueabi.toolchain.cmake")
+endif()
+
+if(OPENCV_TEST_DATA_PATH AND EXISTS "${OPENCV_TEST_DATA_PATH}")
+    add_cmake_cache_entry("OPENCV_TEST_DATA_PATH" TYPE "PATH" "${OPENCV_TEST_DATA_PATH}")
+endif()
+
+if(OPENCV_EXTRA_MODULES_PATH)
+    add_cmake_cache_entry("OPENCV_EXTRA_MODULES_PATH" TYPE "STRING" "${OPENCV_EXTRA_MODULES_PATH}")
+endif()
+
+add_cmake_cache_entry("ENABLE_CTEST" TYPE "BOOL" "ON")
+
+if(CTEST_WITH_COVERAGE)
+    add_cmake_cache_entry("ENABLE_COVERAGE" TYPE "BOOL" "ON")
+else()
+    add_cmake_cache_entry("ENABLE_COVERAGE" TYPE "BOOL" "OFF")
+endif()
+
+add_cmake_cache_entry("BUILD_SHARED_LIBS" TYPE "BOOL" "${OPENCV_BUILD_SHARED_LIBS}")
+add_cmake_cache_entry("BUILD_EXAMPLES"    TYPE "BOOL" "${OPENCV_BUILD_EXAMPLES}")
+add_cmake_cache_entry("BUILD_TESTS"       TYPE "BOOL" "ON")
+add_cmake_cache_entry("BUILD_PERF_TESTS"  TYPE "BOOL" "ON")
+
+if(CTEST_MODEL MATCHES "Documentation")
+    add_cmake_cache_entry("BUILD_DOCS" TYPE "BOOL" "ON")
+endif()
+
+foreach(item ${OPENCV_FEATURES_ENABLE})
+    add_cmake_cache_entry("WITH_${item}" TYPE "BOOL" "ON")
+endforeach()
+
+foreach(item ${OPENCV_FEATURES_DISABLE})
+    add_cmake_cache_entry("WITH_${item}" TYPE "BOOL" "OFF")
+endforeach()
+
+if(CTEST_MODEL MATCHES "Release")
+    add_cmake_cache_entry("INSTALL_TESTS" TYPE "BOOL" "ON")
+
+    if(CTEST_TARGET_SYSTEM MATCHES "Windows")
+        add_cmake_cache_entry("CPACK_GENERATOR" TYPE "STRING" "ZIP")
+    else()
+        add_cmake_cache_entry("CPACK_GENERATOR" TYPE "STRING" "TGZ")
+    endif()
+endif()
+
+#
+# Start testing
+#
+
+ctest_ext_start()
+
+if(CTEST_STAGE MATCHES "Start")
+    ctest_ext_note("OPENCV_EXTRA_SOURCE_DIRECTORY           : ${OPENCV_EXTRA_SOURCE_DIRECTORY}")
+    ctest_ext_note("OPENCV_EXTRA_GIT_URL                    : ${OPENCV_EXTRA_GIT_URL}")
+    ctest_ext_note("OPENCV_EXTRA_GIT_BRANCH                 : ${OPENCV_EXTRA_GIT_BRANCH}")
+    ctest_ext_note("OPENCV_TEST_DATA_PATH                   : ${OPENCV_TEST_DATA_PATH}")
+    ctest_ext_note("")
+
+    ctest_ext_note("OPENCV_EXTRA_MODULES                    : ${OPENCV_EXTRA_MODULES}")
+    foreach(module ${OPENCV_EXTRA_MODULES})
+        ctest_ext_note("OPENCV_${module}_SOURCE_DIRECTORY       : ${OPENCV_${module}_SOURCE_DIRECTORY}")
+        ctest_ext_note("OPENCV_${module}_MODULES_DIRECTORY      : ${OPENCV_${module}_MODULES_DIRECTORY}")
+        ctest_ext_note("OPENCV_${module}_GIT_URL                : ${OPENCV_${module}_GIT_URL}")
+        ctest_ext_note("OPENCV_${module}_GIT_BRANCH             : ${OPENCV_${module}_GIT_BRANCH}")
+    endforeach()
+    ctest_ext_note("OPENCV_EXTRA_MODULES_PATH               : ${OPENCV_EXTRA_MODULES_PATH}")
+    ctest_ext_note("")
+
+    ctest_ext_note("OPENCV_BUILD_SHARED_LIBS                : ${OPENCV_BUILD_SHARED_LIBS}")
+    ctest_ext_note("OPENCV_BUILD_EXAMPLES                   : ${OPENCV_BUILD_EXAMPLES}")
+    ctest_ext_note("")
+
+    ctest_ext_note("OPENCV_FEATURES_ONLY                    : ${OPENCV_FEATURES_ONLY}")
+    ctest_ext_note("OPENCV_FEATURES_ENABLE                  : ${OPENCV_FEATURES_ENABLE}")
+    ctest_ext_note("OPENCV_FEATURES_DISABLE                 : ${OPENCV_FEATURES_DISABLE}")
+    ctest_ext_note("")
+endif()
+
+#
+# Remove previous test reports
+#
+
+set(TEST_REPORTS_DIR "${CTEST_BINARY_DIRECTORY}/test-reports")
+set(ACCURACY_REPORTS_DIR "${TEST_REPORTS_DIR}/accuracy")
+set(PERF_REPORTS_DIR "${TEST_REPORTS_DIR}/performance")
+set(SANITY_REPORTS_DIR "${TEST_REPORTS_DIR}/sanity")
+
+if(CTEST_STAGE MATCHES "Configure")
+    if(NOT CTEST_EMPTY_BINARY_DIRECTORY AND EXISTS "${TEST_REPORTS_DIR}")
+        file(REMOVE_RECURSE "${TEST_REPORTS_DIR}")
+    endif()
+endif()
+
+#
+# Configure
+#
+
+ctest_ext_configure()
+
+#
+# Build
+#
+
+if(CTEST_MODEL MATCHES "Release")
+    ctest_ext_build(TARGETS "ALL" "package")
+elseif(CTEST_MODEL MATCHES "Documentation")
+    ctest_ext_build(TARGET "doxygen")
+else()
+    ctest_ext_build()
+endif()
+
+#
+# Test
+#
+
+if(CTEST_MODEL MATCHES "Performance")
+    ctest_ext_test(
+        INCLUDE_LABEL "Performance")
+else()
+    ctest_ext_test(
+        EXCLUDE_LABEL "Performance"
+        EXCLUDE "^(opencv_test_viz|opencv_test_highgui|opencv_test_shape|opencv_sanity_videoio)$")
+endif()
+
+#
+# Coverage
+#
+
+ctest_ext_coverage(
+    CDASH
+        LABELS "Module")
+
+#
+# DynamicAnalysis
+#
+
+ctest_ext_dynamic_analysis(
+    CDASH
+        INCLUDE_LABEL "Accuracy"
+        EXCLUDE "^(opencv_test_viz|opencv_test_highgui|opencv_test_shape)$")
+
+#
+# Submit
+#
+
+if(CTEST_MODEL MATCHES "Performance")
+    file(GLOB perf_xmls "${PERF_REPORTS_DIR}/*.xml")
+    list(APPEND CTEST_UPLOAD_FILES ${perf_xmls})
+endif()
+
+ctest_ext_submit()

--- a/ctest/template.build.cmake
+++ b/ctest/template.build.cmake
@@ -1,0 +1,46 @@
+#
+# Mandatory settings (must be set)
+#
+
+set(CTEST_TARGET_SYSTEM                      "@CTEST_TARGET_SYSTEM@")
+set(CTEST_MODEL                              "@MODEL@")
+
+set(CTEST_SITE                               "@CTEST_SITE@")
+set(CTEST_BUILD_NAME                         "@CTEST_BUILD_NAME@")
+
+set(CTEST_DASHBOARD_ROOT                     "@CMAKE_CURRENT_BINARY_DIR@")
+set(CTEST_SOURCE_DIRECTORY                   "@CMAKE_SOURCE_DIR@")
+set(CTEST_BINARY_DIRECTORY                   "@CMAKE_BINARY_DIR@")
+
+#
+# Repository settings (mandatory, if the script should support checkout/update steps)
+#
+
+set(CTEST_WITH_UPDATE                        FALSE)
+set(CTEST_GIT_COMMAND                        "@GIT_EXECUTABLE@")
+
+#
+# Project settings (optional)
+#
+
+set(OPENCV_TEST_DATA_PATH                    "@OPENCV_TEST_DATA_PATH@")
+
+set(OPENCV_EXTRA_MODULES                     "")
+set(OPENCV_EXTRA_MODULES_PATH                @OPENCV_EXTRA_MODULES_PATH@)
+
+#
+# Testing settings (optional)
+#
+
+set(CTEST_UPDATE_CMAKE_CACHE                 FALSE)
+set(CTEST_EMPTY_BINARY_DIRECTORY             FALSE)
+
+set(CTEST_CMAKE_GENERATOR                    "@CMAKE_GENERATOR@")
+set(CTEST_CONFIGURATION_TYPE                 "@CMAKE_BUILD_TYPE@")
+set(CTEST_BUILD_FLAGS                        @CTEST_BUILD_FLAGS@)
+
+#
+# Include common part of client scripts
+#
+
+include("${CTEST_SCRIPT_DIRECTORY}/opencv_test.cmake")

--- a/modules/cudev/test/CMakeLists.txt
+++ b/modules/cudev/test/CMakeLists.txt
@@ -46,7 +46,5 @@ if(OCV_DEPENDENCIES_FOUND)
     set_target_properties(${the_target} PROPERTIES FOLDER "tests accuracy")
   endif()
 
-  enable_testing()
-  get_target_property(LOC ${the_target} LOCATION)
-  add_test(${the_target} "${LOC}")
+  ocv_add_test_from_target("${the_target}" "Accuracy" "${the_target}")
 endif()

--- a/modules/cudev/test/CMakeLists.txt
+++ b/modules/cudev/test/CMakeLists.txt
@@ -32,6 +32,10 @@ if(OCV_DEPENDENCIES_FOUND)
   ocv_target_link_libraries(${the_target} ${test_deps} ${OPENCV_LINKER_LIBS} ${CUDA_LIBRARIES})
   add_dependencies(opencv_tests ${the_target})
 
+  set_target_properties(${the_target} PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL}")
+  set_source_files_properties(${OPENCV_TEST_${the_module}_SOURCES} ${${the_target}_pch}
+    PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};AccuracyTest")
+
   # Additional target properties
   set_target_properties(${the_target} PROPERTIES
     DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -2954,6 +2954,9 @@ MatComparator::operator()(const char* expr1, const char* expr2,
 
 void printVersionInfo(bool useStdOut)
 {
+    // Tell CTest not to discard any output
+    if(useStdOut) std::cout << "CTEST_FULL_OUTPUT" << std::endl;
+
     ::testing::Test::RecordProperty("cv_version", CV_VERSION);
     if(useStdOut) std::cout << "OpenCV version: " << CV_VERSION << std::endl;
 


### PR DESCRIPTION
The requests adds new CTest scripts for OpenCV dashboard testing, which includes:

* repository update;
* project configuration via CMake;
* building;
* testing;
* code coverage analysis;
* memory check analysis via valgrind;
* packaging;
* submitting results to remote server (currently disabled).

The new scripts will allow users to perform full OpenCV testing on their machines and send reports to a common place, for example CDash server (http://my.cdash.org/index.php). This can be used as an extension for current testing procedure to cover larger number of possible configurations (OS, compilers, features like CUDA, etc.).

For detailed information please refer to the [README](https://github.com/jet47/opencv/blob/ctest-dashboard-testing/ctest/README.md).