### PR TITLE
[2.4] [Java] Back port of #4056 to 2.4

### DIFF
--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -1153,6 +1153,7 @@ extern "C" {
                     if "O" in a.out:
                         if not type_dict[a.ctype]["j_type"].startswith("MatOf"):
                             j_epilogue.append("Converters.Mat_to_%(t)s(%(n)s_mat, %(n)s);" % {"t" : a.ctype, "n" : a.name})
+                            j_epilogue.append( "%s_mat.release();" % a.name )
                         c_epilogue.append( "%(t)s_to_Mat( %(n)s, %(n)s_mat );" % {"n" : a.name, "t" : a.ctype} )
                 else:
                     fields = type_dict[a.ctype].get("jn_args", ((a.ctype, ""),))

--- a/modules/java/generator/src/java/utils+Converters.java
+++ b/modules/java/generator/src/java/utils+Converters.java
@@ -501,7 +501,9 @@ public class Converters {
         for (Mat mi : mats) {
             MatOfPoint pt = new MatOfPoint(mi);
             pts.add(pt);
+            mi.release();
         }
+        mats.clear();
     }
 
     // vector_vector_Point2f
@@ -517,7 +519,9 @@ public class Converters {
         for (Mat mi : mats) {
             MatOfPoint2f pt = new MatOfPoint2f(mi);
             pts.add(pt);
+            mi.release();
         }
+        mats.clear();
     }
 
     // vector_vector_Point2f
@@ -547,7 +551,9 @@ public class Converters {
         for (Mat mi : mats) {
             MatOfPoint3f pt = new MatOfPoint3f(mi);
             pts.add(pt);
+            mi.release();
         }
+        mats.clear();
     }
 
     // vector_vector_Point3f
@@ -590,7 +596,9 @@ public class Converters {
         for (Mat mi : mats) {
             MatOfKeyPoint vkp = new MatOfKeyPoint(mi);
             kps.add(vkp);
+            mi.release();
         }
+        mats.clear();
     }
 
     public static Mat vector_double_to_Mat(List<Double> ds) {
@@ -689,7 +697,9 @@ public class Converters {
         for (Mat mi : mats) {
             MatOfDMatch vdm = new MatOfDMatch(mi);
             lvdm.add(vdm);
+            mi.release();
         }
+        mats.clear();
     }
 
     // vector_vector_char
@@ -719,6 +729,8 @@ public class Converters {
             List<Byte> lb = new ArrayList<Byte>();
             Mat_to_vector_char(mi, lb);
             llb.add(lb);
+            mi.release();
         }
+        mats.clear();
     }
 }


### PR DESCRIPTION
Back port of #4056 to 2.4
Native memory cleanup; thanks to @sgjava for pointing to the problem (https://github.com/sgjava/opencvmem)