### PR TITLE
Fix issue 3891

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1586,7 +1586,13 @@ template<typename _Tp> template<int n> inline
 Mat_<_Tp>::operator Vec<typename DataType<_Tp>::channel_type, n>() const
 {
     CV_Assert(n % DataType<_Tp>::channels == 0);
+
+#if defined _MSC_VER
+    const Mat* pMat = (const Mat*)this; // workaround for MSVS <= 2012 compiler bugs (but GCC 4.6 dislikes this workaround)
+    return pMat->operator Vec<typename DataType<_Tp>::channel_type, n>();
+#else
     return this->Mat::operator Vec<typename DataType<_Tp>::channel_type, n>();
+#endif
 }
 
 template<typename _Tp> template<int m, int n> inline
@@ -1594,8 +1600,14 @@ Mat_<_Tp>::operator Matx<typename DataType<_Tp>::channel_type, m, n>() const
 {
     CV_Assert(n % DataType<_Tp>::channels == 0);
 
+#if defined _MSC_VER
+    const Mat* pMat = (const Mat*)this; // workaround for MSVS <= 2012 compiler bugs (but GCC 4.6 dislikes this workaround)
+    Matx<typename DataType<_Tp>::channel_type, m, n> res = pMat->operator Matx<typename DataType<_Tp>::channel_type, m, n>();
+    return res;
+#else
     Matx<typename DataType<_Tp>::channel_type, m, n> res = this->Mat::operator Matx<typename DataType<_Tp>::channel_type, m, n>();
     return res;
+#endif
 }
 
 template<typename _Tp> inline

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1214,7 +1214,7 @@ TEST(Core_Matx, fromMat_)
 {
     Mat_<double> a = (Mat_<double>(2,2) << 10, 11, 12, 13);
     Matx22d b(a);
-    ASSERT_EQ( norm(a, b, NORM_INF), 0.);
+    ASSERT_EQ( cvtest::norm(a, b, NORM_INF), 0.);
 }
 
 TEST(Core_InputArray, empty)


### PR DESCRIPTION
http://code.opencv.org/issues/3891
It looks like a compiler bug, workarounds were added.

Related commits:
- https://github.com/Itseez/opencv/commit/8f6f9c3e58cfd64ab8d34cdf83cdcb636b4f7608 - revert doesn't help
- https://github.com/Itseez/opencv/commit/9fbd1d68ad95d7bad2d09501110081ecd82d5ad8 - added test that fails on MSVS 2012/2010 builds

Update:
GCC 4.6 (used in ABI checker) dislikes this workaround so `#if` added:
http://pullrequest.opencv.org/buildbot/builders/precommit_linux64/builds/3498