### PR TITLE
Fixed python crash when both cv2.imshow and gtk module are used

### DIFF
--- a/modules/highgui/src/window_gtk.cpp
+++ b/modules/highgui/src/window_gtk.cpp
@@ -577,8 +577,8 @@ CV_IMPL int cvInitSystem( int argc, char** argv )
     {
         hg_windows = 0;
 
-        gtk_disable_setlocale();
         gtk_init( &argc, &argv );
+        setlocale(LC_NUMERIC,"C");
 
         #ifdef HAVE_OPENGL
             gtk_gl_init(&argc, &argv);


### PR DESCRIPTION
Should fix issue [3895](http://code.opencv.org/issues/3895). Similar fixes were made for other window systems in PR #3046.