### PR TITLE
OCL: cleanup unused code in case of undef HAVE_OPENCL

### DIFF
--- a/cmake/cl2cpp.cmake
+++ b/cmake/cl2cpp.cmake
@@ -26,6 +26,8 @@ set(STR_CPP "// This file is auto-generated. Do not edit!
 #include \"precomp.hpp\"
 #include \"${OUTPUT_HPP_NAME}\"
 
+#ifdef HAVE_OPENCL
+
 namespace cv
 {
 namespace ocl
@@ -39,6 +41,8 @@ set(STR_HPP "// This file is auto-generated. Do not edit!
 #include \"opencv2/core/ocl.hpp\"
 #include \"opencv2/core/ocl_genbase.hpp\"
 #include \"opencv2/core/opencl/ocl_defs.hpp\"
+
+#ifdef HAVE_OPENCL
 
 namespace cv
 {
@@ -82,8 +86,8 @@ foreach(cl ${cl_list})
   set(STR_HPP "${STR_HPP}${STR_HPP_DECL}")
 endforeach()
 
-set(STR_CPP "${STR_CPP}}\n${nested_namespace_end}}\n")
-set(STR_HPP "${STR_HPP}}\n${nested_namespace_end}}\n")
+set(STR_CPP "${STR_CPP}}\n${nested_namespace_end}}\n#endif\n")
+set(STR_HPP "${STR_HPP}}\n${nested_namespace_end}}\n#endif\n")
 
 file(WRITE "${OUTPUT}" "${STR_CPP}")
 

--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -86,6 +86,7 @@ struct StereoBMParams
     int dispType;
 };
 
+#ifdef HAVE_OPENCL
 static bool ocl_prefilter_norm(InputArray _input, OutputArray _output, int winsize, int prefilterCap)
 {
     ocl::Kernel k("prefilter_norm", ocl::calib3d::stereobm_oclsrc, cv::format("-D WSZ=%d", winsize));
@@ -106,6 +107,7 @@ static bool ocl_prefilter_norm(InputArray _input, OutputArray _output, int winsi
 
     return k.run(2, globalThreads, NULL, false);
 }
+#endif
 
 static void prefilterNorm( const Mat& src, Mat& dst, int winsize, int ftzero, uchar* buf )
 {
@@ -170,6 +172,7 @@ static void prefilterNorm( const Mat& src, Mat& dst, int winsize, int ftzero, uc
     }
 }
 
+#ifdef HAVE_OPENCL
 static bool ocl_prefilter_xsobel(InputArray _input, OutputArray _output, int prefilterCap)
 {
     ocl::Kernel k("prefilter_xsobel", ocl::calib3d::stereobm_oclsrc);
@@ -186,6 +189,7 @@ static bool ocl_prefilter_xsobel(InputArray _input, OutputArray _output, int pre
 
     return k.run(2, globalThreads, NULL, false);
 }
+#endif
 
 static void
 prefilterXSobel( const Mat& src, Mat& dst, int ftzero )
@@ -849,6 +853,7 @@ findStereoCorrespondenceBM( const Mat& left, const Mat& right,
     }
 }
 
+#ifdef HAVE_OPENCL
 static bool ocl_prefiltering(InputArray left0, InputArray right0, OutputArray left, OutputArray right, StereoBMParams* state)
 {
     if( state->preFilterType == StereoBM::PREFILTER_NORMALIZED_RESPONSE )
@@ -867,6 +872,7 @@ static bool ocl_prefiltering(InputArray left0, InputArray right0, OutputArray le
     }
     return true;
 }
+#endif
 
 struct PrefilterInvoker : public ParallelLoopBody
 {
@@ -896,6 +902,7 @@ struct PrefilterInvoker : public ParallelLoopBody
     StereoBMParams* state;
 };
 
+#ifdef HAVE_OPENCL
 static bool ocl_stereobm( InputArray _left, InputArray _right,
                        OutputArray _disp, StereoBMParams* state)
 {
@@ -940,6 +947,7 @@ static bool ocl_stereobm( InputArray _left, InputArray _right,
     idx = k.set(idx, state->uniquenessRatio);
     return k.run(3, globalThreads, localThreads, false);
 }
+#endif
 
 struct FindStereoCorrespInvoker : public ParallelLoopBody
 {
@@ -1074,6 +1082,7 @@ public:
 
         int FILTERED = (params.minDisparity - 1) << DISPARITY_SHIFT;
 
+#ifdef HAVE_OPENCL
         if(ocl::useOpenCL() && disparr.isUMat() && params.textureThreshold == 0)
         {
             UMat left, right;
@@ -1090,6 +1099,7 @@ public:
                 }
             }
         }
+#endif
 
         Mat left0 = leftarr.getMat(), right0 = rightarr.getMat();
         disparr.create(left0.size(), dtype);

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -1364,10 +1364,16 @@ void pow( InputArray _src, double power, OutputArray _dst )
 {
     int type = _src.type(), depth = CV_MAT_DEPTH(type),
             cn = CV_MAT_CN(type), ipower = cvRound(power);
-    bool is_ipower = fabs(ipower - power) < DBL_EPSILON,
-            useOpenCL = _dst.isUMat() && _src.dims() <= 2;
+    bool is_ipower = fabs(ipower - power) < DBL_EPSILON;
+#ifdef HAVE_OPENCL
+    bool useOpenCL = _dst.isUMat() && _src.dims() <= 2;
+#endif
 
-    if( is_ipower && !(ocl::Device::getDefault().isIntel() && useOpenCL && depth != CV_64F))
+    if( is_ipower
+#ifdef HAVE_OPENCL
+            && !(useOpenCL && ocl::Device::getDefault().isIntel() && depth != CV_64F)
+#endif
+      )
     {
         switch( ipower )
         {

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -46,6 +46,28 @@
 #include <sstream>
 #include <iostream> // std::cerr
 
+#include <opencv2/core/ocl.hpp>
+
+#ifdef HAVE_OPENCL
+
+#define OCL_CODE(...) __VA_ARGS__
+#else
+#define OCL_NOT_AVAILABLE CV_ErrorNoReturn(Error::StsNotImplemented, "OpenCL is not available");
+#define OCL_CODE(...) { OCL_NOT_AVAILABLE }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#elif defined _MSC_VER
+#pragma warning( disable : 4100 )
+#pragma warning( disable : 4505 )
+#pragma warning( disable : 4702 )
+#endif
+
+#endif
+
+
 #define CV_OPENCL_ALWAYS_SHOW_BUILD_LOG 0
 #define CV_OPENCL_SHOW_RUN_ERRORS       0
 #define CV_OPENCL_SHOW_SVM_ERROR_LOG    1
@@ -137,1218 +159,7 @@ static size_t getConfigurationParameterForSize(const char* name, size_t defaultV
 
 #include "opencv2/core/opencl/runtime/opencl_clamdblas.hpp"
 #include "opencv2/core/opencl/runtime/opencl_clamdfft.hpp"
-
-#ifdef HAVE_OPENCL
 #include "opencv2/core/opencl/runtime/opencl_core.hpp"
-#else
-// TODO FIXIT: This file can't be build without OPENCL
-
-/*
-  Part of the file is an extract from the standard OpenCL headers from Khronos site.
-  Below is the original copyright.
-*/
-
-/*******************************************************************************
- * Copyright (c) 2008 - 2012 The Khronos Group Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and/or associated documentation files (the
- * "Materials"), to deal in the Materials without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Materials, and to
- * permit persons to whom the Materials are furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Materials.
- *
- * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
- ******************************************************************************/
-
-#if 0 //defined __APPLE__
-#define HAVE_OPENCL 1
-#else
-#undef HAVE_OPENCL
-#endif
-
-#define OPENCV_CL_NOT_IMPLEMENTED -1000
-
-#ifdef HAVE_OPENCL
-
-#if defined __APPLE__
-#include <OpenCL/opencl.h>
-#else
-#include <CL/opencl.h>
-#endif
-
-static const bool g_haveOpenCL = true;
-
-#else
-
-extern "C" {
-
-struct _cl_platform_id { int dummy; };
-struct _cl_device_id { int dummy; };
-struct _cl_context { int dummy; };
-struct _cl_command_queue { int dummy; };
-struct _cl_mem { int dummy; };
-struct _cl_program { int dummy; };
-struct _cl_kernel { int dummy; };
-struct _cl_event { int dummy; };
-struct _cl_sampler { int dummy; };
-
-typedef struct _cl_platform_id *    cl_platform_id;
-typedef struct _cl_device_id *      cl_device_id;
-typedef struct _cl_context *        cl_context;
-typedef struct _cl_command_queue *  cl_command_queue;
-typedef struct _cl_mem *            cl_mem;
-typedef struct _cl_program *        cl_program;
-typedef struct _cl_kernel *         cl_kernel;
-typedef struct _cl_event *          cl_event;
-typedef struct _cl_sampler *        cl_sampler;
-
-typedef int cl_int;
-typedef unsigned cl_uint;
-#if defined (_WIN32) && defined(_MSC_VER)
-    typedef __int64 cl_long;
-    typedef unsigned __int64 cl_ulong;
-#else
-    typedef long cl_long;
-    typedef unsigned long cl_ulong;
-#endif
-
-typedef cl_uint             cl_bool; /* WARNING!  Unlike cl_ types in cl_platform.h, cl_bool is not guaranteed to be the same size as the bool in kernels. */
-typedef cl_ulong            cl_bitfield;
-typedef cl_bitfield         cl_device_type;
-typedef cl_uint             cl_platform_info;
-typedef cl_uint             cl_device_info;
-typedef cl_bitfield         cl_device_fp_config;
-typedef cl_uint             cl_device_mem_cache_type;
-typedef cl_uint             cl_device_local_mem_type;
-typedef cl_bitfield         cl_device_exec_capabilities;
-typedef cl_bitfield         cl_command_queue_properties;
-typedef intptr_t            cl_device_partition_property;
-typedef cl_bitfield         cl_device_affinity_domain;
-
-typedef intptr_t            cl_context_properties;
-typedef cl_uint             cl_context_info;
-typedef cl_uint             cl_command_queue_info;
-typedef cl_uint             cl_channel_order;
-typedef cl_uint             cl_channel_type;
-typedef cl_bitfield         cl_mem_flags;
-typedef cl_uint             cl_mem_object_type;
-typedef cl_uint             cl_mem_info;
-typedef cl_bitfield         cl_mem_migration_flags;
-typedef cl_uint             cl_image_info;
-typedef cl_uint             cl_buffer_create_type;
-typedef cl_uint             cl_addressing_mode;
-typedef cl_uint             cl_filter_mode;
-typedef cl_uint             cl_sampler_info;
-typedef cl_bitfield         cl_map_flags;
-typedef cl_uint             cl_program_info;
-typedef cl_uint             cl_program_build_info;
-typedef cl_uint             cl_program_binary_type;
-typedef cl_int              cl_build_status;
-typedef cl_uint             cl_kernel_info;
-typedef cl_uint             cl_kernel_arg_info;
-typedef cl_uint             cl_kernel_arg_address_qualifier;
-typedef cl_uint             cl_kernel_arg_access_qualifier;
-typedef cl_bitfield         cl_kernel_arg_type_qualifier;
-typedef cl_uint             cl_kernel_work_group_info;
-typedef cl_uint             cl_event_info;
-typedef cl_uint             cl_command_type;
-typedef cl_uint             cl_profiling_info;
-
-
-typedef struct _cl_image_format {
-    cl_channel_order        image_channel_order;
-    cl_channel_type         image_channel_data_type;
-} cl_image_format;
-
-typedef struct _cl_image_desc {
-    cl_mem_object_type      image_type;
-    size_t                  image_width;
-    size_t                  image_height;
-    size_t                  image_depth;
-    size_t                  image_array_size;
-    size_t                  image_row_pitch;
-    size_t                  image_slice_pitch;
-    cl_uint                 num_mip_levels;
-    cl_uint                 num_samples;
-    cl_mem                  buffer;
-} cl_image_desc;
-
-typedef struct _cl_buffer_region {
-    size_t                  origin;
-    size_t                  size;
-} cl_buffer_region;
-
-
-//////////////////////////////////////////////////////////
-
-#define CL_SUCCESS                                  0
-#define CL_DEVICE_NOT_FOUND                         -1
-#define CL_DEVICE_NOT_AVAILABLE                     -2
-#define CL_COMPILER_NOT_AVAILABLE                   -3
-#define CL_MEM_OBJECT_ALLOCATION_FAILURE            -4
-#define CL_OUT_OF_RESOURCES                         -5
-#define CL_OUT_OF_HOST_MEMORY                       -6
-#define CL_PROFILING_INFO_NOT_AVAILABLE             -7
-#define CL_MEM_COPY_OVERLAP                         -8
-#define CL_IMAGE_FORMAT_MISMATCH                    -9
-#define CL_IMAGE_FORMAT_NOT_SUPPORTED               -10
-#define CL_BUILD_PROGRAM_FAILURE                    -11
-#define CL_MAP_FAILURE                              -12
-#define CL_MISALIGNED_SUB_BUFFER_OFFSET             -13
-#define CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST -14
-#define CL_COMPILE_PROGRAM_FAILURE                  -15
-#define CL_LINKER_NOT_AVAILABLE                     -16
-#define CL_LINK_PROGRAM_FAILURE                     -17
-#define CL_DEVICE_PARTITION_FAILED                  -18
-#define CL_KERNEL_ARG_INFO_NOT_AVAILABLE            -19
-
-#define CL_INVALID_VALUE                            -30
-#define CL_INVALID_DEVICE_TYPE                      -31
-#define CL_INVALID_PLATFORM                         -32
-#define CL_INVALID_DEVICE                           -33
-#define CL_INVALID_CONTEXT                          -34
-#define CL_INVALID_QUEUE_PROPERTIES                 -35
-#define CL_INVALID_COMMAND_QUEUE                    -36
-#define CL_INVALID_HOST_PTR                         -37
-#define CL_INVALID_MEM_OBJECT                       -38
-#define CL_INVALID_IMAGE_FORMAT_DESCRIPTOR          -39
-#define CL_INVALID_IMAGE_SIZE                       -40
-#define CL_INVALID_SAMPLER                          -41
-#define CL_INVALID_BINARY                           -42
-#define CL_INVALID_BUILD_OPTIONS                    -43
-#define CL_INVALID_PROGRAM                          -44
-#define CL_INVALID_PROGRAM_EXECUTABLE               -45
-#define CL_INVALID_KERNEL_NAME                      -46
-#define CL_INVALID_KERNEL_DEFINITION                -47
-#define CL_INVALID_KERNEL                           -48
-#define CL_INVALID_ARG_INDEX                        -49
-#define CL_INVALID_ARG_VALUE                        -50
-#define CL_INVALID_ARG_SIZE                         -51
-#define CL_INVALID_KERNEL_ARGS                      -52
-#define CL_INVALID_WORK_DIMENSION                   -53
-#define CL_INVALID_WORK_GROUP_SIZE                  -54
-#define CL_INVALID_WORK_ITEM_SIZE                   -55
-#define CL_INVALID_GLOBAL_OFFSET                    -56
-#define CL_INVALID_EVENT_WAIT_LIST                  -57
-#define CL_INVALID_EVENT                            -58
-#define CL_INVALID_OPERATION                        -59
-#define CL_INVALID_GL_OBJECT                        -60
-#define CL_INVALID_BUFFER_SIZE                      -61
-#define CL_INVALID_MIP_LEVEL                        -62
-#define CL_INVALID_GLOBAL_WORK_SIZE                 -63
-#define CL_INVALID_PROPERTY                         -64
-#define CL_INVALID_IMAGE_DESCRIPTOR                 -65
-#define CL_INVALID_COMPILER_OPTIONS                 -66
-#define CL_INVALID_LINKER_OPTIONS                   -67
-#define CL_INVALID_DEVICE_PARTITION_COUNT           -68
-
-/*#define CL_VERSION_1_0                              1
-#define CL_VERSION_1_1                              1
-#define CL_VERSION_1_2                              1*/
-
-#define CL_FALSE                                    0
-#define CL_TRUE                                     1
-#define CL_BLOCKING                                 CL_TRUE
-#define CL_NON_BLOCKING                             CL_FALSE
-
-#define CL_PLATFORM_PROFILE                         0x0900
-#define CL_PLATFORM_VERSION                         0x0901
-#define CL_PLATFORM_NAME                            0x0902
-#define CL_PLATFORM_VENDOR                          0x0903
-#define CL_PLATFORM_EXTENSIONS                      0x0904
-
-#define CL_DEVICE_TYPE_DEFAULT                      (1 << 0)
-#define CL_DEVICE_TYPE_CPU                          (1 << 1)
-#define CL_DEVICE_TYPE_GPU                          (1 << 2)
-#define CL_DEVICE_TYPE_ACCELERATOR                  (1 << 3)
-#define CL_DEVICE_TYPE_CUSTOM                       (1 << 4)
-#define CL_DEVICE_TYPE_ALL                          0xFFFFFFFF
-#define CL_DEVICE_TYPE                              0x1000
-#define CL_DEVICE_VENDOR_ID                         0x1001
-#define CL_DEVICE_MAX_COMPUTE_UNITS                 0x1002
-#define CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS          0x1003
-#define CL_DEVICE_MAX_WORK_GROUP_SIZE               0x1004
-#define CL_DEVICE_MAX_WORK_ITEM_SIZES               0x1005
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR       0x1006
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT      0x1007
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT        0x1008
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG       0x1009
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT      0x100A
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE     0x100B
-#define CL_DEVICE_MAX_CLOCK_FREQUENCY               0x100C
-#define CL_DEVICE_ADDRESS_BITS                      0x100D
-#define CL_DEVICE_MAX_READ_IMAGE_ARGS               0x100E
-#define CL_DEVICE_MAX_WRITE_IMAGE_ARGS              0x100F
-#define CL_DEVICE_MAX_MEM_ALLOC_SIZE                0x1010
-#define CL_DEVICE_IMAGE2D_MAX_WIDTH                 0x1011
-#define CL_DEVICE_IMAGE2D_MAX_HEIGHT                0x1012
-#define CL_DEVICE_IMAGE3D_MAX_WIDTH                 0x1013
-#define CL_DEVICE_IMAGE3D_MAX_HEIGHT                0x1014
-#define CL_DEVICE_IMAGE3D_MAX_DEPTH                 0x1015
-#define CL_DEVICE_IMAGE_SUPPORT                     0x1016
-#define CL_DEVICE_MAX_PARAMETER_SIZE                0x1017
-#define CL_DEVICE_MAX_SAMPLERS                      0x1018
-#define CL_DEVICE_MEM_BASE_ADDR_ALIGN               0x1019
-#define CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE          0x101A
-#define CL_DEVICE_SINGLE_FP_CONFIG                  0x101B
-#define CL_DEVICE_GLOBAL_MEM_CACHE_TYPE             0x101C
-#define CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE         0x101D
-#define CL_DEVICE_GLOBAL_MEM_CACHE_SIZE             0x101E
-#define CL_DEVICE_GLOBAL_MEM_SIZE                   0x101F
-#define CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE          0x1020
-#define CL_DEVICE_MAX_CONSTANT_ARGS                 0x1021
-#define CL_DEVICE_LOCAL_MEM_TYPE                    0x1022
-#define CL_DEVICE_LOCAL_MEM_SIZE                    0x1023
-#define CL_DEVICE_ERROR_CORRECTION_SUPPORT          0x1024
-#define CL_DEVICE_PROFILING_TIMER_RESOLUTION        0x1025
-#define CL_DEVICE_ENDIAN_LITTLE                     0x1026
-#define CL_DEVICE_AVAILABLE                         0x1027
-#define CL_DEVICE_COMPILER_AVAILABLE                0x1028
-#define CL_DEVICE_EXECUTION_CAPABILITIES            0x1029
-#define CL_DEVICE_QUEUE_PROPERTIES                  0x102A
-#define CL_DEVICE_NAME                              0x102B
-#define CL_DEVICE_VENDOR                            0x102C
-#define CL_DRIVER_VERSION                           0x102D
-#define CL_DEVICE_PROFILE                           0x102E
-#define CL_DEVICE_VERSION                           0x102F
-#define CL_DEVICE_EXTENSIONS                        0x1030
-#define CL_DEVICE_PLATFORM                          0x1031
-#define CL_DEVICE_DOUBLE_FP_CONFIG                  0x1032
-#define CL_DEVICE_HALF_FP_CONFIG                    0x1033
-#define CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF       0x1034
-#define CL_DEVICE_HOST_UNIFIED_MEMORY               0x1035
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR          0x1036
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT         0x1037
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_INT           0x1038
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG          0x1039
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT         0x103A
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE        0x103B
-#define CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF          0x103C
-#define CL_DEVICE_OPENCL_C_VERSION                  0x103D
-#define CL_DEVICE_LINKER_AVAILABLE                  0x103E
-#define CL_DEVICE_BUILT_IN_KERNELS                  0x103F
-#define CL_DEVICE_IMAGE_MAX_BUFFER_SIZE             0x1040
-#define CL_DEVICE_IMAGE_MAX_ARRAY_SIZE              0x1041
-#define CL_DEVICE_PARENT_DEVICE                     0x1042
-#define CL_DEVICE_PARTITION_MAX_SUB_DEVICES         0x1043
-#define CL_DEVICE_PARTITION_PROPERTIES              0x1044
-#define CL_DEVICE_PARTITION_AFFINITY_DOMAIN         0x1045
-#define CL_DEVICE_PARTITION_TYPE                    0x1046
-#define CL_DEVICE_REFERENCE_COUNT                   0x1047
-#define CL_DEVICE_PREFERRED_INTEROP_USER_SYNC       0x1048
-#define CL_DEVICE_PRINTF_BUFFER_SIZE                0x1049
-#define CL_DEVICE_IMAGE_PITCH_ALIGNMENT             0x104A
-#define CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT      0x104B
-
-#define CL_FP_DENORM                                (1 << 0)
-#define CL_FP_INF_NAN                               (1 << 1)
-#define CL_FP_ROUND_TO_NEAREST                      (1 << 2)
-#define CL_FP_ROUND_TO_ZERO                         (1 << 3)
-#define CL_FP_ROUND_TO_INF                          (1 << 4)
-#define CL_FP_FMA                                   (1 << 5)
-#define CL_FP_SOFT_FLOAT                            (1 << 6)
-#define CL_FP_CORRECTLY_ROUNDED_DIVIDE_SQRT         (1 << 7)
-
-#define CL_NONE                                     0x0
-#define CL_READ_ONLY_CACHE                          0x1
-#define CL_READ_WRITE_CACHE                         0x2
-#define CL_LOCAL                                    0x1
-#define CL_GLOBAL                                   0x2
-#define CL_EXEC_KERNEL                              (1 << 0)
-#define CL_EXEC_NATIVE_KERNEL                       (1 << 1)
-#define CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE      (1 << 0)
-#define CL_QUEUE_PROFILING_ENABLE                   (1 << 1)
-
-#define CL_CONTEXT_REFERENCE_COUNT                  0x1080
-#define CL_CONTEXT_DEVICES                          0x1081
-#define CL_CONTEXT_PROPERTIES                       0x1082
-#define CL_CONTEXT_NUM_DEVICES                      0x1083
-#define CL_CONTEXT_PLATFORM                         0x1084
-#define CL_CONTEXT_INTEROP_USER_SYNC                0x1085
-
-#define CL_DEVICE_PARTITION_EQUALLY                 0x1086
-#define CL_DEVICE_PARTITION_BY_COUNTS               0x1087
-#define CL_DEVICE_PARTITION_BY_COUNTS_LIST_END      0x0
-#define CL_DEVICE_PARTITION_BY_AFFINITY_DOMAIN      0x1088
-#define CL_DEVICE_AFFINITY_DOMAIN_NUMA                     (1 << 0)
-#define CL_DEVICE_AFFINITY_DOMAIN_L4_CACHE                 (1 << 1)
-#define CL_DEVICE_AFFINITY_DOMAIN_L3_CACHE                 (1 << 2)
-#define CL_DEVICE_AFFINITY_DOMAIN_L2_CACHE                 (1 << 3)
-#define CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE                 (1 << 4)
-#define CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE       (1 << 5)
-#define CL_QUEUE_CONTEXT                            0x1090
-#define CL_QUEUE_DEVICE                             0x1091
-#define CL_QUEUE_REFERENCE_COUNT                    0x1092
-#define CL_QUEUE_PROPERTIES                         0x1093
-#define CL_MEM_READ_WRITE                           (1 << 0)
-#define CL_MEM_WRITE_ONLY                           (1 << 1)
-#define CL_MEM_READ_ONLY                            (1 << 2)
-#define CL_MEM_USE_HOST_PTR                         (1 << 3)
-#define CL_MEM_ALLOC_HOST_PTR                       (1 << 4)
-#define CL_MEM_COPY_HOST_PTR                        (1 << 5)
-// reserved                                         (1 << 6)
-#define CL_MEM_HOST_WRITE_ONLY                      (1 << 7)
-#define CL_MEM_HOST_READ_ONLY                       (1 << 8)
-#define CL_MEM_HOST_NO_ACCESS                       (1 << 9)
-#define CL_MIGRATE_MEM_OBJECT_HOST                  (1 << 0)
-#define CL_MIGRATE_MEM_OBJECT_CONTENT_UNDEFINED     (1 << 1)
-
-#define CL_R                                        0x10B0
-#define CL_A                                        0x10B1
-#define CL_RG                                       0x10B2
-#define CL_RA                                       0x10B3
-#define CL_RGB                                      0x10B4
-#define CL_RGBA                                     0x10B5
-#define CL_BGRA                                     0x10B6
-#define CL_ARGB                                     0x10B7
-#define CL_INTENSITY                                0x10B8
-#define CL_LUMINANCE                                0x10B9
-#define CL_Rx                                       0x10BA
-#define CL_RGx                                      0x10BB
-#define CL_RGBx                                     0x10BC
-#define CL_DEPTH                                    0x10BD
-#define CL_DEPTH_STENCIL                            0x10BE
-
-#define CL_SNORM_INT8                               0x10D0
-#define CL_SNORM_INT16                              0x10D1
-#define CL_UNORM_INT8                               0x10D2
-#define CL_UNORM_INT16                              0x10D3
-#define CL_UNORM_SHORT_565                          0x10D4
-#define CL_UNORM_SHORT_555                          0x10D5
-#define CL_UNORM_INT_101010                         0x10D6
-#define CL_SIGNED_INT8                              0x10D7
-#define CL_SIGNED_INT16                             0x10D8
-#define CL_SIGNED_INT32                             0x10D9
-#define CL_UNSIGNED_INT8                            0x10DA
-#define CL_UNSIGNED_INT16                           0x10DB
-#define CL_UNSIGNED_INT32                           0x10DC
-#define CL_HALF_FLOAT                               0x10DD
-#define CL_FLOAT                                    0x10DE
-#define CL_UNORM_INT24                              0x10DF
-
-#define CL_MEM_OBJECT_BUFFER                        0x10F0
-#define CL_MEM_OBJECT_IMAGE2D                       0x10F1
-#define CL_MEM_OBJECT_IMAGE3D                       0x10F2
-#define CL_MEM_OBJECT_IMAGE2D_ARRAY                 0x10F3
-#define CL_MEM_OBJECT_IMAGE1D                       0x10F4
-#define CL_MEM_OBJECT_IMAGE1D_ARRAY                 0x10F5
-#define CL_MEM_OBJECT_IMAGE1D_BUFFER                0x10F6
-
-#define CL_MEM_TYPE                                 0x1100
-#define CL_MEM_FLAGS                                0x1101
-#define CL_MEM_SIZE                                 0x1102
-#define CL_MEM_HOST_PTR                             0x1103
-#define CL_MEM_MAP_COUNT                            0x1104
-#define CL_MEM_REFERENCE_COUNT                      0x1105
-#define CL_MEM_CONTEXT                              0x1106
-#define CL_MEM_ASSOCIATED_MEMOBJECT                 0x1107
-#define CL_MEM_OFFSET                               0x1108
-
-#define CL_IMAGE_FORMAT                             0x1110
-#define CL_IMAGE_ELEMENT_SIZE                       0x1111
-#define CL_IMAGE_ROW_PITCH                          0x1112
-#define CL_IMAGE_SLICE_PITCH                        0x1113
-#define CL_IMAGE_WIDTH                              0x1114
-#define CL_IMAGE_HEIGHT                             0x1115
-#define CL_IMAGE_DEPTH                              0x1116
-#define CL_IMAGE_ARRAY_SIZE                         0x1117
-#define CL_IMAGE_BUFFER                             0x1118
-#define CL_IMAGE_NUM_MIP_LEVELS                     0x1119
-#define CL_IMAGE_NUM_SAMPLES                        0x111A
-
-#define CL_ADDRESS_NONE                             0x1130
-#define CL_ADDRESS_CLAMP_TO_EDGE                    0x1131
-#define CL_ADDRESS_CLAMP                            0x1132
-#define CL_ADDRESS_REPEAT                           0x1133
-#define CL_ADDRESS_MIRRORED_REPEAT                  0x1134
-
-#define CL_FILTER_NEAREST                           0x1140
-#define CL_FILTER_LINEAR                            0x1141
-
-#define CL_SAMPLER_REFERENCE_COUNT                  0x1150
-#define CL_SAMPLER_CONTEXT                          0x1151
-#define CL_SAMPLER_NORMALIZED_COORDS                0x1152
-#define CL_SAMPLER_ADDRESSING_MODE                  0x1153
-#define CL_SAMPLER_FILTER_MODE                      0x1154
-
-#define CL_MAP_READ                                 (1 << 0)
-#define CL_MAP_WRITE                                (1 << 1)
-#define CL_MAP_WRITE_INVALIDATE_REGION              (1 << 2)
-
-#define CL_PROGRAM_REFERENCE_COUNT                  0x1160
-#define CL_PROGRAM_CONTEXT                          0x1161
-#define CL_PROGRAM_NUM_DEVICES                      0x1162
-#define CL_PROGRAM_DEVICES                          0x1163
-#define CL_PROGRAM_SOURCE                           0x1164
-#define CL_PROGRAM_BINARY_SIZES                     0x1165
-#define CL_PROGRAM_BINARIES                         0x1166
-#define CL_PROGRAM_NUM_KERNELS                      0x1167
-#define CL_PROGRAM_KERNEL_NAMES                     0x1168
-#define CL_PROGRAM_BUILD_STATUS                     0x1181
-#define CL_PROGRAM_BUILD_OPTIONS                    0x1182
-#define CL_PROGRAM_BUILD_LOG                        0x1183
-#define CL_PROGRAM_BINARY_TYPE                      0x1184
-#define CL_PROGRAM_BINARY_TYPE_NONE                 0x0
-#define CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT      0x1
-#define CL_PROGRAM_BINARY_TYPE_LIBRARY              0x2
-#define CL_PROGRAM_BINARY_TYPE_EXECUTABLE           0x4
-
-#define CL_BUILD_SUCCESS                            0
-#define CL_BUILD_NONE                               -1
-#define CL_BUILD_ERROR                              -2
-#define CL_BUILD_IN_PROGRESS                        -3
-
-#define CL_KERNEL_FUNCTION_NAME                     0x1190
-#define CL_KERNEL_NUM_ARGS                          0x1191
-#define CL_KERNEL_REFERENCE_COUNT                   0x1192
-#define CL_KERNEL_CONTEXT                           0x1193
-#define CL_KERNEL_PROGRAM                           0x1194
-#define CL_KERNEL_ATTRIBUTES                        0x1195
-#define CL_KERNEL_ARG_ADDRESS_QUALIFIER             0x1196
-#define CL_KERNEL_ARG_ACCESS_QUALIFIER              0x1197
-#define CL_KERNEL_ARG_TYPE_NAME                     0x1198
-#define CL_KERNEL_ARG_TYPE_QUALIFIER                0x1199
-#define CL_KERNEL_ARG_NAME                          0x119A
-#define CL_KERNEL_ARG_ADDRESS_GLOBAL                0x119B
-#define CL_KERNEL_ARG_ADDRESS_LOCAL                 0x119C
-#define CL_KERNEL_ARG_ADDRESS_CONSTANT              0x119D
-#define CL_KERNEL_ARG_ADDRESS_PRIVATE               0x119E
-#define CL_KERNEL_ARG_ACCESS_READ_ONLY              0x11A0
-#define CL_KERNEL_ARG_ACCESS_WRITE_ONLY             0x11A1
-#define CL_KERNEL_ARG_ACCESS_READ_WRITE             0x11A2
-#define CL_KERNEL_ARG_ACCESS_NONE                   0x11A3
-#define CL_KERNEL_ARG_TYPE_NONE                     0
-#define CL_KERNEL_ARG_TYPE_CONST                    (1 << 0)
-#define CL_KERNEL_ARG_TYPE_RESTRICT                 (1 << 1)
-#define CL_KERNEL_ARG_TYPE_VOLATILE                 (1 << 2)
-#define CL_KERNEL_WORK_GROUP_SIZE                   0x11B0
-#define CL_KERNEL_COMPILE_WORK_GROUP_SIZE           0x11B1
-#define CL_KERNEL_LOCAL_MEM_SIZE                    0x11B2
-#define CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE 0x11B3
-#define CL_KERNEL_PRIVATE_MEM_SIZE                  0x11B4
-#define CL_KERNEL_GLOBAL_WORK_SIZE                  0x11B5
-
-#define CL_EVENT_COMMAND_QUEUE                      0x11D0
-#define CL_EVENT_COMMAND_TYPE                       0x11D1
-#define CL_EVENT_REFERENCE_COUNT                    0x11D2
-#define CL_EVENT_COMMAND_EXECUTION_STATUS           0x11D3
-#define CL_EVENT_CONTEXT                            0x11D4
-
-#define CL_COMMAND_NDRANGE_KERNEL                   0x11F0
-#define CL_COMMAND_TASK                             0x11F1
-#define CL_COMMAND_NATIVE_KERNEL                    0x11F2
-#define CL_COMMAND_READ_BUFFER                      0x11F3
-#define CL_COMMAND_WRITE_BUFFER                     0x11F4
-#define CL_COMMAND_COPY_BUFFER                      0x11F5
-#define CL_COMMAND_READ_IMAGE                       0x11F6
-#define CL_COMMAND_WRITE_IMAGE                      0x11F7
-#define CL_COMMAND_COPY_IMAGE                       0x11F8
-#define CL_COMMAND_COPY_IMAGE_TO_BUFFER             0x11F9
-#define CL_COMMAND_COPY_BUFFER_TO_IMAGE             0x11FA
-#define CL_COMMAND_MAP_BUFFER                       0x11FB
-#define CL_COMMAND_MAP_IMAGE                        0x11FC
-#define CL_COMMAND_UNMAP_MEM_OBJECT                 0x11FD
-#define CL_COMMAND_MARKER                           0x11FE
-#define CL_COMMAND_ACQUIRE_GL_OBJECTS               0x11FF
-#define CL_COMMAND_RELEASE_GL_OBJECTS               0x1200
-#define CL_COMMAND_READ_BUFFER_RECT                 0x1201
-#define CL_COMMAND_WRITE_BUFFER_RECT                0x1202
-#define CL_COMMAND_COPY_BUFFER_RECT                 0x1203
-#define CL_COMMAND_USER                             0x1204
-#define CL_COMMAND_BARRIER                          0x1205
-#define CL_COMMAND_MIGRATE_MEM_OBJECTS              0x1206
-#define CL_COMMAND_FILL_BUFFER                      0x1207
-#define CL_COMMAND_FILL_IMAGE                       0x1208
-
-#define CL_COMPLETE                                 0x0
-#define CL_RUNNING                                  0x1
-#define CL_SUBMITTED                                0x2
-#define CL_QUEUED                                   0x3
-#define CL_BUFFER_CREATE_TYPE_REGION                0x1220
-
-#define CL_PROFILING_COMMAND_QUEUED                 0x1280
-#define CL_PROFILING_COMMAND_SUBMIT                 0x1281
-#define CL_PROFILING_COMMAND_START                  0x1282
-#define CL_PROFILING_COMMAND_END                    0x1283
-
-#define CL_CALLBACK CV_STDCALL
-
-static volatile bool g_haveOpenCL = false;
-static const char* oclFuncToCheck = "clEnqueueReadBufferRect";
-
-#if defined(__APPLE__)
-#include <dlfcn.h>
-
-static void* initOpenCLAndLoad(const char* funcname)
-{
-    static bool initialized = false;
-    static void* handle = 0;
-    if (!handle)
-    {
-        if(!initialized)
-        {
-            const char* oclpath = getenv("OPENCV_OPENCL_RUNTIME");
-            oclpath = oclpath && strlen(oclpath) > 0 ? oclpath :
-                "/System/Library/Frameworks/OpenCL.framework/Versions/Current/OpenCL";
-            handle = dlopen(oclpath, RTLD_LAZY);
-            initialized = true;
-            g_haveOpenCL = handle != 0 && dlsym(handle, oclFuncToCheck) != 0;
-            if( g_haveOpenCL )
-                fprintf(stderr, "Successfully loaded OpenCL v1.1+ runtime from %s\n", oclpath);
-            else
-                fprintf(stderr, "Failed to load OpenCL runtime\n");
-        }
-        if(!handle)
-            return 0;
-    }
-
-    return funcname && handle ? dlsym(handle, funcname) : 0;
-}
-
-#elif defined WIN32 || defined _WIN32
-
-#ifndef _WIN32_WINNT           // This is needed for the declaration of TryEnterCriticalSection in winbase.h with Visual Studio 2005 (and older?)
-  #define _WIN32_WINNT 0x0400  // http://msdn.microsoft.com/en-us/library/ms686857(VS.85).aspx
-#endif
-#include <windows.h>
-#if (_WIN32_WINNT >= 0x0602)
-  #include <synchapi.h>
-#endif
-#undef small
-#undef min
-#undef max
-#undef abs
-
-static void* initOpenCLAndLoad(const char* funcname)
-{
-    static bool initialized = false;
-    static HMODULE handle = 0;
-    if (!handle)
-    {
-#ifndef WINRT
-        if(!initialized)
-        {
-            handle = LoadLibraryA("OpenCL.dll");
-            initialized = true;
-            g_haveOpenCL = handle != 0 && GetProcAddress(handle, oclFuncToCheck) != 0;
-        }
-#endif
-        if(!handle)
-            return 0;
-    }
-
-    return funcname ? (void*)GetProcAddress(handle, funcname) : 0;
-}
-
-#elif defined(__linux)
-
-#include <dlfcn.h>
-#include <stdio.h>
-
-static void* initOpenCLAndLoad(const char* funcname)
-{
-    static bool initialized = false;
-    static void* handle = 0;
-    if (!handle)
-    {
-        if(!initialized)
-        {
-            handle = dlopen("libOpenCL.so", RTLD_LAZY);
-            if(!handle)
-                handle = dlopen("libCL.so", RTLD_LAZY);
-            initialized = true;
-            g_haveOpenCL = handle != 0 && dlsym(handle, oclFuncToCheck) != 0;
-        }
-        if(!handle)
-            return 0;
-    }
-
-    return funcname ? (void*)dlsym(handle, funcname) : 0;
-}
-
-#else
-
-static void* initOpenCLAndLoad(const char*)
-{
-    return 0;
-}
-
-#endif
-
-
-#define OCL_FUNC(rettype, funcname, argsdecl, args) \
-    typedef rettype (CV_STDCALL * funcname##_t) argsdecl; \
-    static rettype funcname argsdecl \
-    { \
-        static funcname##_t funcname##_p = 0; \
-        if( !funcname##_p ) \
-        { \
-            funcname##_p = (funcname##_t)initOpenCLAndLoad(#funcname); \
-            if( !funcname##_p ) \
-                return OPENCV_CL_NOT_IMPLEMENTED; \
-        } \
-        return funcname##_p args; \
-    }
-
-
-#define OCL_FUNC_P(rettype, funcname, argsdecl, args) \
-    typedef rettype (CV_STDCALL * funcname##_t) argsdecl; \
-    static rettype funcname argsdecl \
-    { \
-        static funcname##_t funcname##_p = 0; \
-        if( !funcname##_p ) \
-        { \
-            funcname##_p = (funcname##_t)initOpenCLAndLoad(#funcname); \
-            if( !funcname##_p ) \
-            { \
-                if( errcode_ret ) \
-                    *errcode_ret = OPENCV_CL_NOT_IMPLEMENTED; \
-                return 0; \
-            } \
-        } \
-        return funcname##_p args; \
-    }
-
-OCL_FUNC(cl_int, clGetPlatformIDs,
-    (cl_uint num_entries, cl_platform_id* platforms, cl_uint* num_platforms),
-    (num_entries, platforms, num_platforms))
-
-OCL_FUNC(cl_int, clGetPlatformInfo,
-    (cl_platform_id platform, cl_platform_info param_name,
-    size_t param_value_size, void * param_value,
-    size_t * param_value_size_ret),
-    (platform, param_name, param_value_size, param_value, param_value_size_ret))
-
-OCL_FUNC(cl_int, clGetDeviceInfo,
-         (cl_device_id device,
-          cl_device_info param_name,
-          size_t param_value_size,
-          void * param_value,
-          size_t * param_value_size_ret),
-         (device, param_name, param_value_size, param_value, param_value_size_ret))
-
-
-OCL_FUNC(cl_int, clGetDeviceIDs,
-    (cl_platform_id platform,
-    cl_device_type device_type,
-    cl_uint num_entries,
-    cl_device_id * devices,
-    cl_uint * num_devices),
-    (platform, device_type, num_entries, devices, num_devices))
-
-OCL_FUNC_P(cl_context, clCreateContext,
-    (const cl_context_properties * properties,
-    cl_uint num_devices,
-    const cl_device_id * devices,
-    void (CL_CALLBACK * pfn_notify)(const char *, const void *, size_t, void *),
-    void * user_data,
-    cl_int * errcode_ret),
-    (properties, num_devices, devices, pfn_notify, user_data, errcode_ret))
-
-OCL_FUNC(cl_int, clReleaseContext, (cl_context context), (context))
-
-
-OCL_FUNC(cl_int, clRetainContext, (cl_context context), (context))
-/*
-OCL_FUNC_P(cl_context, clCreateContextFromType,
-    (const cl_context_properties * properties,
-    cl_device_type device_type,
-    void (CL_CALLBACK * pfn_notify)(const char *, const void *, size_t, void *),
-    void * user_data,
-    cl_int * errcode_ret),
-    (properties, device_type, pfn_notify, user_data, errcode_ret))
-
-OCL_FUNC(cl_int, clGetContextInfo,
-    (cl_context context,
-    cl_context_info param_name,
-    size_t param_value_size,
-    void * param_value,
-    size_t * param_value_size_ret),
-    (context, param_name, param_value_size,
-    param_value, param_value_size_ret))
-*/
-OCL_FUNC_P(cl_command_queue, clCreateCommandQueue,
-    (cl_context context,
-    cl_device_id device,
-    cl_command_queue_properties properties,
-    cl_int * errcode_ret),
-    (context, device, properties, errcode_ret))
-
-OCL_FUNC(cl_int, clReleaseCommandQueue, (cl_command_queue command_queue), (command_queue))
-
-OCL_FUNC_P(cl_mem, clCreateBuffer,
-    (cl_context context,
-    cl_mem_flags flags,
-    size_t size,
-    void * host_ptr,
-    cl_int * errcode_ret),
-    (context, flags, size, host_ptr, errcode_ret))
-
-/*
-OCL_FUNC(cl_int, clRetainCommandQueue, (cl_command_queue command_queue), (command_queue))
-
-OCL_FUNC(cl_int, clGetCommandQueueInfo,
- (cl_command_queue command_queue,
- cl_command_queue_info param_name,
- size_t param_value_size,
- void * param_value,
- size_t * param_value_size_ret),
- (command_queue, param_name, param_value_size, param_value, param_value_size_ret))
-
-OCL_FUNC_P(cl_mem, clCreateSubBuffer,
-    (cl_mem buffer,
-    cl_mem_flags flags,
-    cl_buffer_create_type buffer_create_type,
-    const void * buffer_create_info,
-    cl_int * errcode_ret),
-    (buffer, flags, buffer_create_type, buffer_create_info, errcode_ret))
-*/
-
-OCL_FUNC_P(cl_mem, clCreateImage,
-    (cl_context context,
-    cl_mem_flags flags,
-    const cl_image_format * image_format,
-    const cl_image_desc * image_desc,
-    void * host_ptr,
-    cl_int * errcode_ret),
-    (context, flags, image_format, image_desc, host_ptr, errcode_ret))
-
-OCL_FUNC_P(cl_mem, clCreateImage2D,
-    (cl_context context,
-    cl_mem_flags flags,
-    const cl_image_format * image_format,
-    size_t image_width,
-    size_t image_height,
-    size_t image_row_pitch,
-    void * host_ptr,
-    cl_int *errcode_ret),
-    (context, flags, image_format, image_width, image_height, image_row_pitch, host_ptr, errcode_ret))
-
-OCL_FUNC(cl_int, clGetSupportedImageFormats,
- (cl_context context,
- cl_mem_flags flags,
- cl_mem_object_type image_type,
- cl_uint num_entries,
- cl_image_format * image_formats,
- cl_uint * num_image_formats),
- (context, flags, image_type, num_entries, image_formats, num_image_formats))
-
-
-OCL_FUNC(cl_int, clGetMemObjectInfo,
- (cl_mem memobj,
- cl_mem_info param_name,
- size_t param_value_size,
- void * param_value,
- size_t * param_value_size_ret),
- (memobj, param_name, param_value_size, param_value, param_value_size_ret))
-
-OCL_FUNC(cl_int, clGetImageInfo,
- (cl_mem image,
- cl_image_info param_name,
- size_t param_value_size,
- void * param_value,
- size_t * param_value_size_ret),
- (image, param_name, param_value_size, param_value, param_value_size_ret))
-
-/*
-OCL_FUNC(cl_int, clCreateKernelsInProgram,
- (cl_program program,
- cl_uint num_kernels,
- cl_kernel * kernels,
- cl_uint * num_kernels_ret),
- (program, num_kernels, kernels, num_kernels_ret))
-
-OCL_FUNC(cl_int, clRetainKernel, (cl_kernel kernel), (kernel))
-
-OCL_FUNC(cl_int, clGetKernelArgInfo,
- (cl_kernel kernel,
- cl_uint arg_indx,
- cl_kernel_arg_info param_name,
- size_t param_value_size,
- void * param_value,
- size_t * param_value_size_ret),
- (kernel, arg_indx, param_name, param_value_size, param_value, param_value_size_ret))
-
-OCL_FUNC(cl_int, clEnqueueReadImage,
- (cl_command_queue command_queue,
- cl_mem image,
- cl_bool blocking_read,
- const size_t * origin[3],
- const size_t * region[3],
- size_t row_pitch,
- size_t slice_pitch,
- void * ptr,
- cl_uint num_events_in_wait_list,
- const cl_event * event_wait_list,
- cl_event * event),
- (command_queue, image, blocking_read, origin, region,
- row_pitch, slice_pitch,
- ptr,
- num_events_in_wait_list,
- event_wait_list,
- event))
-
-OCL_FUNC(cl_int, clEnqueueWriteImage,
- (cl_command_queue command_queue,
- cl_mem image,
- cl_bool blocking_write,
- const size_t * origin[3],
- const size_t * region[3],
- size_t input_row_pitch,
- size_t input_slice_pitch,
- const void * ptr,
- cl_uint num_events_in_wait_list,
- const cl_event * event_wait_list,
- cl_event * event),
- (command_queue, image, blocking_write, origin, region, input_row_pitch,
- input_slice_pitch, ptr, num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueFillImage,
- (cl_command_queue command_queue,
- cl_mem image,
- const void * fill_color,
- const size_t * origin[3],
- const size_t * region[3],
- cl_uint num_events_in_wait_list,
- const cl_event * event_wait_list,
- cl_event * event),
- (command_queue, image, fill_color, origin, region,
- num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueCopyImage,
- (cl_command_queue command_queue,
- cl_mem src_image,
- cl_mem dst_image,
- const size_t * src_origin[3],
- const size_t * dst_origin[3],
- const size_t * region[3],
- cl_uint num_events_in_wait_list,
- const cl_event * event_wait_list,
- cl_event * event),
- (command_queue, src_image, dst_image, src_origin, dst_origin,
- region, num_events_in_wait_list, event_wait_list, event))
-*/
-
-OCL_FUNC(cl_int, clEnqueueCopyImageToBuffer,
- (cl_command_queue command_queue,
- cl_mem src_image,
- cl_mem dst_buffer,
- const size_t * src_origin,
- const size_t * region,
- size_t dst_offset,
- cl_uint num_events_in_wait_list,
- const cl_event * event_wait_list,
- cl_event * event),
- (command_queue, src_image, dst_buffer, src_origin, region, dst_offset,
- num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueCopyBufferToImage,
- (cl_command_queue command_queue,
- cl_mem src_buffer,
- cl_mem dst_image,
- size_t src_offset,
- const size_t dst_origin[3],
- const size_t region[3],
- cl_uint num_events_in_wait_list,
- const cl_event * event_wait_list,
- cl_event * event),
- (command_queue, src_buffer, dst_image, src_offset, dst_origin,
- region, num_events_in_wait_list, event_wait_list, event))
-
- OCL_FUNC(cl_int, clFlush,
- (cl_command_queue command_queue),
- (command_queue))
-
-/*
-OCL_FUNC_P(void*, clEnqueueMapImage,
- (cl_command_queue command_queue,
- cl_mem image,
- cl_bool blocking_map,
- cl_map_flags map_flags,
- const size_t * origin[3],
- const size_t * region[3],
- size_t * image_row_pitch,
- size_t * image_slice_pitch,
- cl_uint num_events_in_wait_list,
- const cl_event * event_wait_list,
- cl_event * event,
- cl_int * errcode_ret),
- (command_queue, image, blocking_map, map_flags, origin, region,
- image_row_pitch, image_slice_pitch, num_events_in_wait_list,
- event_wait_list, event, errcode_ret))
-*/
-
-/*
-OCL_FUNC(cl_int, clRetainProgram, (cl_program program), (program))
-
-OCL_FUNC(cl_int, clGetKernelInfo,
- (cl_kernel kernel,
- cl_kernel_info param_name,
- size_t param_value_size,
- void * param_value,
- size_t * param_value_size_ret),
- (kernel, param_name, param_value_size, param_value, param_value_size_ret))
-
-*/
-
-OCL_FUNC(cl_int, clRetainMemObject, (cl_mem memobj), (memobj))
-
-OCL_FUNC(cl_int, clReleaseMemObject, (cl_mem memobj), (memobj))
-
-
-OCL_FUNC_P(cl_program, clCreateProgramWithSource,
-    (cl_context context,
-    cl_uint count,
-    const char ** strings,
-    const size_t * lengths,
-    cl_int * errcode_ret),
-    (context, count, strings, lengths, errcode_ret))
-
-OCL_FUNC_P(cl_program, clCreateProgramWithBinary,
-    (cl_context context,
-    cl_uint num_devices,
-    const cl_device_id * device_list,
-    const size_t * lengths,
-    const unsigned char ** binaries,
-    cl_int * binary_status,
-    cl_int * errcode_ret),
-    (context, num_devices, device_list, lengths, binaries, binary_status, errcode_ret))
-
-OCL_FUNC(cl_int, clReleaseProgram, (cl_program program), (program))
-
-OCL_FUNC(cl_int, clBuildProgram,
-    (cl_program program,
-    cl_uint num_devices,
-    const cl_device_id * device_list,
-    const char * options,
-    void (CL_CALLBACK * pfn_notify)(cl_program, void *),
-    void * user_data),
-    (program, num_devices, device_list, options, pfn_notify, user_data))
-
-OCL_FUNC(cl_int, clGetProgramInfo,
-    (cl_program program,
-    cl_program_info param_name,
-    size_t param_value_size,
-    void * param_value,
-    size_t * param_value_size_ret),
-    (program, param_name, param_value_size, param_value, param_value_size_ret))
-
-OCL_FUNC(cl_int, clGetProgramBuildInfo,
-    (cl_program program,
-    cl_device_id device,
-    cl_program_build_info param_name,
-    size_t param_value_size,
-    void * param_value,
-    size_t * param_value_size_ret),
-    (program, device, param_name, param_value_size, param_value, param_value_size_ret))
-
-OCL_FUNC_P(cl_kernel, clCreateKernel,
-    (cl_program program,
-    const char * kernel_name,
-    cl_int * errcode_ret),
-    (program, kernel_name, errcode_ret))
-
-OCL_FUNC(cl_int, clReleaseKernel, (cl_kernel kernel), (kernel))
-
-OCL_FUNC(cl_int, clSetKernelArg,
-    (cl_kernel kernel,
-    cl_uint arg_index,
-    size_t arg_size,
-    const void * arg_value),
-    (kernel, arg_index, arg_size, arg_value))
-
-OCL_FUNC(cl_int, clGetKernelWorkGroupInfo,
-    (cl_kernel kernel,
-    cl_device_id device,
-    cl_kernel_work_group_info param_name,
-    size_t param_value_size,
-    void * param_value,
-    size_t * param_value_size_ret),
-    (kernel, device, param_name, param_value_size, param_value, param_value_size_ret))
-
-OCL_FUNC(cl_int, clFinish, (cl_command_queue command_queue), (command_queue))
-
-OCL_FUNC(cl_int, clEnqueueReadBuffer,
-    (cl_command_queue command_queue,
-    cl_mem buffer,
-    cl_bool blocking_read,
-    size_t offset,
-    size_t size,
-    void * ptr,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, buffer, blocking_read, offset, size, ptr,
-    num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueReadBufferRect,
-    (cl_command_queue command_queue,
-    cl_mem buffer,
-    cl_bool blocking_read,
-    const size_t * buffer_offset,
-    const size_t * host_offset,
-    const size_t * region,
-    size_t buffer_row_pitch,
-    size_t buffer_slice_pitch,
-    size_t host_row_pitch,
-    size_t host_slice_pitch,
-    void * ptr,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, buffer, blocking_read, buffer_offset, host_offset, region, buffer_row_pitch,
-    buffer_slice_pitch, host_row_pitch, host_slice_pitch, ptr, num_events_in_wait_list,
-    event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueWriteBuffer,
-    (cl_command_queue command_queue,
-    cl_mem buffer,
-    cl_bool blocking_write,
-    size_t offset,
-    size_t size,
-    const void * ptr,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, buffer, blocking_write, offset, size, ptr,
-    num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueWriteBufferRect,
-    (cl_command_queue command_queue,
-    cl_mem buffer,
-    cl_bool blocking_write,
-    const size_t * buffer_offset,
-    const size_t * host_offset,
-    const size_t * region,
-    size_t buffer_row_pitch,
-    size_t buffer_slice_pitch,
-    size_t host_row_pitch,
-    size_t host_slice_pitch,
-    const void * ptr,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, buffer, blocking_write, buffer_offset, host_offset,
-    region, buffer_row_pitch, buffer_slice_pitch, host_row_pitch,
-    host_slice_pitch, ptr, num_events_in_wait_list, event_wait_list, event))
-
-/*OCL_FUNC(cl_int, clEnqueueFillBuffer,
-    (cl_command_queue command_queue,
-    cl_mem buffer,
-    const void * pattern,
-    size_t pattern_size,
-    size_t offset,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, buffer, pattern, pattern_size, offset, size,
-    num_events_in_wait_list, event_wait_list, event))*/
-
-OCL_FUNC(cl_int, clEnqueueCopyBuffer,
-    (cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_buffer,
-    size_t src_offset,
-    size_t dst_offset,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, src_buffer, dst_buffer, src_offset, dst_offset,
-    size, num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueCopyBufferRect,
-    (cl_command_queue command_queue,
-    cl_mem src_buffer,
-    cl_mem dst_buffer,
-    const size_t * src_origin,
-    const size_t * dst_origin,
-    const size_t * region,
-    size_t src_row_pitch,
-    size_t src_slice_pitch,
-    size_t dst_row_pitch,
-    size_t dst_slice_pitch,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, src_buffer, dst_buffer, src_origin, dst_origin,
-    region, src_row_pitch, src_slice_pitch, dst_row_pitch, dst_slice_pitch,
-    num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC_P(void*, clEnqueueMapBuffer,
-    (cl_command_queue command_queue,
-    cl_mem buffer,
-    cl_bool blocking_map,
-    cl_map_flags map_flags,
-    size_t offset,
-    size_t size,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event,
-    cl_int * errcode_ret),
-    (command_queue, buffer, blocking_map, map_flags, offset, size,
-    num_events_in_wait_list, event_wait_list, event, errcode_ret))
-
-OCL_FUNC(cl_int, clEnqueueUnmapMemObject,
-    (cl_command_queue command_queue,
-    cl_mem memobj,
-    void * mapped_ptr,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, memobj, mapped_ptr, num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueNDRangeKernel,
-    (cl_command_queue command_queue,
-    cl_kernel kernel,
-    cl_uint work_dim,
-    const size_t * global_work_offset,
-    const size_t * global_work_size,
-    const size_t * local_work_size,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, kernel, work_dim, global_work_offset, global_work_size,
-    local_work_size, num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clEnqueueTask,
-    (cl_command_queue command_queue,
-    cl_kernel kernel,
-    cl_uint num_events_in_wait_list,
-    const cl_event * event_wait_list,
-    cl_event * event),
-    (command_queue, kernel, num_events_in_wait_list, event_wait_list, event))
-
-OCL_FUNC(cl_int, clSetEventCallback,
-    (cl_event event,
-    cl_int command_exec_callback_type ,
-    void (CL_CALLBACK  *pfn_event_notify) (cl_event event, cl_int event_command_exec_status, void *user_data),
-    void *user_data),
-    (event, command_exec_callback_type, pfn_event_notify, user_data))
-
-OCL_FUNC(cl_int, clReleaseEvent, (cl_event event), (event))
-
-}
-
-#endif
-
-#ifndef CL_VERSION_1_2
-#define CL_VERSION_1_2
-#endif
-
-#endif // HAVE_OPENCL
 
 #ifdef _DEBUG
 #define CV_OclDbgAssert CV_DbgAssert
@@ -1479,6 +290,7 @@ bool haveOpenCL()
 
 bool useOpenCL()
 {
+#ifdef HAVE_OPENCL
     CoreTLSData* data = getCoreTlsData().get();
     if( data->useOpenCL < 0 )
     {
@@ -1492,15 +304,22 @@ bool useOpenCL()
         }
     }
     return data->useOpenCL > 0;
+#else
+    return false;
+#endif
 }
 
 void setUseOpenCL(bool flag)
 {
+#ifdef HAVE_OPENCL
     if( haveOpenCL() )
     {
         CoreTLSData* data = getCoreTlsData().get();
         data->useOpenCL = (flag && Device::getDefault().ptr() != NULL) ? 1 : 0;
     }
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 #ifdef HAVE_CLAMDBLAS
@@ -1679,6 +498,7 @@ void finish()
 
 /////////////////////////////////////////// Platform /////////////////////////////////////////////
 
+#ifdef HAVE_OPENCL
 struct Platform::Impl
 {
     Impl()
@@ -1717,6 +537,12 @@ struct Platform::Impl
     String vendor;
     bool initialized;
 };
+#else
+struct Platform::Impl
+{
+    IMPLEMENT_REFCOUNTABLE();
+};
+#endif
 
 Platform::Platform()
 {
@@ -1749,11 +575,16 @@ Platform& Platform::operator = (const Platform& pl)
 
 void* Platform::ptr() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->handle : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 Platform& Platform::getDefault()
 {
+#ifdef HAVE_OPENCL
     static Platform p;
     if( !p.p )
     {
@@ -1761,9 +592,14 @@ Platform& Platform::getDefault()
         p.p->init();
     }
     return p;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 /////////////////////////////////////// Device ////////////////////////////////////////////
+
+#ifdef HAVE_OPENCL
 
 // deviceVersion has format
 //   OpenCL<space><major_version.minor_version><space><vendor-specific information>
@@ -1861,7 +697,12 @@ struct Device::Impl
     String vendorName_;
     int vendorID_;
 };
-
+#else
+struct Device::Impl
+{
+    IMPLEMENT_REFCOUNTABLE();
+};
+#endif
 
 Device::Device()
 {
@@ -1900,113 +741,130 @@ Device::~Device()
 
 void Device::set(void* d)
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
     p = new Impl(d);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 void* Device::ptr() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->handle : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 String Device::name() const
-{ return p ? p->name_ : String(); }
+OCL_CODE({ return p ? p->name_ : String(); })
 
 String Device::extensions() const
-{ return p ? p->getStrProp(CL_DEVICE_EXTENSIONS) : String(); }
+OCL_CODE({ return p ? p->getStrProp(CL_DEVICE_EXTENSIONS) : String(); })
 
 String Device::version() const
-{ return p ? p->version_ : String(); }
+OCL_CODE({ return p ? p->version_ : String(); })
 
 String Device::vendorName() const
-{ return p ? p->vendorName_ : String(); }
+OCL_CODE({ return p ? p->vendorName_ : String(); })
 
 int Device::vendorID() const
-{ return p ? p->vendorID_ : 0; }
+OCL_CODE({ return p ? p->vendorID_ : 0; })
 
 String Device::OpenCL_C_Version() const
-{ return p ? p->getStrProp(CL_DEVICE_OPENCL_C_VERSION) : String(); }
+OCL_CODE({ return p ? p->getStrProp(CL_DEVICE_OPENCL_C_VERSION) : String(); })
 
 String Device::OpenCLVersion() const
-{ return p ? p->getStrProp(CL_DEVICE_EXTENSIONS) : String(); }
+OCL_CODE({ return p ? p->getStrProp(CL_DEVICE_EXTENSIONS) : String(); })
 
 int Device::deviceVersionMajor() const
-{ return p ? p->deviceVersionMajor_ : 0; }
+OCL_CODE({ return p ? p->deviceVersionMajor_ : 0; })
 
 int Device::deviceVersionMinor() const
-{ return p ? p->deviceVersionMinor_ : 0; }
+OCL_CODE({ return p ? p->deviceVersionMinor_ : 0; })
 
 String Device::driverVersion() const
-{ return p ? p->driverVersion_ : String(); }
+OCL_CODE({ return p ? p->driverVersion_ : String(); })
 
 int Device::type() const
-{ return p ? p->type_ : 0; }
+OCL_CODE({ return p ? p->type_ : 0; })
 
 int Device::addressBits() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_ADDRESS_BITS) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_ADDRESS_BITS) : 0; })
 
 bool Device::available() const
-{ return p ? p->getBoolProp(CL_DEVICE_AVAILABLE) : false; }
+OCL_CODE({ return p ? p->getBoolProp(CL_DEVICE_AVAILABLE) : false; })
 
 bool Device::compilerAvailable() const
-{ return p ? p->getBoolProp(CL_DEVICE_COMPILER_AVAILABLE) : false; }
+OCL_CODE({ return p ? p->getBoolProp(CL_DEVICE_COMPILER_AVAILABLE) : false; })
 
 bool Device::linkerAvailable() const
+#ifdef HAVE_OPENCL
 #ifdef CL_VERSION_1_2
 { return p ? p->getBoolProp(CL_DEVICE_LINKER_AVAILABLE) : false; }
 #else
 { CV_REQUIRE_OPENCL_1_2_ERROR; }
 #endif
+#else
+{ OCL_NOT_AVAILABLE }
+#endif
 
 int Device::doubleFPConfig() const
-{ return p ? p->doubleFPConfig_ : 0; }
+OCL_CODE({ return p ? p->doubleFPConfig_ : 0; })
 
 int Device::singleFPConfig() const
-{ return p ? p->getProp<cl_device_fp_config, int>(CL_DEVICE_SINGLE_FP_CONFIG) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_device_fp_config, int>(CL_DEVICE_SINGLE_FP_CONFIG) : 0; })
 
 int Device::halfFPConfig() const
+#ifdef HAVE_OPENCL
 #ifdef CL_VERSION_1_2
 { return p ? p->getProp<cl_device_fp_config, int>(CL_DEVICE_HALF_FP_CONFIG) : 0; }
 #else
 { CV_REQUIRE_OPENCL_1_2_ERROR; }
 #endif
+#else
+{ OCL_NOT_AVAILABLE }
+#endif
 
 bool Device::endianLittle() const
-{ return p ? p->getBoolProp(CL_DEVICE_ENDIAN_LITTLE) : false; }
+OCL_CODE({ return p ? p->getBoolProp(CL_DEVICE_ENDIAN_LITTLE) : false; })
 
 bool Device::errorCorrectionSupport() const
-{ return p ? p->getBoolProp(CL_DEVICE_ERROR_CORRECTION_SUPPORT) : false; }
+OCL_CODE({ return p ? p->getBoolProp(CL_DEVICE_ERROR_CORRECTION_SUPPORT) : false; })
 
 int Device::executionCapabilities() const
-{ return p ? p->getProp<cl_device_exec_capabilities, int>(CL_DEVICE_EXECUTION_CAPABILITIES) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_device_exec_capabilities, int>(CL_DEVICE_EXECUTION_CAPABILITIES) : 0; })
 
 size_t Device::globalMemCacheSize() const
-{ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_GLOBAL_MEM_CACHE_SIZE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_GLOBAL_MEM_CACHE_SIZE) : 0; })
 
 int Device::globalMemCacheType() const
-{ return p ? p->getProp<cl_device_mem_cache_type, int>(CL_DEVICE_GLOBAL_MEM_CACHE_TYPE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_device_mem_cache_type, int>(CL_DEVICE_GLOBAL_MEM_CACHE_TYPE) : 0; })
 
 int Device::globalMemCacheLineSize() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE) : 0; })
 
 size_t Device::globalMemSize() const
-{ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_GLOBAL_MEM_SIZE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_GLOBAL_MEM_SIZE) : 0; })
 
 size_t Device::localMemSize() const
-{ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_LOCAL_MEM_SIZE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_LOCAL_MEM_SIZE) : 0; })
 
 int Device::localMemType() const
-{ return p ? p->getProp<cl_device_local_mem_type, int>(CL_DEVICE_LOCAL_MEM_TYPE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_device_local_mem_type, int>(CL_DEVICE_LOCAL_MEM_TYPE) : 0; })
 
 bool Device::hostUnifiedMemory() const
-{ return p ? p->hostUnifiedMemory_ : false; }
+OCL_CODE({ return p ? p->hostUnifiedMemory_ : false; })
 
 bool Device::imageSupport() const
-{ return p ? p->getBoolProp(CL_DEVICE_IMAGE_SUPPORT) : false; }
+OCL_CODE({ return p ? p->getBoolProp(CL_DEVICE_IMAGE_SUPPORT) : false; })
 
 bool Device::imageFromBufferSupport() const
 {
+#ifdef HAVE_OPENCL
     bool ret = false;
     if (p)
     {
@@ -2017,90 +875,112 @@ bool Device::imageFromBufferSupport() const
         }
     }
     return ret;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 uint Device::imagePitchAlignment() const
 {
+#ifdef HAVE_OPENCL
 #ifdef CL_DEVICE_IMAGE_PITCH_ALIGNMENT
     return p ? p->getProp<cl_uint, uint>(CL_DEVICE_IMAGE_PITCH_ALIGNMENT) : 0;
 #else
     return 0;
 #endif
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 uint Device::imageBaseAddressAlignment() const
 {
+#ifdef HAVE_OPENCL
 #ifdef CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT
     return p ? p->getProp<cl_uint, uint>(CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT) : 0;
 #else
     return 0;
 #endif
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 size_t Device::image2DMaxWidth() const
-{ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE2D_MAX_WIDTH) : 0; }
+OCL_CODE({ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE2D_MAX_WIDTH) : 0; })
 
 size_t Device::image2DMaxHeight() const
-{ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE2D_MAX_HEIGHT) : 0; }
+OCL_CODE({ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE2D_MAX_HEIGHT) : 0; })
 
 size_t Device::image3DMaxWidth() const
-{ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE3D_MAX_WIDTH) : 0; }
+OCL_CODE({ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE3D_MAX_WIDTH) : 0; })
 
 size_t Device::image3DMaxHeight() const
-{ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE3D_MAX_HEIGHT) : 0; }
+OCL_CODE({ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE3D_MAX_HEIGHT) : 0; })
 
 size_t Device::image3DMaxDepth() const
-{ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE3D_MAX_DEPTH) : 0; }
+OCL_CODE({ return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE3D_MAX_DEPTH) : 0; })
 
 size_t Device::imageMaxBufferSize() const
+#ifdef HAVE_OPENCL
 #ifdef CL_VERSION_1_2
 { return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE_MAX_BUFFER_SIZE) : 0; }
 #else
 { CV_REQUIRE_OPENCL_1_2_ERROR; }
 #endif
+#else
+{ OCL_NOT_AVAILABLE }
+#endif
+
 
 size_t Device::imageMaxArraySize() const
+#ifdef HAVE_OPENCL
 #ifdef CL_VERSION_1_2
 { return p ? p->getProp<size_t, size_t>(CL_DEVICE_IMAGE_MAX_ARRAY_SIZE) : 0; }
 #else
 { CV_REQUIRE_OPENCL_1_2_ERROR; }
 #endif
+#else
+{ OCL_NOT_AVAILABLE }
+#endif
+
 
 int Device::maxClockFrequency() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_CLOCK_FREQUENCY) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_CLOCK_FREQUENCY) : 0; })
 
 int Device::maxComputeUnits() const
