### PR TITLE
Fix errors while compiling with c++11 flag

### DIFF
--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -540,11 +540,11 @@ bool CvCaptureCAM::setProperty(int property_id, double value) {
             return true;
 
         case CV_CAP_PROP_IOS_DEVICE_FOCUS:
-            if ([mCaptureDevice isFocusModeSupported:(int)value]){
+            if ([mCaptureDevice isFocusModeSupported:(AVCaptureFocusMode)value]){
                 NSError* error = nil;
                 [mCaptureDevice lockForConfiguration:&error];
                 if (error) return false;
-                [mCaptureDevice setFocusMode:(int)value];
+                [mCaptureDevice setFocusMode:(AVCaptureFocusMode)value];
                 [mCaptureDevice unlockForConfiguration];
                 //NSLog(@"Focus set");
                 return true;
@@ -553,11 +553,11 @@ bool CvCaptureCAM::setProperty(int property_id, double value) {
             }
 
         case CV_CAP_PROP_IOS_DEVICE_EXPOSURE:
-            if ([mCaptureDevice isExposureModeSupported:(int)value]){
+            if ([mCaptureDevice isExposureModeSupported:(AVCaptureExposureMode)value]){
                 NSError* error = nil;
                 [mCaptureDevice lockForConfiguration:&error];
                 if (error) return false;
-                [mCaptureDevice setExposureMode:(int)value];
+                [mCaptureDevice setExposureMode:(AVCaptureExposureMode)value];
                 [mCaptureDevice unlockForConfiguration];
                 //NSLog(@"Exposure set");
                 return true;
@@ -566,11 +566,11 @@ bool CvCaptureCAM::setProperty(int property_id, double value) {
             }
 
         case CV_CAP_PROP_IOS_DEVICE_FLASH:
-            if ( [mCaptureDevice hasFlash] && [mCaptureDevice isFlashModeSupported:(int)value]){
+            if ( [mCaptureDevice hasFlash] && [mCaptureDevice isFlashModeSupported:(AVCaptureFlashMode)value]){
                 NSError* error = nil;
                 [mCaptureDevice lockForConfiguration:&error];
                 if (error) return false;
-                [mCaptureDevice setFlashMode:(int)value];
+                [mCaptureDevice setFlashMode:(AVCaptureFlashMode)value];
                 [mCaptureDevice unlockForConfiguration];
                 //NSLog(@"Flash mode set");
                 return true;
@@ -579,11 +579,11 @@ bool CvCaptureCAM::setProperty(int property_id, double value) {
             }
 
         case CV_CAP_PROP_IOS_DEVICE_WHITEBALANCE:
-            if ([mCaptureDevice isWhiteBalanceModeSupported:(int)value]){
+            if ([mCaptureDevice isWhiteBalanceModeSupported:(AVCaptureWhiteBalanceMode)value]){
                 NSError* error = nil;
                 [mCaptureDevice lockForConfiguration:&error];
                 if (error) return false;
-                [mCaptureDevice setWhiteBalanceMode:(int)value];
+                [mCaptureDevice setWhiteBalanceMode:(AVCaptureWhiteBalanceMode)value];
                 [mCaptureDevice unlockForConfiguration];
                 //NSLog(@"White balance set");
                 return true;
@@ -592,11 +592,11 @@ bool CvCaptureCAM::setProperty(int property_id, double value) {
             }
 
         case CV_CAP_PROP_IOS_DEVICE_TORCH:
-            if ([mCaptureDevice hasFlash] && [mCaptureDevice isTorchModeSupported:(int)value]){
+            if ([mCaptureDevice hasFlash] && [mCaptureDevice isTorchModeSupported:(AVCaptureTorchMode)value]){
                 NSError* error = nil;
                 [mCaptureDevice lockForConfiguration:&error];
                 if (error) return false;
-                [mCaptureDevice setTorchMode:(int)value];
+                [mCaptureDevice setTorchMode:(AVCaptureTorchMode)value];
                 [mCaptureDevice unlockForConfiguration];
                 //NSLog(@"Torch mode set");
                 return true;


### PR DESCRIPTION
Fix errors in file cap_avfoundation.mm.
Compiled with Xcode 6.2, iOS SDK 8.2

Example:

cap_avfoundation.mm:543:54: error: cannot initialize a parameter of
type 'AVCaptureFocusMode' with an rvalue of type 'int'
    if ([mCaptureDevice isFocusModeSupported:(int)value]){
                                             ^~~~~~~~~~