### PR TITLE
added the signedGradient varaible to the HOGDescriptor class.

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -345,18 +345,18 @@ public:
     CV_WRAP HOGDescriptor() : winSize(64,128), blockSize(16,16), blockStride(8,8),
         cellSize(8,8), nbins(9), derivAperture(1), winSigma(-1),
         histogramNormType(HOGDescriptor::L2Hys), L2HysThreshold(0.2), gammaCorrection(true),
-        free_coef(-1.f), nlevels(HOGDescriptor::DEFAULT_NLEVELS)
+        free_coef(-1.f), nlevels(HOGDescriptor::DEFAULT_NLEVELS), signedGradient(false)
     {}
 
     CV_WRAP HOGDescriptor(Size _winSize, Size _blockSize, Size _blockStride,
                   Size _cellSize, int _nbins, int _derivAperture=1, double _winSigma=-1,
                   int _histogramNormType=HOGDescriptor::L2Hys,
                   double _L2HysThreshold=0.2, bool _gammaCorrection=false,
-                  int _nlevels=HOGDescriptor::DEFAULT_NLEVELS)
+                  int _nlevels=HOGDescriptor::DEFAULT_NLEVELS, bool _signedGradient=false)
     : winSize(_winSize), blockSize(_blockSize), blockStride(_blockStride), cellSize(_cellSize),
     nbins(_nbins), derivAperture(_derivAperture), winSigma(_winSigma),
     histogramNormType(_histogramNormType), L2HysThreshold(_L2HysThreshold),
-    gammaCorrection(_gammaCorrection), free_coef(-1.f), nlevels(_nlevels)
+    gammaCorrection(_gammaCorrection), free_coef(-1.f), nlevels(_nlevels), signedGradient(_signedGradient)
     {}
 
     CV_WRAP HOGDescriptor(const String& filename)
@@ -432,6 +432,7 @@ public:
     UMat oclSvmDetector;
     float free_coef;
     CV_PROP int nlevels;
+    CV_PROP bool signedGradient;
 
 
     //! evaluate specified ROI and return confidence value for each location


### PR DESCRIPTION
opencv implementation of HOGDescriptor used only unsigned gradient for the orientation histogram.
As pointed out in the original Dalal & Triggs paper, this make sense for people detector but in other context signed gradient can be more appropriate. For example, when we are sure the object one want to detect is brighter than the background (or the opposite). 

This has been discussed few times:
http://stackoverflow.com/questions/7385029/signed-hog-descriptor
http://answers.opencv.org/question/54814/hog-descriptor-signed-0-360-orientation-bins/
http://code.opencv.org/issues/4301

I added the possibility to use signed gradient to the HOG Descriptor class by adding a boolean variable to the class. When true, signed gradient are used for the angular histogram computation.
Default value is false for backward compatibility.


