### PR TITLE
Prevent the parent from drawing over OpenGL context.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -739,6 +739,11 @@ CV_IMPL int cvNamedWindow( const char* name, int flags )
     if( !(flags & CV_WINDOW_AUTOSIZE))//YV add border in order to resize the window
        defStyle |= WS_SIZEBOX;
 
+#ifdef HAVE_OPENGL
+    if (flags & CV_WINDOW_OPENGL)
+        defStyle |= WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
+#endif
+
     icvLoadWindowPos( name, rect );
 
     mainhWnd = CreateWindow( "Main HighGUI class", name, defStyle | WS_OVERLAPPED,


### PR DESCRIPTION
When creating a named window with the OpenGL flag, the parent Window draws over the OpenGL context when it erases the background. This clears the OpenGL context and leaves it showing a solid color (the background color of the parent).

This fix simply instructs the parent to exclude both children and siblings from the draw area, thereby avoiding painting over them. During resizing the OpenGL context blanks-out, but immediately after resizing it redraws itself correctly and shows its contents. I haven't attempted removing the latter nuisance as that is more involved and the benefits less.