### PR TITLE
fix isContourConvex

### DIFF
--- a/modules/imgproc/src/convhull.cpp
+++ b/modules/imgproc/src/convhull.cpp
@@ -347,7 +347,7 @@ static bool isContourConvex_( const Point_<_Tp>* p, int n )
     _Tp dy0 = cur_pt.y - prev_pt.y;
     int orientation = 0;
 
-    for( int i = 0; i < n-1; i++ )
+    for( int i = 0; i < n; i++ )
     {
         _Tp dxdy0, dydx0;
         _Tp dx, dy;


### PR DESCRIPTION
Correct a bug in isContourConvex function.

Convexity is checked by analizying the crossproducts of each consecutive pair of vectors in the contour. If the size of the contour is N, there should be N crossproducts.

The convexity was not being checked in one of the contour points (the penultimate one). 
The stop condition in the *for* loop was wrong.

Example of contour that was producing erroneous result:
*(328, 26)*
*(638, 199)*
*(500, 44)*
*(628, 1)*

It is a non-convex contour, but the function was returning true.

