### PR TITLE
Fix cyclic deps error (contrib,world,shared)

### DIFF
--- a/modules/stitching/CMakeLists.txt
+++ b/modules/stitching/CMakeLists.txt
@@ -4,6 +4,10 @@ if(HAVE_CUDA)
   ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef -Wmissing-declarations -Wshadow)
 endif()
 
+set(STITCHING_CONTRIB_DEPS "opencv_xfeatures2d")
+if(BUILD_SHARED_LIBS AND BUILD_opencv_world)
+  set(STITCHING_CONTRIB_DEPS "")
+endif()
 ocv_define_module(stitching opencv_imgproc opencv_features2d opencv_calib3d opencv_objdetect
-                  OPTIONAL opencv_cudaarithm opencv_cudafilters opencv_cudafeatures2d opencv_cudalegacy opencv_xfeatures2d
+                  OPTIONAL opencv_cudaarithm opencv_cudafilters opencv_cudafeatures2d opencv_cudalegacy ${STITCHING_CONTRIB_DEPS}
                   WRAP python)


### PR DESCRIPTION
```
CMake Error: The inter-target dependency graph contains the following strongly connected component (cycle):
  "opencv_world" of type SHARED_LIBRARY
    depends on "opencv_xfeatures2d" (weak)
  "opencv_xfeatures2d" of type SHARED_LIBRARY
    depends on "opencv_world" (weak)
At least one of these targets is not a STATIC_LIBRARY.  Cyclic dependencies are allowed only among static libraries.
```

Problem is in deps of `stitching` module.