### PR TITLE
Enable NEON optimization for cvRound on newer devices

### DIFF
--- a/modules/hal/include/opencv2/hal/defs.h
+++ b/modules/hal/include/opencv2/hal/defs.h
@@ -179,7 +179,7 @@
 #  define CV_NEON 1
 #endif
 
-#if defined __GNUC__ && defined __arm__ && (defined __ARM_PCS_VFP || defined __ARM_VFPV3__)
+#if defined __GNUC__ && defined __arm__ && (defined __ARM_PCS_VFP || defined __ARM_VFPV3__ || defined __ARM_NEON__) && !defined __SOFTFP__
 #  define CV_VFP 1
 #endif
 


### PR DESCRIPTION
cvRound seems was not optimized with NEON instructions on newer devices.
Tested on an NVIDIA SHIELD TABLET and with the flag CV_VFP on, the speed up is greater than 4x.

Still I'm not sure why TEGRA_OPTIMIZATION is not enabled, if forced with a define, the header tries to include a mysterious file "tegra_round.hpp", which is not found