### PR TITLE
Remove bindings generation for DetectionBasedTracker

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/detection_based_tracker.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/detection_based_tracker.hpp
@@ -44,6 +44,7 @@
 #ifndef __OPENCV_OBJDETECT_DBT_HPP__
 #define __OPENCV_OBJDETECT_DBT_HPP__
 
+// After this condition removal update blacklist for bindings: modules/python/common.cmake
 #if defined(__linux__) || defined(LINUX) || defined(__APPLE__) || defined(__ANDROID__) || \
   (defined(__cplusplus) &&  __cplusplus > 201103L) || (defined(_MSC_VER) && _MSC_VER >= 1700)
 

--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -28,6 +28,7 @@ endforeach(m)
 ocv_list_filterout(opencv_hdrs ".h$")
 ocv_list_filterout(opencv_hdrs "cuda")
 ocv_list_filterout(opencv_hdrs "cudev")
+ocv_list_filterout(opencv_hdrs "detection_based_tracker.hpp") # Conditional compilation
 
 set(cv2_generated_hdrs
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_include.h"


### PR DESCRIPTION
Build was broken because DetectionBasedTracker is conditionally compiled and bindings generator is not able to track `#if`.

https://github.com/Itseez/opencv/blob/c12243cf4fccf5df7b0270a32883986b373dca7b/modules/objdetect/include/opencv2/objdetect/detection_based_tracker.hpp#L47

http://code.opencv.org/issues/4394