-{ return p ? p->maxComputeUnits_ : 0; }
+OCL_CODE({ return p ? p->maxComputeUnits_ : 0; })
 
 int Device::maxConstantArgs() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_CONSTANT_ARGS) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_CONSTANT_ARGS) : 0; })
 
 size_t Device::maxConstantBufferSize() const
-{ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE) : 0; })
 
 size_t Device::maxMemAllocSize() const
-{ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_MAX_MEM_ALLOC_SIZE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_MAX_MEM_ALLOC_SIZE) : 0; })
 
 size_t Device::maxParameterSize() const
-{ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_MAX_PARAMETER_SIZE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_ulong, size_t>(CL_DEVICE_MAX_PARAMETER_SIZE) : 0; })
 
 int Device::maxReadImageArgs() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_READ_IMAGE_ARGS) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_READ_IMAGE_ARGS) : 0; })
 
 int Device::maxWriteImageArgs() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_WRITE_IMAGE_ARGS) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_WRITE_IMAGE_ARGS) : 0; })
 
 int Device::maxSamplers() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_SAMPLERS) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_SAMPLERS) : 0; })
 
 size_t Device::maxWorkGroupSize() const
-{ return p ? p->maxWorkGroupSize_ : 0; }
+OCL_CODE({ return p ? p->maxWorkGroupSize_ : 0; })
 
 int Device::maxWorkItemDims() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS) : 0; })
 
 void Device::maxWorkItemSizes(size_t* sizes) const
 {
+#ifdef HAVE_OPENCL
     if(p)
     {
         const int MAX_DIMS = 32;
@@ -2108,73 +988,86 @@ void Device::maxWorkItemSizes(size_t* sizes) const
         CV_OclDbgAssert(clGetDeviceInfo(p->handle, CL_DEVICE_MAX_WORK_ITEM_SIZES,
                 MAX_DIMS*sizeof(sizes[0]), &sizes[0], &retsz) == CL_SUCCESS);
     }
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 int Device::memBaseAddrAlign() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MEM_BASE_ADDR_ALIGN) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_MEM_BASE_ADDR_ALIGN) : 0; })
 
 int Device::nativeVectorWidthChar() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR) : 0; })
 
 int Device::nativeVectorWidthShort() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT) : 0; })
 
 int Device::nativeVectorWidthInt() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_INT) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_INT) : 0; })
 
 int Device::nativeVectorWidthLong() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG) : 0; })
 
 int Device::nativeVectorWidthFloat() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT) : 0; })
 
 int Device::nativeVectorWidthDouble() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE) : 0; })
 
 int Device::nativeVectorWidthHalf() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF) : 0; })
 
 int Device::preferredVectorWidthChar() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR) : 0; })
 
 int Device::preferredVectorWidthShort() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT) : 0; })
 
 int Device::preferredVectorWidthInt() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT) : 0; })
 
 int Device::preferredVectorWidthLong() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG) : 0; })
 
 int Device::preferredVectorWidthFloat() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT) : 0; })
 
 int Device::preferredVectorWidthDouble() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE) : 0; })
 
 int Device::preferredVectorWidthHalf() const
