### PR TITLE
Fix `cmake -E touch classes.jar' step

### DIFF
--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -282,6 +282,8 @@ else()
   set(LIB_NAME_SUFIX "${OPENCV_VERSION_MAJOR}${OPENCV_VERSION_MINOR}${OPENCV_VERSION_PATCH}")
 endif()
 
+file(MAKE_DIRECTORY "${OpenCV_BINARY_DIR}/bin")
+
 # step 4: build jar
 if(ANDROID)
   set(JAR_FILE "${OpenCV_BINARY_DIR}/bin/classes.jar")


### PR DESCRIPTION
`-E touch` command doesn't create intermediate directories. We have to do it
manually using `file(MAKE_DIRECTORY ...)` command.