### PR TITLE
Adding backslash in macro-based paths of WINRT samples

### DIFF
--- a/platforms/winrt/readme.txt
+++ b/platforms/winrt/readme.txt
@@ -57,7 +57,7 @@ bin
 
 "-b" flag in the command above builds each generated solutions in both "Debug" and "Release" configurations. It also builds the predefined "INSTALL" project within generated solutions. Building it creates a separate install location that accumulates binaries and includes for specified platforms. Default location is "<ocv-src>\bin\install\".
 
-WinRT samples reference 'install' binaries and include files via "OPENCV_WINRT_INSTALL_DIR" environment variable. Please declare it and point to "<ocv-src>\bin\install\" directory (note slash at the end) to resolve references within sample applications.
+WinRT samples reference 'install' binaries and include files via "OPENCV_WINRT_INSTALL_DIR" environment variable. Please declare it and point to "<ocv-src>\bin\install\" directory to resolve references within sample applications.
 
 If you don't want to build all configurations automatically, you can omit "-b" flag and build OpenCV.sln for the particular platform you are targeting manually. Due to the current limitations of CMake, separate x86/x64/ARM projects must be generated for each platform.
 

--- a/samples/winrt/FaceDetection/FaceDetection/opencv.props
+++ b/samples/winrt/FaceDetection/FaceDetection/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'">

--- a/samples/winrt/ImageManipulations/MediaExtensions/OcvTransform/opencv.props
+++ b/samples/winrt/ImageManipulations/MediaExtensions/OcvTransform/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'"></DebugSuffix>

--- a/samples/winrt/ImageManipulations/opencv.props
+++ b/samples/winrt/ImageManipulations/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'"></DebugSuffix>

--- a/samples/winrt/JavaScript/MediaCaptureJavaScript.jsproj
+++ b/samples/winrt/JavaScript/MediaCaptureJavaScript.jsproj
@@ -80,9 +80,9 @@
     <SDKReference Include="Microsoft.WinJS.2.0, Version=1.0" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'">

--- a/samples/winrt/OcvImageProcessing/OcvImageProcessing/opencv.props
+++ b/samples/winrt/OcvImageProcessing/OcvImageProcessing/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'"></DebugSuffix>

--- a/samples/winrt_universal/PhoneTutorial/opencv.props
+++ b/samples/winrt_universal/PhoneTutorial/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WP\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WP\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WP\8.1\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.1\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'"></DebugSuffix>

--- a/samples/winrt_universal/VideoCaptureXAML/video_capture_xaml/opencv.props
+++ b/samples/winrt_universal/VideoCaptureXAML/video_capture_xaml/opencv.props
@@ -4,9 +4,9 @@
   <PropertyGroup Label="UserMacros">
     <Runtime Condition="'$(ApplicationType)'=='Windows Phone'">WP</Runtime>
     <Runtime Condition="'$(ApplicationType)'=='Windows Store'">WS</Runtime>
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)$(Runtime)\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)$(Runtime)\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)$(Runtime)\8.1\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\$(Runtime)\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\$(Runtime)\8.1\$(PlatformTarget)\$(PlatformTarget)\vc12\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\$(Runtime)\8.1\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'"></DebugSuffix>

--- a/samples/winrt_universal/VideoCaptureXAML/video_capture_xaml/video_capture_xaml.Windows/video_capture_xaml.Windows.vcxproj
+++ b/samples/winrt_universal/VideoCaptureXAML/video_capture_xaml/video_capture_xaml.Windows/video_capture_xaml.Windows.vcxproj
@@ -104,7 +104,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
-    <LibraryPath>$(OPENCV_WINRT_INSTALL_DIR)WS\8.1\x86\x86\vc12\lib;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);</LibraryPath>
+    <LibraryPath>$(OPENCV_WINRT_INSTALL_DIR)\WS\8.1\x86\x86\vc12\lib;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <IgnoreImportLibrary>false</IgnoreImportLibrary>

--- a/samples/winrt_universal/VideoCaptureXAML/video_capture_xaml/video_capture_xaml.WindowsPhone/video_capture_xaml.WindowsPhone.vcxproj
+++ b/samples/winrt_universal/VideoCaptureXAML/video_capture_xaml/video_capture_xaml.WindowsPhone/video_capture_xaml.WindowsPhone.vcxproj
@@ -73,10 +73,10 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LibraryPath>$(OPENCV_WINRT_INSTALL_DIR)WP\8.1\x86\x86\vc12\lib;$(VC_LibraryPath_x86);$(WindowsPhoneSDK_LibraryPath_x86);</LibraryPath>
+    <LibraryPath>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.1\x86\x86\vc12\lib;$(VC_LibraryPath_x86);$(WindowsPhoneSDK_LibraryPath_x86);</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
-    <LibraryPath>$(OPENCV_WINRT_INSTALL_DIR)WP\8.1\ARM\ARM\vc12\lib;$(VC_LibraryPath_ARM);$(WindowsPhoneSDK_LibraryPath_arm);</LibraryPath>
+    <LibraryPath>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.1\ARM\ARM\vc12\lib;$(VC_LibraryPath_ARM);$(WindowsPhoneSDK_LibraryPath_arm);</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>

--- a/samples/wp8/OcvImageManipulation/PhoneXamlDirect3DApp1/PhoneXamlDirect3DApp1Comp/opencv.props
+++ b/samples/wp8/OcvImageManipulation/PhoneXamlDirect3DApp1/PhoneXamlDirect3DApp1Comp/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'">

--- a/samples/wp8/OcvRotatingCube/PhoneXamlDirect3DApp1/PhoneXamlDirect3DApp1Comp/opencv.props
+++ b/samples/wp8/OcvRotatingCube/PhoneXamlDirect3DApp1/PhoneXamlDirect3DApp1Comp/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'"></DebugSuffix>

--- a/samples/wp8/OpenCVXaml/OpenCVComponent/opencv.props
+++ b/samples/wp8/OpenCVXaml/OpenCVComponent/opencv.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\bin\</OpenCV_Bin>
-    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\lib\</OpenCV_Lib>
-    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)WP\8.0\$(PlatformTarget)\include\</OpenCV_Include>
+    <OpenCV_Bin>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\bin\</OpenCV_Bin>
+    <OpenCV_Lib>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\$(PlatformTarget)\vc11\lib\</OpenCV_Lib>
+    <OpenCV_Include>$(OPENCV_WINRT_INSTALL_DIR)\WP\8.0\$(PlatformTarget)\include\</OpenCV_Include>
     <!--debug suffix for OpenCV dlls and libs -->
     <DebugSuffix Condition="'$(Configuration)'=='Debug'">d</DebugSuffix>
     <DebugSuffix Condition="'$(Configuration)'!='Debug'"></DebugSuffix>


### PR DESCRIPTION
This removes requirement to add OPENCV_WINRT_INSTALL_DIR environment variable with backslash in the end. In case trailing slash is presented VS handles duplicated slashes w/o issues