-{ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF) : 0; }
+OCL_CODE({ return p ? p->getProp<cl_uint, int>(CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF) : 0; })
 
 size_t Device::printfBufferSize() const
+#ifdef HAVE_OPENCL
 #ifdef CL_VERSION_1_2
 { return p ? p->getProp<size_t, size_t>(CL_DEVICE_PRINTF_BUFFER_SIZE) : 0; }
 #else
 { CV_REQUIRE_OPENCL_1_2_ERROR; }
 #endif
+#else
+{ OCL_NOT_AVAILABLE }
+#endif
 
 
 size_t Device::profilingTimerResolution() const
-{ return p ? p->getProp<size_t, size_t>(CL_DEVICE_PROFILING_TIMER_RESOLUTION) : 0; }
+OCL_CODE({ return p ? p->getProp<size_t, size_t>(CL_DEVICE_PROFILING_TIMER_RESOLUTION) : 0; })
 
 const Device& Device::getDefault()
 {
+#ifdef HAVE_OPENCL
     const Context& ctx = Context::getDefault();
     int idx = getCoreTlsData().get()->device;
     const Device& device = ctx.device(idx);
     return device;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 ////////////////////////////////////// Context ///////////////////////////////////////////////////
+
+#ifdef HAVE_OPENCL
 
 template <typename Functor, typename ObjectType>
 inline cl_int getStringInfo(Functor f, ObjectType obj, cl_uint name, std::string& param)
@@ -2239,12 +1132,6 @@ static bool parseOpenCLDeviceConfiguration(const std::string& configurationStr,
     return true;
 }
 
-#ifdef WINRT
-static cl_device_id selectOpenCLDevice()
-{
-    return NULL;
-}
-#else
 static cl_device_id selectOpenCLDevice()
 {
     std::string platform, deviceName;
@@ -2461,6 +1348,7 @@ static unsigned int getSVMCapabilitiesMask()
 } // namespace
 #endif
 
+#ifdef HAVE_OPENCL
 struct Context::Impl
 {
     static Context::Impl* get(Context& context) { return context.p; }
@@ -2748,7 +1636,8 @@ struct Context::Impl
     }
 #endif
 };
