### PR TITLE
copyTo: Disabled IPP for 64-bit systems due to errors

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -291,8 +291,10 @@ void Mat::copyTo( OutputArray _dst ) const
             Size sz = getContinuousSize(*this, dst);
             size_t len = sz.width*elemSize();
 
-            CV_IPP_RUN(true, ippiCopy_8u_C1R(sptr, (int)step, dptr, (int)dst.step, ippiSize((int)len, sz.height)) >= 0)
-
+            if (len == (unsigned int)(int)len)
+            {
+                CV_IPP_RUN(true, ippiCopy_8u_C1R(sptr, (int)step, dptr, (int)dst.step, ippiSize((int)len, sz.height)) >= 0)
+            }
             for( ; sz.height--; sptr += step, dptr += dst.step )
                 memcpy( dptr, sptr, len );
         }


### PR DESCRIPTION
Truncating `size_t len` to `int` leaded to unexpected behaviour for big matrices. See issue http://code.opencv.org/issues/4421