### PR TITLE
Avoid clearing HaarEvaluator::tofs variable in setImage() call

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -680,7 +680,6 @@ void HaarEvaluator::computeOptFeatures()
 }
 
 bool HaarEvaluator::setImage(InputArray _image, const std::vector<float>& _scales){
-    tofs = 0;
     return FeatureEvaluator::setImage(_image, _scales);
 }
 


### PR DESCRIPTION
Avoid clearing HaarEvaluator::tofs variable in setImage() call (introduced Itseez/opencv@fb8478eb7b6c76f15c106c29a8843d8c3722bb62) in HaarEvaluator::setImage(...) since it won't be recomputed by HaarEvaluator::computeOptFeatures() for cases where the input image dimensions and requested search scales are the same as the previous image.  If none of the above change, then it should be correct, and if they do change it will be computed correctly inside HaarEvaluator::computeOptFeatures() (in commit Itseez/opencv@952f9dbe629e8e9f310c70c78ed46d484439c1c9)

I'm guessing there is a unit test for this that needs to be called 2x with the same image and search parameters (or another image with the same size) to illustrate the problem.  