### PR TITLE
cleanup after PR #4017

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -679,10 +679,6 @@ void HaarEvaluator::computeOptFeatures()
     copyVectorToUMat(*optfeatures_lbuf, ufbuf);
 }
 
-bool HaarEvaluator::setImage(InputArray _image, const std::vector<float>& _scales){
-    return FeatureEvaluator::setImage(_image, _scales);
-}
-
 bool HaarEvaluator::setWindow( Point pt, int scaleIdx )
 {
     const ScaleData& s = getScaleData(scaleIdx);

--- a/modules/objdetect/src/cascadedetect.hpp
+++ b/modules/objdetect/src/cascadedetect.hpp
@@ -347,7 +347,6 @@ public:
     virtual Ptr<FeatureEvaluator> clone() const;
     virtual int getFeatureType() const { return FeatureEvaluator::HAAR; }
 
-    virtual bool setImage(InputArray _image, const std::vector<float>& _scales);
     virtual bool setWindow(Point p, int scaleIdx);
     Rect getNormRect() const;
     int getSquaresOffset() const;


### PR DESCRIPTION
this will remove the now unused function after #4017. It seems to be ok just as it is right now.