### PR TITLE
Opencv sgjava

### DIFF
--- a/modules/core/misc/java/src/java/core+Mat.java
+++ b/modules/core/misc/java/src/java/core+Mat.java
@@ -640,6 +640,7 @@ public class Mat {
     {
 
         n_release(nativeObj);
+        n_delete(nativeObj);
 
         return;
     }
@@ -904,12 +905,6 @@ public class Mat {
         Mat retVal = new Mat(n_zeros(size.width, size.height, type));
 
         return retVal;
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-        n_delete(nativeObj);
-        super.finalize();
     }
 
     // javadoc:Mat::toString()

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -1530,7 +1530,7 @@ JNIEXPORT $rtype JNICALL Java_org_opencv_${module}_${clazz}_$fname
             # finalize()
             ci.j_code.write(
 """
-    protected void delete() {
+    public void delete() {
         delete(nativeObj);
     }
 """ )


### PR DESCRIPTION
Made generated delete() public instead of protected, so calling code can access.

Removed finalize() from Mat and added n_delete to release() to prevent native memory leaks.