### PR TITLE
Remove private copy and assignment constructor declarations from CvSVM

### DIFF
--- a/modules/ml/include/opencv2/ml/ml.hpp
+++ b/modules/ml/include/opencv2/ml/ml.hpp
@@ -548,10 +548,6 @@ protected:
 
     CvSVMSolver* solver;
     CvSVMKernel* kernel;
-
-private:
-    CvSVM(const CvSVM&);
-    CvSVM& operator = (const CvSVM&);
 };
 
 /****************************************************************************************\


### PR DESCRIPTION
These private declarations of copy and assignment constructors in CvSVM currently prevent anyone from using a CvSVM instance with RIAA. They are never actually defined, and were apparently originally intended to prevent people from using them, according to this commit: cf00349b5bfddea8b65efcfde88f9e94ff7bc682

Even if they were public, their declaration without definition causes linker errors whenever they are used. The expected effect of these constructors should be a shallow copy. Omitting the declarations entirely gives this behavior.