-
+#else
+#endif
 
 Context::Context()
 {
@@ -2758,11 +1647,14 @@ Context::Context()
 Context::Context(int dtype)
 {
     p = 0;
+#ifdef HAVE_OPENCL
     create(dtype);
+#endif
 }
 
 bool Context::create()
 {
+#ifdef HAVE_OPENCL
     if( !haveOpenCL() )
         return false;
     if(p)
@@ -2774,10 +1666,14 @@ bool Context::create()
         p = 0;
     }
     return p != 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Context::create(int dtype0)
 {
+#ifdef HAVE_OPENCL
     if( !haveOpenCL() )
         return false;
     if(p)
@@ -2789,53 +1685,71 @@ bool Context::create(int dtype0)
         p = 0;
     }
     return p != 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 Context::~Context()
 {
+#ifdef HAVE_OPENCL
     if (p)
     {
         p->release();
         p = NULL;
     }
+#endif
 }
 
 Context::Context(const Context& c)
 {
+#ifdef HAVE_OPENCL
     p = (Impl*)c.p;
     if(p)
         p->addref();
+#endif
 }
 
 Context& Context::operator = (const Context& c)
 {
+#ifdef HAVE_OPENCL
     Impl* newp = (Impl*)c.p;
     if(newp)
         newp->addref();
     if(p)
         p->release();
     p = newp;
+#endif
     return *this;
 }
 
 void* Context::ptr() const
 {
+#ifdef HAVE_OPENCL
     return p == NULL ? NULL : p->handle;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 size_t Context::ndevices() const
 {
-    return p ? p->devices.size() : 0;
+    OCL_CODE(return p ? p->devices.size() : 0;)
 }
 
 const Device& Context::device(size_t idx) const
 {
+#ifdef HAVE_OPENCL
     static Device dummy;
     return !p || idx >= p->devices.size() ? dummy : p->devices[idx];
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 Context& Context::getDefault(bool initialize)
 {
+#ifdef HAVE_OPENCL
     static Context* ctx = new Context();
     if(!ctx->p && haveOpenCL())
     {
@@ -2851,14 +1765,20 @@ Context& Context::getDefault(bool initialize)
                 ctx->p->setDefault();
         }
     }
-
     return *ctx;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 Program Context::getProg(const ProgramSource& prog,
                          const String& buildopts, String& errmsg)
 {
+#ifdef HAVE_OPENCL
     return p ? p->getProg(prog, buildopts, errmsg) : Program();
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 
@@ -2925,6 +1845,7 @@ CV_EXPORTS bool useSVM(UMatUsageFlags usageFlags)
 #endif // HAVE_OPENCL_SVM
 
 
+#ifdef HAVE_OPENCL
 static void get_platform_name(cl_platform_id id, String& name)
 {
     // get platform name string length
@@ -2942,12 +1863,14 @@ static void get_platform_name(cl_platform_id id, String& name)
 
     name = (const char*)buf;
 }
+#endif
 
 /*
 // Attaches OpenCL context to OpenCV
 */
 void attachContext(const String& platformName, void* platformID, void* context, void* deviceID)
 {
+#ifdef HAVE_OPENCL
     cl_uint cnt = 0;
 
     if(CL_SUCCESS != clGetPlatformIDs(0, 0, &cnt))
@@ -3000,11 +1923,15 @@ void attachContext(const String& platformName, void* platformID, void* context, 
     getCoreTlsData().get()->oclQueue = q;
 
     return;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 } // attachContext()
 
 
 void initializeContextFromHandle(Context& ctx, void* platform, void* _context, void* _device)
 {
+#ifdef HAVE_OPENCL
     cl_context context = (cl_context)_context;
     cl_device_id device = (cl_device_id)_device;
 
@@ -3023,10 +1950,14 @@ void initializeContextFromHandle(Context& ctx, void* platform, void* _context, v
     Platform& p = Platform::getDefault();
     Platform::Impl* pImpl = p.p;
     pImpl->handle = (cl_platform_id)platform;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 /////////////////////////////////////////// Queue /////////////////////////////////////////////
 
+#ifdef HAVE_OPENCL
 struct Queue::Impl
 {
     Impl(const Context& c, const Device& d)
@@ -3066,6 +1997,7 @@ struct Queue::Impl
 
     cl_command_queue handle;
 };
+#endif
 
 Queue::Queue()
 {
@@ -3080,57 +2012,82 @@ Queue::Queue(const Context& c, const Device& d)
 
 Queue::Queue(const Queue& q)
 {
+#ifdef HAVE_OPENCL
     p = q.p;
     if(p)
         p->addref();
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 Queue& Queue::operator = (const Queue& q)
 {
+#ifdef HAVE_OPENCL
     Impl* newp = (Impl*)q.p;
     if(newp)
         newp->addref();
     if(p)
         p->release();
     p = newp;
+#endif
     return *this;
 }
 
 Queue::~Queue()
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
+#endif
 }
 
 bool Queue::create(const Context& c, const Device& d)
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
     p = new Impl(c, d);
     return p->handle != 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 void Queue::finish()
 {
+#ifdef HAVE_OPENCL
     if(p && p->handle)
     {
         CV_OclDbgAssert(clFinish(p->handle) == CL_SUCCESS);
     }
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 void* Queue::ptr() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->handle : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 Queue& Queue::getDefault()
 {
+#ifdef HAVE_OPENCL
     Queue& q = getCoreTlsData().get()->oclQueue;
     if( !q.p && haveOpenCL() )
         q.create(Context::getDefault());
     return q;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
+#ifdef HAVE_OPENCL
 static cl_command_queue getQueue(const Queue& q)
 {
     cl_command_queue qq = (cl_command_queue)q.ptr();
@@ -3138,6 +2095,7 @@ static cl_command_queue getQueue(const Queue& q)
         qq = (cl_command_queue)Queue::getDefault().ptr();
     return qq;
 }
+#endif
 
 /////////////////////////////////////////// KernelArg /////////////////////////////////////////////
 
@@ -3159,6 +2117,7 @@ KernelArg KernelArg::Constant(const Mat& m)
 
 /////////////////////////////////////////// Kernel /////////////////////////////////////////////
 
+#ifdef HAVE_OPENCL
 struct Kernel::Impl
 {
     Impl(const char* kname, const Program& prog) :
@@ -3240,6 +2199,8 @@ static void CL_CALLBACK oclCleanupCallback(cl_event, cl_int, void *p)
 
 namespace cv { namespace ocl {
 
+#endif // HAVE_OPENCL
+
 Kernel::Kernel()
 {
     p = 0;
@@ -3261,29 +2222,36 @@ Kernel::Kernel(const char* kname, const ProgramSource& src,
 Kernel::Kernel(const Kernel& k)
 {
     p = k.p;
+#ifdef HAVE_OPENCL
     if(p)
         p->addref();
+#endif
 }
 
 Kernel& Kernel::operator = (const Kernel& k)
 {
+#ifdef HAVE_OPENCL
     Impl* newp = (Impl*)k.p;
     if(newp)
         newp->addref();
     if(p)
         p->release();
     p = newp;
+#endif
     return *this;
 }
 
 Kernel::~Kernel()
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
+#endif
 }
 
 bool Kernel::create(const char* kname, const Program& prog)
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
     p = new Impl(kname, prog);
@@ -3296,11 +2264,15 @@ bool Kernel::create(const char* kname, const Program& prog)
     CV_Assert(p);
 #endif
     return p != 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Kernel::create(const char* kname, const ProgramSource& src,
                     const String& buildopts, String* errmsg)
 {
+#ifdef HAVE_OPENCL
     if(p)
     {
         p->release();
@@ -3310,20 +2282,32 @@ bool Kernel::create(const char* kname, const ProgramSource& src,
     if( !errmsg ) errmsg = &tempmsg;
     const Program& prog = Context::getDefault().getProg(src, buildopts, *errmsg);
     return create(kname, prog);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 void* Kernel::ptr() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->handle : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Kernel::empty() const
 {
+#ifdef HAVE_OPENCL
     return ptr() == 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 int Kernel::set(int i, const void* value, size_t sz)
 {
+#ifdef HAVE_OPENCL
     if (!p || !p->handle)
         return -1;
     if (i < 0)
@@ -3336,22 +2320,34 @@ int Kernel::set(int i, const void* value, size_t sz)
     if (retval != CL_SUCCESS)
         return -1;
     return i+1;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 int Kernel::set(int i, const Image2D& image2D)
 {
+#ifdef HAVE_OPENCL
     p->addImage(image2D);
     cl_mem h = (cl_mem)image2D.ptr();
     return set(i, &h, sizeof(h));
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 int Kernel::set(int i, const UMat& m)
 {
+#ifdef HAVE_OPENCL
     return set(i, KernelArg(KernelArg::READ_WRITE, (UMat*)&m, 0, 0));
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 int Kernel::set(int i, const KernelArg& arg)
 {
+#ifdef HAVE_OPENCL
     if( !p || !p->handle )
         return -1;
     if (i < 0)
@@ -3432,12 +2428,16 @@ int Kernel::set(int i, const KernelArg& arg)
     }
     CV_OclDbgAssert(clSetKernelArg(p->handle, (cl_uint)i, arg.sz, arg.obj) == CL_SUCCESS);
     return i+1;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 
 bool Kernel::run(int dims, size_t _globalsize[], size_t _localsize[],
                  bool sync, const Queue& q)
 {
+#ifdef HAVE_OPENCL
     if(!p || !p->handle || p->e != 0)
         return false;
 
@@ -3478,10 +2478,14 @@ bool Kernel::run(int dims, size_t _globalsize[], size_t _localsize[],
         CV_OclDbgAssert(clSetEventCallback(p->e, CL_COMPLETE, oclCleanupCallback, p) == CL_SUCCESS);
     }
     return retval == CL_SUCCESS;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Kernel::runTask(bool sync, const Queue& q)
 {
+#ifdef HAVE_OPENCL
     if(!p || !p->handle || p->e != 0)
         return false;
 
@@ -3498,41 +2502,57 @@ bool Kernel::runTask(bool sync, const Queue& q)
         CV_OclDbgAssert(clSetEventCallback(p->e, CL_COMPLETE, oclCleanupCallback, p) == CL_SUCCESS);
     }
     return retval == CL_SUCCESS;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 
 size_t Kernel::workGroupSize() const
 {
+#ifdef HAVE_OPENCL
     if(!p || !p->handle)
         return 0;
     size_t val = 0, retsz = 0;
     cl_device_id dev = (cl_device_id)Device::getDefault().ptr();
     return clGetKernelWorkGroupInfo(p->handle, dev, CL_KERNEL_WORK_GROUP_SIZE,
                                     sizeof(val), &val, &retsz) == CL_SUCCESS ? val : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 size_t Kernel::preferedWorkGroupSizeMultiple() const
 {
+#ifdef HAVE_OPENCL
     if(!p || !p->handle)
         return 0;
     size_t val = 0, retsz = 0;
     cl_device_id dev = (cl_device_id)Device::getDefault().ptr();
     return clGetKernelWorkGroupInfo(p->handle, dev, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE,
                                     sizeof(val), &val, &retsz) == CL_SUCCESS ? val : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Kernel::compileWorkGroupSize(size_t wsz[]) const
 {
+#ifdef HAVE_OPENCL
     if(!p || !p->handle || !wsz)
         return 0;
     size_t retsz = 0;
     cl_device_id dev = (cl_device_id)Device::getDefault().ptr();
     return clGetKernelWorkGroupInfo(p->handle, dev, CL_KERNEL_COMPILE_WORK_GROUP_SIZE,
                                     sizeof(wsz[0])*3, wsz, &retsz) == CL_SUCCESS;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 size_t Kernel::localMemSize() const
 {
+#ifdef HAVE_OPENCL
     if(!p || !p->handle)
         return 0;
     size_t retsz = 0;
@@ -3540,10 +2560,14 @@ size_t Kernel::localMemSize() const
     cl_device_id dev = (cl_device_id)Device::getDefault().ptr();
     return clGetKernelWorkGroupInfo(p->handle, dev, CL_KERNEL_LOCAL_MEM_SIZE,
                                     sizeof(val), &val, &retsz) == CL_SUCCESS ? (size_t)val : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 /////////////////////////////////////////// Program /////////////////////////////////////////////
 
+#ifdef HAVE_OPENCL
 struct Program::Impl
 {
     Impl(const ProgramSource& _src,
@@ -3678,7 +2702,7 @@ struct Program::Impl
     String buildflags;
     cl_program handle;
 };
-
+#endif
 
 Program::Program() { p = 0; }
 
@@ -3691,31 +2715,38 @@ Program::Program(const ProgramSource& src,
 
 Program::Program(const Program& prog)
 {
+#ifdef HAVE_OPENCL
     p = prog.p;
     if(p)
         p->addref();
+#endif
 }
 
 Program& Program::operator = (const Program& prog)
 {
+#ifdef HAVE_OPENCL
     Impl* newp = (Impl*)prog.p;
     if(newp)
         newp->addref();
     if(p)
         p->release();
     p = newp;
+#endif
     return *this;
 }
 
 Program::~Program()
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
+#endif
 }
 
 bool Program::create(const ProgramSource& src,
             const String& buildflags, String& errmsg)
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
     p = new Impl(src, buildflags, errmsg);
@@ -3725,48 +2756,75 @@ bool Program::create(const ProgramSource& src,
         p = 0;
     }
     return p != 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 const ProgramSource& Program::source() const
 {
+#ifdef HAVE_OPENCL
     static ProgramSource dummy;
     return p ? p->src : dummy;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 void* Program::ptr() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->handle : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Program::read(const String& bin, const String& buildflags)
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
     p = new Impl(bin, buildflags);
     return p->handle != 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Program::write(String& bin) const
 {
+#ifdef HAVE_OPENCL
     if(!p)
         return false;
     bin = p->store();
     return !bin.empty();
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 String Program::getPrefix() const
 {
+#ifdef HAVE_OPENCL
     if(!p)
         return String();
     return getPrefix(p->buildflags);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 String Program::getPrefix(const String& buildflags)
 {
+#ifdef HAVE_OPENCL
     const Context& ctx = Context::getDefault();
     const Device& dev = ctx.device(0);
     return format("name=%s\ndriver=%s\nbuildflags=%s\n",
                   dev.name().c_str(), dev.driverVersion().c_str(), buildflags.c_str());
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 ///////////////////////////////////////// ProgramSource ///////////////////////////////////////////////
@@ -3844,6 +2902,7 @@ ProgramSource::hash_t ProgramSource::hash() const
     return p ? p->h : 0;
 }
 
+#ifdef HAVE_OPENCL
 //////////////////////////////////////////// OpenCLAllocator //////////////////////////////////////////////////
 
 template<typename T>
@@ -5236,16 +4295,21 @@ public:
 
     MatAllocator* matStdAllocator;
 };
+#endif
 
 // This line should not force OpenCL runtime initialization! (don't put "new OpenCLAllocator()" here)
 static MatAllocator *ocl_allocator = NULL;
 MatAllocator* getOpenCLAllocator()
 {
+#ifdef HAVE_OPENCL
     if (ocl_allocator == NULL)
     {
         ocl_allocator = new OpenCLAllocator();
     }
     return ocl_allocator;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 }} // namespace cv::ocl
@@ -5270,6 +4334,7 @@ namespace cv { namespace ocl {
 */
 void convertFromBuffer(void* cl_mem_buffer, size_t step, int rows, int cols, int type, UMat& dst)
 {
+#ifdef HAVE_OPENCL
     int d = 2;
     int sizes[] = { rows, cols };
 
@@ -5312,6 +4377,9 @@ void convertFromBuffer(void* cl_mem_buffer, size_t step, int rows, int cols, int
     dst.addref();
 
     return;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 } // convertFromBuffer()
 
 
@@ -5320,6 +4388,7 @@ void convertFromBuffer(void* cl_mem_buffer, size_t step, int rows, int cols, int
 */
 void convertFromImage(void* cl_mem_image, UMat& dst)
 {
+#ifdef HAVE_OPENCL
     cl_mem             clImage = (cl_mem)cl_mem_image;
     cl_mem_object_type mem_type = 0;
 
@@ -5406,11 +4475,15 @@ void convertFromImage(void* cl_mem_image, UMat& dst)
     CV_Assert(clFinish(q) == CL_SUCCESS);
 
     return;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 } // convertFromImage()
 
 
 ///////////////////////////////////////////// Utility functions /////////////////////////////////////////////////
 
+#ifdef HAVE_OPENCL
 static void getDevices(std::vector<cl_device_id>& devices, cl_platform_id platform)
 {
     cl_uint numDevices = 0;
@@ -5449,6 +4522,7 @@ struct PlatformInfo::Impl
     std::vector<cl_device_id> devices;
     cl_platform_id handle;
 };
+#endif
 
 PlatformInfo::PlatformInfo()
 {
@@ -5457,24 +4531,33 @@ PlatformInfo::PlatformInfo()
 
 PlatformInfo::PlatformInfo(void* platform_id)
 {
+#ifdef HAVE_OPENCL
     p = new Impl(platform_id);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 PlatformInfo::~PlatformInfo()
 {
+#ifdef HAVE_OPENCL
     if(p)
         p->release();
+#endif
 }
 
 PlatformInfo::PlatformInfo(const PlatformInfo& i)
 {
+#ifdef HAVE_OPENCL
     if (i.p)
         i.p->addref();
     p = i.p;
+#endif
 }
 
 PlatformInfo& PlatformInfo::operator =(const PlatformInfo& i)
 {
+#ifdef HAVE_OPENCL
     if (i.p != p)
     {
         if (i.p)
@@ -5483,36 +4566,58 @@ PlatformInfo& PlatformInfo::operator =(const PlatformInfo& i)
             p->release();
         p = i.p;
     }
+#endif
     return *this;
 }
 
 int PlatformInfo::deviceNumber() const
 {
+#ifdef HAVE_OPENCL
     return p ? (int)p->devices.size() : 0;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 void PlatformInfo::getDevice(Device& device, int d) const
 {
+#ifdef HAVE_OPENCL
     CV_Assert(p && d < (int)p->devices.size() );
     if(p)
         device.set(p->devices[d]);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 String PlatformInfo::name() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->getStrProp(CL_PLATFORM_NAME) : String();
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 String PlatformInfo::vendor() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->getStrProp(CL_PLATFORM_VENDOR) : String();
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 String PlatformInfo::version() const
 {
+#ifdef HAVE_OPENCL
     return p ? p->getStrProp(CL_PLATFORM_VERSION) : String();
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
+#ifdef HAVE_OPENCL
 static void getPlatforms(std::vector<cl_platform_id>& platforms)
 {
     cl_uint numPlatforms = 0;
@@ -5527,18 +4632,24 @@ static void getPlatforms(std::vector<cl_platform_id>& platforms)
     platforms.resize((size_t)numPlatforms);
     CV_OclDbgAssert(clGetPlatformIDs(numPlatforms, &platforms[0], &numPlatforms) == CL_SUCCESS);
 }
+#endif
 
 void getPlatfomsInfo(std::vector<PlatformInfo>& platformsInfo)
 {
+#ifdef HAVE_OPENCL
     std::vector<cl_platform_id> platforms;
     getPlatforms(platforms);
 
     for (size_t i = 0; i < platforms.size(); i++)
         platformsInfo.push_back( PlatformInfo((void*)&platforms[i]) );
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 const char* typeToStr(int type)
 {
+#ifdef HAVE_OPENCL
     static const char* tab[]=
     {
         "uchar", "uchar2", "uchar3", "uchar4", 0, 0, 0, "uchar8", 0, 0, 0, 0, 0, 0, 0, "uchar16",
@@ -5552,10 +4663,14 @@ const char* typeToStr(int type)
     };
     int cn = CV_MAT_CN(type), depth = CV_MAT_DEPTH(type);
     return cn > 16 ? "?" : tab[depth*16 + cn-1];
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 const char* memopTypeToStr(int type)
 {
+#ifdef HAVE_OPENCL
     static const char* tab[] =
     {
         "uchar", "uchar2", "uchar3", "uchar4", 0, 0, 0, "uchar8", 0, 0, 0, 0, 0, 0, 0, "uchar16",
@@ -5569,10 +4684,14 @@ const char* memopTypeToStr(int type)
     };
     int cn = CV_MAT_CN(type), depth = CV_MAT_DEPTH(type);
     return cn > 16 ? "?" : tab[depth*16 + cn-1];
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 const char* vecopTypeToStr(int type)
 {
+#ifdef HAVE_OPENCL
     static const char* tab[] =
     {
         "uchar", "short", "uchar3", "int", 0, 0, 0, "int2", 0, 0, 0, 0, 0, 0, 0, "int4",
@@ -5586,10 +4705,14 @@ const char* vecopTypeToStr(int type)
     };
     int cn = CV_MAT_CN(type), depth = CV_MAT_DEPTH(type);
     return cn > 16 ? "?" : tab[depth*16 + cn-1];
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 const char* convertTypeStr(int sdepth, int ddepth, int cn, char* buf)
 {
+#ifdef HAVE_OPENCL
     if( sdepth == ddepth )
         return "noconvert";
     const char *typestr = typeToStr(CV_MAKETYPE(ddepth, cn));
@@ -5606,8 +4729,12 @@ const char* convertTypeStr(int sdepth, int ddepth, int cn, char* buf)
         sprintf(buf, "convert_%s_sat", typestr);
 
     return buf;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
+#ifdef HAVE_OPENCL
 template <typename T>
 static std::string kerToStr(const Mat & k)
 {
@@ -5639,9 +4766,11 @@ static std::string kerToStr(const Mat & k)
 
     return stream.str();
 }
+#endif
 
 String kernelToStr(InputArray _kernel, int ddepth, const char * name)
 {
+#ifdef HAVE_OPENCL
     Mat kernel = _kernel.getMat().reshape(1, 1);
 
     int depth = kernel.depth();
@@ -5658,6 +4787,9 @@ String kernelToStr(InputArray _kernel, int ddepth, const char * name)
     CV_Assert(func != 0);
 
     return cv::format(" -D %s=%s", name ? name : "COEFF", func(kernel).c_str());
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 #define PROCESS_SRC(src) \
@@ -5687,6 +4819,7 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
                               InputArray src7, InputArray src8, InputArray src9,
                               OclVectorStrategy strat)
 {
+#ifdef HAVE_OPENCL
     const ocl::Device & d = ocl::Device::getDefault();
 
     int vectorWidths[] = { d.preferredVectorWidthChar(), d.preferredVectorWidthChar(),
@@ -5704,6 +4837,9 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
     }
 
     return checkOptimalVectorWidth(vectorWidths, src1, src2, src3, src4, src5, src6, src7, src8, src9, strat);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 int checkOptimalVectorWidth(const int *vectorWidths,
@@ -5712,6 +4848,7 @@ int checkOptimalVectorWidth(const int *vectorWidths,
                             InputArray src7, InputArray src8, InputArray src9,
                             OclVectorStrategy strat)
 {
+#ifdef HAVE_OPENCL
     CV_Assert(vectorWidths);
 
     int ref_type = src1.type();
@@ -5738,6 +4875,9 @@ int checkOptimalVectorWidth(const int *vectorWidths,
     int kercn = *std::min_element(kercns.begin(), kercns.end());
 
     return kercn;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 int predictOptimalVectorWidthMax(InputArray src1, InputArray src2, InputArray src3,
@@ -5753,6 +4893,7 @@ int predictOptimalVectorWidthMax(InputArray src1, InputArray src2, InputArray sr
 // TODO Make this as a method of OpenCL "BuildOptions" class
 void buildOptionsAddMatrixDescription(String& buildOptions, const String& name, InputArray _m)
 {
+#ifdef HAVE_OPENCL
     if (!buildOptions.empty())
         buildOptions += " ";
     int type = _m.type(), depth = CV_MAT_DEPTH(type);
@@ -5765,9 +4906,12 @@ void buildOptionsAddMatrixDescription(String& buildOptions, const String& name, 
             name.c_str(), (int)CV_ELEM_SIZE1(type),
             name.c_str(), (int)depth
             );
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
-
+#ifdef HAVE_OPENCL
 struct Image2D::Impl
 {
     Impl(const UMat &src, bool norm, bool alias)
@@ -5912,6 +5056,7 @@ struct Image2D::Impl
 
     cl_mem handle;
 };
+#endif
 
 Image2D::Image2D()
 {
@@ -5920,11 +5065,16 @@ Image2D::Image2D()
 
 Image2D::Image2D(const UMat &src, bool norm, bool alias)
 {
+#ifdef HAVE_OPENCL
     p = new Impl(src, norm, alias);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Image2D::canCreateAlias(const UMat &m)
 {
+#ifdef HAVE_OPENCL
     bool ret = false;
     const Device & d = ocl::Device::getDefault();
     if (d.imageFromBufferSupport() && !m.empty())
@@ -5942,24 +5092,34 @@ bool Image2D::canCreateAlias(const UMat &m)
         }
     }
     return ret;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool Image2D::isFormatSupported(int depth, int cn, bool norm)
 {
+#ifdef HAVE_OPENCL
     cl_image_format format = Impl::getImageFormat(depth, cn, norm);
 
     return Impl::isFormatSupported(format);
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 Image2D::Image2D(const Image2D & i)
 {
+#ifdef HAVE_OPENCL
     p = i.p;
     if (p)
         p->addref();
+#endif
 }
 
 Image2D & Image2D::operator = (const Image2D & i)
 {
+#ifdef HAVE_OPENCL
     if (i.p != p)
     {
         if (i.p)
@@ -5968,22 +5128,26 @@ Image2D & Image2D::operator = (const Image2D & i)
             p->release();
         p = i.p;
     }
+#endif
     return *this;
 }
 
 Image2D::~Image2D()
 {
+#ifdef HAVE_OPENCL
     if (p)
         p->release();
+#endif
 }
 
 void* Image2D::ptr() const
 {
-    return p ? p->handle : 0;
+    OCL_CODE(return p ? p->handle : 0;)
 }
 
 bool internal::isPerformanceCheckBypassed()
 {
+#ifdef HAVE_OPENCL
     static bool initialized = false;
     static bool value = false;
     if (!initialized)
@@ -5992,10 +5156,14 @@ bool internal::isPerformanceCheckBypassed()
         initialized = true;
     }
     return value;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 bool internal::isCLBuffer(UMat& u)
 {
+#ifdef HAVE_OPENCL
     void* h = u.handle(ACCESS_RW);
     if (!h)
         return true;
@@ -6010,6 +5178,9 @@ bool internal::isCLBuffer(UMat& u)
         return false;
 #endif
     return true;
+#else
+    OCL_NOT_AVAILABLE
+#endif
 }
 
 }}

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -264,9 +264,9 @@ struct ImplCollector
 struct CoreTLSData
 {
     CoreTLSData() :
-#ifdef HAVE_OPENCL
+//#ifdef HAVE_OPENCL
         device(0), useOpenCL(-1),
-#endif
+//#endif
         useIPP(-1)
     {
 #ifdef HAVE_TEGRA_OPTIMIZATION
@@ -275,11 +275,11 @@ struct CoreTLSData
     }
 
     RNG rng;
-#ifdef HAVE_OPENCL
+//#ifdef HAVE_OPENCL
     int device;
     ocl::Queue oclQueue;
     int useOpenCL; // 1 - use, 0 - do not use, -1 - auto/not initialized
-#endif
+//#endif
     int useIPP; // 1 - use, 0 - do not use, -1 - auto/not initialized
 #ifdef HAVE_TEGRA_OPTIMIZATION
     int useTegra; // 1 - use, 0 - do not use, -1 - auto/not initialized

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -53,7 +53,9 @@
 
 #include "opencv2/core/private.hpp"
 #include "opencv2/core/private.cuda.hpp"
+#ifdef HAVE_OPENCL
 #include "opencv2/core/ocl.hpp"
+#endif
 
 #include "opencv2/hal.hpp"
 
@@ -261,7 +263,11 @@ struct ImplCollector
 
 struct CoreTLSData
 {
-    CoreTLSData() : device(0), useOpenCL(-1), useIPP(-1)
+    CoreTLSData() :
+#ifdef HAVE_OPENCL
+        device(0), useOpenCL(-1),
+#endif
+        useIPP(-1)
     {
 #ifdef HAVE_TEGRA_OPTIMIZATION
         useTegra = -1;
@@ -269,9 +275,11 @@ struct CoreTLSData
     }
 
     RNG rng;
+#ifdef HAVE_OPENCL
     int device;
     ocl::Queue oclQueue;
     int useOpenCL; // 1 - use, 0 - do not use, -1 - auto/not initialized
+#endif
     int useIPP; // 1 - use, 0 - do not use, -1 - auto/not initialized
 #ifdef HAVE_TEGRA_OPTIMIZATION
     int useTegra; // 1 - use, 0 - do not use, -1 - auto/not initialized

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -264,9 +264,9 @@ struct ImplCollector
 struct CoreTLSData
 {
     CoreTLSData() :
-//#ifdef HAVE_OPENCL
+#ifdef HAVE_OPENCL
         device(0), useOpenCL(-1),
-//#endif
+#endif
         useIPP(-1)
     {
 #ifdef HAVE_TEGRA_OPTIMIZATION
@@ -275,11 +275,11 @@ struct CoreTLSData
     }
 
     RNG rng;
-//#ifdef HAVE_OPENCL
+#ifdef HAVE_OPENCL
     int device;
     ocl::Queue oclQueue;
     int useOpenCL; // 1 - use, 0 - do not use, -1 - auto/not initialized
-//#endif
+#endif
     int useIPP; // 1 - use, 0 - do not use, -1 - auto/not initialized
 #ifdef HAVE_TEGRA_OPTIMIZATION
     int useTegra; // 1 - use, 0 - do not use, -1 - auto/not initialized

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -391,7 +391,9 @@ void setUseOptimized( bool flag )
     USE_SSE2 = currentFeatures->have[CV_CPU_SSE2];
 
     ipp::setUseIPP(flag);
+#ifdef HAVE_OPENCL
     ocl::setUseOpenCL(flag);
+#endif
 #ifdef HAVE_TEGRA_OPTIMIZATION
     ::tegra::setUseTegra(flag);
 #endif

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -524,6 +524,7 @@ INSTANTIATE_TEST_CASE_P(UMat, UMatTestUMatOperations, Combine(OCL_ALL_DEPTHS, OC
 
 ///////////////////////////////////////////////////////////////// OpenCL ////////////////////////////////////////////////////////////////////////////
 
+#ifdef HAVE_OPENCL
 TEST(UMat, BufferPoolGrowing)
 {
 #ifdef _DEBUG
@@ -549,6 +550,7 @@ TEST(UMat, BufferPoolGrowing)
     else
         std::cout << "Skipped, no OpenCL" << std::endl;
 }
+#endif
 
 class CV_UMatTest :
         public cvtest::BaseTest
@@ -771,6 +773,10 @@ TEST(UMat, CopyToIfDeviceCopyIsObsolete)
 
 TEST(UMat, setOpenCL)
 {
+#ifndef HAVE_OPENCL
+    return; // test skipped
+#endif
+
     // save the current state
     bool useOCL = cv::ocl::useOpenCL();
 

--- a/modules/features2d/src/fast.cpp
+++ b/modules/features2d/src/fast.cpp
@@ -250,6 +250,7 @@ void FAST_t(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bo
     }
 }
 
+#ifdef HAVE_OPENCL
 template<typename pt>
 struct cmp_pt
 {
@@ -326,16 +327,18 @@ static bool ocl_FAST( InputArray _img, std::vector<KeyPoint>& keypoints,
 
     return true;
 }
-
+#endif
 
 void FAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool nonmax_suppression, int type)
 {
+#ifdef HAVE_OPENCL
   if( ocl::useOpenCL() && _img.isUMat() && type == FastFeatureDetector::TYPE_9_16 &&
       ocl_FAST(_img, keypoints, threshold, nonmax_suppression, 10000))
   {
     CV_IMPL_ADD(CV_IMPL_OCL);
     return;
   }
+#endif
 
   switch(type) {
     case FastFeatureDetector::TYPE_5_8:

--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -52,6 +52,7 @@ namespace cv
 
 /////////////////////// ocl functions for BFMatcher ///////////////////////////
 
+#ifdef HAVE_OPENCL
 static void ensureSizeIsEnough(int rows, int cols, int type, UMat &m)
 {
     if (m.type() == type && m.rows >= rows && m.cols >= cols)
@@ -390,6 +391,7 @@ static bool ocl_radiusMatchDownload(const UMat &trainIdx, const UMat &distance, 
 
     return ocl_radiusMatchConvert(trainIdxCPU, distanceCPU, nMatchesCPU, matches, compactResult);
 }
+#endif
 
 /****************************************************************************************\
 *                                      DescriptorMatcher                                 *
@@ -693,6 +695,7 @@ Ptr<DescriptorMatcher> BFMatcher::clone( bool emptyTrainData ) const
     return matcher;
 }
 
+#ifdef HAVE_OPENCL
 static bool ocl_match(InputArray query, InputArray _train, std::vector< std::vector<DMatch> > &matches, int dstType)
 {
     UMat trainIdx, distance;
@@ -714,6 +717,7 @@ static bool ocl_knnMatch(InputArray query, InputArray _train, std::vector< std::
         return false;
     return true;
 }
+#endif
 
 void BFMatcher::knnMatchImpl( InputArray _queryDescriptors, std::vector<std::vector<DMatch> >& matches, int knn,
                              InputArrayOfArrays _masks, bool compactResult )
@@ -744,6 +748,7 @@ void BFMatcher::knnMatchImpl( InputArray _queryDescriptors, std::vector<std::vec
         utrainDescCollection.clear();
     }
 
+#ifdef HAVE_OPENCL
     int trainDescVectorSize = trainDescCollection.empty() ? (int)utrainDescCollection.size() : (int)trainDescCollection.size();
     Size trainDescSize = trainDescCollection.empty() ? utrainDescCollection[0].size() : trainDescCollection[0].size();
     int trainDescOffset = trainDescCollection.empty() ? (int)utrainDescCollection[0].offset : 0;
@@ -791,6 +796,7 @@ void BFMatcher::knnMatchImpl( InputArray _queryDescriptors, std::vector<std::vec
             }
         }
     }
+#endif
 
     Mat queryDescriptors = _queryDescriptors.getMat();
     if(trainDescCollection.empty() && !utrainDescCollection.empty())
@@ -851,6 +857,7 @@ void BFMatcher::knnMatchImpl( InputArray _queryDescriptors, std::vector<std::vec
     }
 }
 
+#ifdef HAVE_OPENCL
 static bool ocl_radiusMatch(InputArray query, InputArray _train, std::vector< std::vector<DMatch> > &matches,
         float maxDistance, int dstType, bool compactResult)
 {
@@ -861,6 +868,7 @@ static bool ocl_radiusMatch(InputArray query, InputArray _train, std::vector< st
         return false;
     return true;
 }
+#endif
 
 void BFMatcher::radiusMatchImpl( InputArray _queryDescriptors, std::vector<std::vector<DMatch> >& matches,
                                 float maxDistance, InputArrayOfArrays _masks, bool compactResult )
@@ -888,6 +896,7 @@ void BFMatcher::radiusMatchImpl( InputArray _queryDescriptors, std::vector<std::
         utrainDescCollection.clear();
     }
 
+#ifdef HAVE_OPENCL
     int trainDescVectorSize = trainDescCollection.empty() ? (int)utrainDescCollection.size() : (int)trainDescCollection.size();
     Size trainDescSize = trainDescCollection.empty() ? utrainDescCollection[0].size() : trainDescCollection[0].size();
     int trainDescOffset = trainDescCollection.empty() ? (int)utrainDescCollection[0].offset : 0;
@@ -913,6 +922,7 @@ void BFMatcher::radiusMatchImpl( InputArray _queryDescriptors, std::vector<std::
             }
         }
     }
+#endif
 
     Mat queryDescriptors = _queryDescriptors.getMat();
     if(trainDescCollection.empty() && !utrainDescCollection.empty())

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -1040,7 +1040,7 @@ public:
 struct getRect { Rect operator ()(const CvAvgComp& e) const { return e.rect; } };
 struct getNeighbors { int operator ()(const CvAvgComp& e) const { return e.neighbors; } };
 
-
+#ifdef HAVE_OPENCL
 bool CascadeClassifierImpl::ocl_detectMultiScaleNoGrouping( const std::vector<float>& scales,
                                                             std::vector<Rect>& candidates )
 {
@@ -1171,6 +1171,7 @@ bool CascadeClassifierImpl::ocl_detectMultiScaleNoGrouping( const std::vector<fl
     }
     return ok;
 }
+#endif
 
 bool CascadeClassifierImpl::isOldFormatCascade() const
 {
@@ -1278,10 +1279,12 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
     if( scales.size() == 0 || !featureEvaluator->setImage(gray, scales) )
         return;
 
+#ifdef HAVE_OPENCL
     // OpenCL code
     CV_OCL_RUN(use_ocl, ocl_detectMultiScaleNoGrouping( scales, candidates ))
 
     tryOpenCL = false;
+#endif
 
     // CPU code
     featureEvaluator->getMats();
@@ -1527,9 +1530,11 @@ bool CascadeClassifierImpl::Data::read(const FileNode &root)
 
 bool CascadeClassifierImpl::read_(const FileNode& root)
 {
+#ifdef HAVE_OPENCL
     tryOpenCL = true;
     haarKernel = ocl::Kernel();
     lbpKernel = ocl::Kernel();
+#endif
     ustages.release();
     unodes.release();
     uleaves.release();

--- a/modules/objdetect/src/cascadedetect.hpp
+++ b/modules/objdetect/src/cascadedetect.hpp
@@ -125,9 +125,10 @@ protected:
                             int yStep, double factor, std::vector<Rect>& candidates,
                             std::vector<int>& rejectLevels, std::vector<double>& levelWeights,
                             Size sumSize0, bool outputRejectLevels = false );
+#ifdef HAVE_OPENCL
     bool ocl_detectMultiScaleNoGrouping( const std::vector<float>& scales,
                                          std::vector<Rect>& candidates );
-
+#endif
     void detectMultiScaleNoGrouping( InputArray image, std::vector<Rect>& candidates,
                                     std::vector<int>& rejectLevels, std::vector<double>& levelWeights,
                                     double scaleFactor, Size minObjectSize, Size maxObjectSize,
@@ -218,8 +219,10 @@ protected:
     Ptr<MaskGenerator> maskGenerator;
     UMat ugrayImage;
     UMat ufacepos, ustages, unodes, uleaves, usubsets;
+#ifdef HAVE_OPENCL
     ocl::Kernel haarKernel, lbpKernel;
     bool tryOpenCL;
+#endif
 
     Mutex mtx;
 };

--- a/modules/stitching/src/warpers.cpp
+++ b/modules/stitching/src/warpers.cpp
@@ -110,6 +110,7 @@ Rect PlaneWarper::buildMaps(Size src_size, InputArray K, InputArray R, InputArra
     _xmap.create(dsize, CV_32FC1);
     _ymap.create(dsize, CV_32FC1);
 
+#ifdef HAVE_OPENCL
     if (ocl::useOpenCL())
     {
         ocl::Kernel k("buildWarpPlaneMaps", ocl::stitching::warpers_oclsrc);
@@ -132,6 +133,7 @@ Rect PlaneWarper::buildMaps(Size src_size, InputArray K, InputArray R, InputArra
             }
         }
     }
+#endif
 
     Mat xmap = _xmap.getMat(), ymap = _ymap.getMat();
 
@@ -310,6 +312,7 @@ void SphericalPortraitWarper::detectResultRoi(Size src_size, Point &dst_tl, Poin
 
 Rect SphericalWarper::buildMaps(Size src_size, InputArray K, InputArray R, OutputArray xmap, OutputArray ymap)
 {
+#ifdef HAVE_OPENCL
     if (ocl::useOpenCL())
     {
         ocl::Kernel k("buildWarpSphericalMaps", ocl::stitching::warpers_oclsrc);
@@ -339,7 +342,7 @@ Rect SphericalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Outpu
             }
         }
     }
-
+#endif
     return RotationWarperBase<SphericalProjector>::buildMaps(src_size, K, R, xmap, ymap);
 }
 
@@ -358,6 +361,7 @@ Point SphericalWarper::warp(InputArray src, InputArray K, InputArray R, int inte
 
 Rect CylindricalWarper::buildMaps(Size src_size, InputArray K, InputArray R, OutputArray xmap, OutputArray ymap)
 {
+#ifdef HAVE_OPENCL
     if (ocl::useOpenCL())
     {
         ocl::Kernel k("buildWarpCylindricalMaps", ocl::stitching::warpers_oclsrc);
@@ -388,7 +392,7 @@ Rect CylindricalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Out
             }
         }
     }
-
+#endif
     return RotationWarperBase<CylindricalProjector>::buildMaps(src_size, K, R, xmap, ymap);
 }
 

--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -142,8 +142,9 @@ public:
         fCT = defaultfCT2;
         nShadowDetection =  defaultnShadowDetection2;
         fTau = defaultfTau;
-
+#ifdef HAVE_OPENCL
         opencl_ON = true;
+#endif
     }
     //! the full constructor that takes the length of the history,
     // the number of gaussian mixtures, the background ratio parameter and the noise strength
@@ -168,8 +169,9 @@ public:
         nShadowDetection =  defaultnShadowDetection2;
         fTau = defaultfTau;
         name_ = "BackgroundSubtractor.MOG2";
-
+#ifdef HAVE_OPENCL
         opencl_ON = true;
+#endif
     }
     //! the destructor
     ~BackgroundSubtractorMOG2Impl() {}
@@ -190,6 +192,7 @@ public:
         CV_Assert( nchannels <= CV_CN_MAX );
         CV_Assert( nmixtures <= 255);
 
+#ifdef HAVE_OPENCL
         if (ocl::useOpenCL() && opencl_ON)
         {
             create_ocl_apply_kernel();
@@ -218,6 +221,7 @@ public:
             u_bgmodelUsedModes.setTo(cv::Scalar::all(0));
         }
         else
+#endif
         {
             // for each gaussian mixture of each pixel bg model we store ...
             // the mixture weight (w),
@@ -263,11 +267,13 @@ public:
         if ((bShadowDetection && detectshadows) || (!bShadowDetection && !detectshadows))
             return;
         bShadowDetection = detectshadows;
+#ifdef HAVE_OPENCL
         if (!kernel_apply.empty())
         {
             create_ocl_apply_kernel();
             CV_Assert( !kernel_apply.empty() );
         }
+#endif
     }
 
     virtual int getShadowValue() const { return nShadowDetection; }
@@ -316,6 +322,7 @@ protected:
     Mat bgmodel;
     Mat bgmodelUsedModes;//keep track of number of modes per pixel
 
+#ifdef HAVE_OPENCL
     //for OCL
 
     mutable bool opencl_ON;
@@ -327,6 +334,7 @@ protected:
 
     mutable ocl::Kernel kernel_apply;
     mutable ocl::Kernel kernel_getBg;
+#endif
 
     int nframes;
     int history;
@@ -379,9 +387,11 @@ protected:
 
     String name_;
 
+#ifdef HAVE_OPENCL
     bool ocl_getBackgroundImage(OutputArray backgroundImage) const;
     bool ocl_apply(InputArray _image, OutputArray _fgmask, double learningRate=-1);
     void create_ocl_apply_kernel();
+#endif
 };
 
 struct GaussBGStatModel2Params
@@ -810,14 +820,14 @@ bool BackgroundSubtractorMOG2Impl::ocl_getBackgroundImage(OutputArray _backgroun
     return kernel_getBg.run(2, globalsize, NULL, false);
 }
 
-#endif
-
 void BackgroundSubtractorMOG2Impl::create_ocl_apply_kernel()
 {
     int nchannels = CV_MAT_CN(frameType);
     String opts = format("-D CN=%d -D NMIXTURES=%d%s", nchannels, nmixtures, bShadowDetection ? " -D SHADOW_DETECT" : "");
     kernel_apply.create("mog2_kernel", ocl::video::bgfg_mog2_oclsrc, opts);
 }
+
+#endif
 
 void BackgroundSubtractorMOG2Impl::apply(InputArray _image, OutputArray _fgmask, double learningRate)
 {
@@ -826,6 +836,7 @@ void BackgroundSubtractorMOG2Impl::apply(InputArray _image, OutputArray _fgmask,
     if( needToInitialize )
         initialize(_image.size(), _image.type());
 
+#ifdef HAVE_OPENCL
     if (opencl_ON)
     {
         CV_OCL_RUN(opencl_ON, ocl_apply(_image, _fgmask, learningRate))
@@ -833,6 +844,7 @@ void BackgroundSubtractorMOG2Impl::apply(InputArray _image, OutputArray _fgmask,
         opencl_ON = false;
         initialize(_image.size(), _image.type());
     }
+#endif
 
     Mat image = _image.getMat();
     _fgmask.create( image.size(), CV_8U );
@@ -856,6 +868,7 @@ void BackgroundSubtractorMOG2Impl::apply(InputArray _image, OutputArray _fgmask,
 
 void BackgroundSubtractorMOG2Impl::getBackgroundImage(OutputArray backgroundImage) const
 {
+#ifdef HAVE_OPENCL
     if (opencl_ON)
     {
         CV_OCL_RUN(opencl_ON, ocl_getBackgroundImage(backgroundImage))
@@ -863,6 +876,7 @@ void BackgroundSubtractorMOG2Impl::getBackgroundImage(OutputArray backgroundImag
         opencl_ON = false;
         return;
     }
+#endif
 
     int nchannels = CV_MAT_CN(frameType);
     CV_Assert(nchannels == 1 || nchannels == 3);

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -837,6 +837,7 @@ int cv::buildOpticalFlowPyramid(InputArray _img, OutputArrayOfArrays pyramid, Si
     return maxLevel;
 }
 
+#ifdef HAVE_OPENCL
 namespace cv
 {
     class PyrLKOpticalFlow
@@ -1084,6 +1085,7 @@ namespace cv
         return opticalFlow.sparse(_prevImg.getUMat(), _nextImg.getUMat(), _prevPts.getUMat(), umatNextPts, umatStatus, umatErr);
     }
 };
+#endif
 
 void cv::calcOpticalFlowPyrLK( InputArray _prevImg, InputArray _nextImg,
                            InputArray _prevPts, InputOutputArray _nextPts,
@@ -1092,6 +1094,7 @@ void cv::calcOpticalFlowPyrLK( InputArray _prevImg, InputArray _nextImg,
                            TermCriteria criteria,
                            int flags, double minEigThreshold )
 {
+#ifdef HAVE_OPENCL
     bool use_opencl = ocl::useOpenCL() &&
                       (_prevImg.isUMat() || _nextImg.isUMat()) &&
                       ocl::Image2D::isFormatSupported(CV_32F, 1, false);
@@ -1100,6 +1103,7 @@ void cv::calcOpticalFlowPyrLK( InputArray _prevImg, InputArray _nextImg,
         CV_IMPL_ADD(CV_IMPL_OCL);
         return;
     }
+#endif
 
     Mat prevPtsMat = _prevPts.getMat();
     const int derivDepth = DataType<cv::detail::deriv_type>::depth;

--- a/modules/video/src/optflowgf.cpp
+++ b/modules/video/src/optflowgf.cpp
@@ -583,6 +583,7 @@ FarnebackUpdateFlow_GaussianBlur( const Mat& _R0, const Mat& _R1,
 
 }
 
+#ifdef HAVE_OPENCL
 namespace cv
 {
 class FarnebackOpticalFlow
@@ -1074,17 +1075,20 @@ static bool ocl_calcOpticalFlowFarneback( InputArray _prev0, InputArray _next0,
     return true;
 }
 }
+#endif // HAVE_OPENCL
 
 void cv::calcOpticalFlowFarneback( InputArray _prev0, InputArray _next0,
                                InputOutputArray _flow0, double pyr_scale, int levels, int winsize,
                                int iterations, int poly_n, double poly_sigma, int flags )
 {
+#ifdef HAVE_OPENCL
     bool use_opencl = ocl::useOpenCL() && _flow0.isUMat();
     if( use_opencl && ocl_calcOpticalFlowFarneback(_prev0, _next0, _flow0, pyr_scale, levels, winsize, iterations, poly_n, poly_sigma, flags))
     {
         CV_IMPL_ADD(CV_IMPL_OCL);
         return;
     }
+#endif
 
     Mat prev0 = _prev0.getMat(), next0 = _next0.getMat();
     const int min_size = 32;

--- a/modules/video/src/tvl1flow.cpp
+++ b/modules/video/src/tvl1flow.cpp
@@ -122,11 +122,13 @@ protected:
     int medianFiltering;
 
 private:
-   void procOneScale(const Mat_<float>& I0, const Mat_<float>& I1, Mat_<float>& u1, Mat_<float>& u2, Mat_<float>& u3);
+    void procOneScale(const Mat_<float>& I0, const Mat_<float>& I1, Mat_<float>& u1, Mat_<float>& u2, Mat_<float>& u3);
 
+#ifdef HAVE_OPENCL
     bool procOneScale_ocl(const UMat& I0, const UMat& I1, UMat& u1, UMat& u2);
 
     bool calc_ocl(InputArray I0, InputArray I1, InputOutputArray flow);
+#endif
     struct dataMat
     {
         std::vector<Mat_<float> > I0s;
@@ -170,6 +172,8 @@ private:
         Mat_<float> u3x_buf;
         Mat_<float> u3y_buf;
     } dm;
+
+#ifdef HAVE_OPENCL
     struct dataUMat
     {
         std::vector<UMat> I0s;
@@ -195,8 +199,10 @@ private:
         UMat diff_buf;
         UMat norm_buf;
     } dum;
+#endif
 };
 
+#ifdef HAVE_OPENCL
 namespace cv_ocl_tvl1flow
 {
     bool centeredGradient(const UMat &src, UMat &dx, UMat &dy);
@@ -353,6 +359,7 @@ bool cv_ocl_tvl1flow::estimateDualVariables(UMat &u1, UMat &u2,
     return kernel.run(2, globalsize, NULL, false);
 
 }
+#endif
 
 OpticalFlowDual_TVL1::OpticalFlowDual_TVL1()
 {
@@ -499,6 +506,7 @@ void OpticalFlowDual_TVL1::calc(InputArray _I0, InputArray _I1, InputOutputArray
     merge(uxy, 2, _flow);
 }
 
+#ifdef HAVE_OPENCL
 bool OpticalFlowDual_TVL1::calc_ocl(InputArray _I0, InputArray _I1, InputOutputArray _flow)
 {
     UMat I0 = _I0.getUMat();
@@ -598,6 +606,7 @@ bool OpticalFlowDual_TVL1::calc_ocl(InputArray _I0, InputArray _I1, InputOutputA
     merge(uxy, _flow);
     return true;
 }
+#endif
 
 ////////////////////////////////////////////////////////////
 // buildFlowMap
@@ -1180,6 +1189,7 @@ void estimateDualVariables(const Mat_<float>& u1x, const Mat_<float>& u1y,
     parallel_for_(Range(0, u1x.rows), body);
 }
 
+#ifdef HAVE_OPENCL
 bool OpticalFlowDual_TVL1::procOneScale_ocl(const UMat& I0, const UMat& I1, UMat& u1, UMat& u2)
 {
     using namespace cv_ocl_tvl1flow;
@@ -1267,6 +1277,7 @@ bool OpticalFlowDual_TVL1::procOneScale_ocl(const UMat& I0, const UMat& I1, UMat
     }
     return true;
 }
+#endif
 
 void OpticalFlowDual_TVL1::procOneScale(const Mat_<float>& I0, const Mat_<float>& I1, Mat_<float>& u1, Mat_<float>& u2, Mat_<float>& u3)
 {
@@ -1402,6 +1413,7 @@ void OpticalFlowDual_TVL1::collectGarbage()
     dm.u2x_buf.release();
     dm.u2y_buf.release();
 
+#ifdef HAVE_OPENCL
     //dataUMat structure dum
     dum.I0s.clear();
     dum.I1s.clear();
@@ -1425,6 +1437,7 @@ void OpticalFlowDual_TVL1::collectGarbage()
 
     dum.diff_buf.release();
     dum.norm_buf.release();
+#endif
 }
 
 } // namespace


### PR DESCRIPTION
**WIP**

Related issue: http://code.opencv.org/issues/4409

Binary size reduced for ~1.2Mb (world, Linux-64, without IPP optimizations: ~8%)