### PR TITLE
LATCH sample build and cvconfig.h copy

### DIFF
--- a/cmake/OpenCVGenHeaders.cmake
+++ b/cmake/OpenCVGenHeaders.cmake
@@ -1,5 +1,6 @@
 # platform-specific config file
 configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/cvconfig.h.in" "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/cvconfig.h")
+configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/cvconfig.h.in" "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/opencv2/cvconfig.h")
 install(FILES "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/cvconfig.h" DESTINATION ${OPENCV_INCLUDE_INSTALL_PATH}/opencv2 COMPONENT dev)
 
 # ----------------------------------------------------------------------------

--- a/samples/cpp/tutorial_code/xfeatures2D/LATCH_match.cpp
+++ b/samples/cpp/tutorial_code/xfeatures2D/LATCH_match.cpp
@@ -1,9 +1,14 @@
+#include <iostream>
+
+#include "opencv2/opencv_modules.hpp"
+
+#ifdef HAVE_OPENCV_XFEATURES2D
+
 #include <opencv2/features2d.hpp>
 #include <opencv2/xfeatures2d.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/opencv.hpp>
 #include <vector>
-#include <iostream>
 
 // If you find this code useful, please add a reference to the following paper in your work:
 // Gil Levi and Tal Hassner, "LATCH: Learned Arrangements of Three Patch Codes", arXiv preprint arXiv:1501.03719, 15 Jan. 2015
@@ -90,3 +95,13 @@ int main(void)
     cout << endl;
     return 0;
 }
+
+#else
+
+int main()
+{
+    std::cerr << "OpenCV was built without xfeatures2d module" << std::endl;
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
Failed to build OpenCV samples without opencv_contrib repository due to xfeatures2d dependency.
- Modified LATCH sample similar to https://github.com/Itseez/opencv/blob/master/samples/gpu/surf_keypoint_matcher.cpp
- Added cvconfig.h copy to "include/opencv2/cvconfig.h" to be used during OpenCV build.