### PR TITLE
Bug #4316 fix: undefined references when BUILD_opencv_world:BOOL=ON

### DIFF
--- a/modules/hal/CMakeLists.txt
+++ b/modules/hal/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(the_description "The Hardware Acceleration Layer (HAL) module")
 
 set(OPENCV_MODULE_TYPE STATIC)
-# set(OPENCV_MODULE_IS_PART_OF_WORLD FALSE)
+set(OPENCV_MODULE_IS_PART_OF_WORLD FALSE)
 
 if(UNIX)
   if(CMAKE_COMPILER_IS_GNUCXX OR CV_ICC)


### PR DESCRIPTION
May be more suitable way of fixing it.