### PR TITLE
Update cap_ffmpeg_impl.hpp

### DIFF
--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -687,7 +687,6 @@ bool CvCapture_FFMPEG::grabFrame()
             //picture_pts = picture->best_effort_timestamp;
             if( picture_pts == AV_NOPTS_VALUE_ )
                 picture_pts = packet.pts != AV_NOPTS_VALUE_ && packet.pts != 0 ? packet.pts : packet.dts;
-            frame_number++;
             valid = true;
         }
         else
@@ -700,8 +699,11 @@ bool CvCapture_FFMPEG::grabFrame()
         av_free_packet (&packet);
     }
 
-    if( valid && first_frame_number < 0 )
-        first_frame_number = dts_to_frame_number(picture_pts);
+    if( valid ) {
+        if ( first_frame_number < 0 )
+            first_frame_number = dts_to_frame_number(picture_pts);
+        frame_number = dts_to_frame_number(picture_pts) - first_frame_number;
+    }
 
     // return if we have a new picture or not
     return valid;


### PR DESCRIPTION
Fixes desynchronization issues with some videos where both the frame number returned through `getProperty(CV_FFMPEG_CAP_PROP_POS_FRAMES)` and the timestamp returned with `CV_FFMPEG_CAP_PROP_POS_MSEC` do not match the expected values that you experience in a media player (e.g. VLC) and also differed from `seek()`