### PR TITLE
[CUDA] Fix bug #4343

### DIFF
--- a/modules/cudaarithm/test/test_reductions.cpp
+++ b/modules/cudaarithm/test/test_reductions.cpp
@@ -587,6 +587,44 @@ CUDA_TEST_P(MinMaxLoc, WithoutMask)
     }
 }
 
+CUDA_TEST_P(MinMaxLoc, OneRowMat)
+{
+    cv::Mat src = randomMat(cv::Size(size.width, 1), depth);
+
+    double minVal, maxVal;
+    cv::Point minLoc, maxLoc;
+    cv::cuda::minMaxLoc(loadMat(src, useRoi), &minVal, &maxVal, &minLoc, &maxLoc);
+
+    double minVal_gold, maxVal_gold;
+    cv::Point minLoc_gold, maxLoc_gold;
+    minMaxLocGold(src, &minVal_gold, &maxVal_gold, &minLoc_gold, &maxLoc_gold);
+
+    EXPECT_DOUBLE_EQ(minVal_gold, minVal);
+    EXPECT_DOUBLE_EQ(maxVal_gold, maxVal);
+
+    expectEqual(src, minLoc_gold, minLoc);
+    expectEqual(src, maxLoc_gold, maxLoc);
+}
+
+CUDA_TEST_P(MinMaxLoc, OneColumnMat)
+{
+    cv::Mat src = randomMat(cv::Size(1, size.height), depth);
+
+    double minVal, maxVal;
+    cv::Point minLoc, maxLoc;
+    cv::cuda::minMaxLoc(loadMat(src, useRoi), &minVal, &maxVal, &minLoc, &maxLoc);
+
+    double minVal_gold, maxVal_gold;
+    cv::Point minLoc_gold, maxLoc_gold;
+    minMaxLocGold(src, &minVal_gold, &maxVal_gold, &minLoc_gold, &maxLoc_gold);
+
+    EXPECT_DOUBLE_EQ(minVal_gold, minVal);
+    EXPECT_DOUBLE_EQ(maxVal_gold, maxVal);
+
+    expectEqual(src, minLoc_gold, minLoc);
+    expectEqual(src, maxLoc_gold, maxLoc);
+}
+
 CUDA_TEST_P(MinMaxLoc, Async)
 {
     cv::Mat src = randomMat(size, depth);

--- a/modules/cudev/include/opencv2/cudev/grid/detail/minmaxloc.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/detail/minmaxloc.hpp
@@ -156,7 +156,7 @@ namespace grid_minmaxloc_detail
     __host__ void minMaxLoc(const SrcPtr& src, ResType* minVal, ResType* maxVal, int* minLoc, int* maxLoc, const MaskPtr& mask, int rows, int cols, cudaStream_t stream)
     {
         dim3 block, grid;
-        getLaunchCfg<Policy>(cols, rows, block, grid);
+        getLaunchCfg<Policy>(rows, cols, block, grid);
 
         const int patch_x = divUp(divUp(cols, grid.x), block.x);
         const int patch_y = divUp(divUp(rows, grid.y), block.y);


### PR DESCRIPTION
`cv::cuda::findMinMaxLoc` incorrect output for single row matrix