### PR TITLE
Fix MatAllocator creation/destruction issues

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -222,10 +222,14 @@ public:
     }
 };
 
+static StdMatAllocator *mat_allocator = NULL;
 MatAllocator* Mat::getStdAllocator()
 {
-    static StdMatAllocator allocator;
-    return &allocator;
+    if (mat_allocator == NULL)
+    {
+        mat_allocator = new StdMatAllocator();
+    }
+    return mat_allocator;
 }
 
 void swap( Mat& a, Mat& b )

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -5160,10 +5160,15 @@ public:
     MatAllocator* matStdAllocator;
 };
 
+// This line should not force OpenCL runtime initialization! (don't put "new OpenCLAllocator()" here)
+static MatAllocator *ocl_allocator = NULL;
 MatAllocator* getOpenCLAllocator()
 {
-    static MatAllocator * allocator = new OpenCLAllocator();
-    return allocator;
+    if (ocl_allocator == NULL)
+    {
+        ocl_allocator = new OpenCLAllocator();
+    }
+    return ocl_allocator;
 }
 
 ///////////////////////////////////////////// Utility functions /////////////////////////////////////////////////


### PR DESCRIPTION
http://code.opencv.org/issues/4189 : "Mat::getStdAllocator() is not thread-safe"
http://code.opencv.org/issues/3355 : "Pure virtual method called"
