### PR TITLE
Fix for desynchronization in pos frames and pos msec

### DIFF
--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -701,7 +701,6 @@ bool CvCapture_FFMPEG::grabFrame()
             //picture_pts = picture->best_effort_timestamp;
             if( picture_pts == AV_NOPTS_VALUE_ )
                 picture_pts = packet.pts != AV_NOPTS_VALUE_ && packet.pts != 0 ? packet.pts : packet.dts;
-            frame_number++;
             valid = true;
         }
         else
@@ -714,8 +713,11 @@ bool CvCapture_FFMPEG::grabFrame()
         av_free_packet (&packet);
     }
 
-    if( valid && first_frame_number < 0 )
-        first_frame_number = dts_to_frame_number(picture_pts);
+    if( valid ) {
+        if ( first_frame_number < 0 )
+            first_frame_number = dts_to_frame_number(picture_pts);
+        frame_number = dts_to_frame_number(picture_pts) - first_frame_number;
+    }
 
     // return if we have a new picture or not
     return valid;

--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -713,10 +713,13 @@ bool CvCapture_FFMPEG::grabFrame()
         av_free_packet (&packet);
     }
 
-    if( valid ) {
+    if( valid )
+    {
         if ( first_frame_number < 0 )
             first_frame_number = dts_to_frame_number(picture_pts);
         frame_number = dts_to_frame_number(picture_pts) - first_frame_number;
+        if ( frame_number < 0 )
+            frame_number = get_total_frames();
     }
 
     // return if we have a new picture or not

--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -926,7 +926,6 @@ void CvCapture_FFMPEG::seek(int64_t _frame_number)
                     if(!grabFrame())
                         break;
                 }
-                frame_number++;
                 break;
             }
             else

--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -717,9 +717,9 @@ bool CvCapture_FFMPEG::grabFrame()
     {
         if ( first_frame_number < 0 )
             first_frame_number = dts_to_frame_number(picture_pts);
-        frame_number = dts_to_frame_number(picture_pts) - first_frame_number;
-        if ( frame_number < 0 )
-            frame_number = get_total_frames();
+        int64_t _frame_number_temp = dts_to_frame_number(picture_pts) - first_frame_number;
+        if ( _frame_number_temp >= 0 )
+            frame_number = _frame_number_temp;
     }
 
     // return if we have a new picture or not

--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -926,6 +926,7 @@ void CvCapture_FFMPEG::seek(int64_t _frame_number)
                     if(!grabFrame())
                         break;
                 }
+                frame_number++;
                 break;
             }
             else


### PR DESCRIPTION
Fixes issue where some videos got desynchronized positions in frame and msec that did not match the expected values that you experience in a media player (e.g. VLC) and also differed from the resulting frame after `seek()`