### PR TITLE
fix mutex for uclibc

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -923,7 +923,7 @@ struct Mutex::Impl
     int refcount;
 };
 
-#elif defined __linux__ && !defined ANDROID
+#elif defined __linux__ && !defined ANDROID && !defined __LINUXTHREADS_OLD__
 
 struct Mutex::Impl
 {


### PR DESCRIPTION
The uClibc doesn't have pthread_spin_* implemented on their 'old' linux threads.
Since it is on linux, we have to check if uclibc is using this implementation or not.