### PR TITLE
Fixed alpha preservation when converting 4-channel Mat to UIImage

### DIFF
--- a/modules/imgcodecs/src/ios_conversions.mm
+++ b/modules/imgcodecs/src/ios_conversions.mm
@@ -66,6 +66,10 @@ UIImage* MatToUIImage(const cv::Mat& image) {
     CGDataProviderRef provider =
             CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
 
+    // Preserve alpha transparency, if exists
+    bool alpha = cvMat.channels() == 4;
+    CGBitmapInfo bitMapInfo = (alpha ? kCGImageAlphaLast : kCGImageAlphaNone) | kCGBitmapByteOrderDefault;
+
     // Creating CGImage from cv::Mat
     CGImageRef imageRef = CGImageCreate(image.cols,
                                         image.rows,
@@ -73,8 +77,7 @@ UIImage* MatToUIImage(const cv::Mat& image) {
                                         8 * image.elemSize(),
                                         image.step.p[0],
                                         colorSpace,
-                                        kCGImageAlphaNone|
-                                        kCGBitmapByteOrderDefault,
+                                        bitmapInfo,
                                         provider,
                                         NULL,
                                         false,

--- a/modules/imgcodecs/src/ios_conversions.mm
+++ b/modules/imgcodecs/src/ios_conversions.mm
@@ -67,8 +67,8 @@ UIImage* MatToUIImage(const cv::Mat& image) {
             CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
 
     // Preserve alpha transparency, if exists
-    bool alpha = cvMat.channels() == 4;
-    CGBitmapInfo bitMapInfo = (alpha ? kCGImageAlphaLast : kCGImageAlphaNone) | kCGBitmapByteOrderDefault;
+    bool alpha = image.channels() == 4;
+    CGBitmapInfo bitmapInfo = (alpha ? kCGImageAlphaLast : kCGImageAlphaNone) | kCGBitmapByteOrderDefault;
 
     // Creating CGImage from cv::Mat
     CGImageRef imageRef = CGImageCreate(image.cols,


### PR DESCRIPTION
I hope this is not too naively done, but MatToUIImage needs to preserve the alpha channel.