### PR TITLE
Fixed build with CUDA

### DIFF
--- a/modules/cudev/CMakeLists.txt
+++ b/modules/cudev/CMakeLists.txt
@@ -8,7 +8,7 @@ ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4189 /wd4505 -Wundef -Wmissing-declarati
 
 ocv_add_module(cudev)
 
-ocv_module_include_directories(opencv_core)
+ocv_module_include_directories(opencv_core opencv_hal)
 
 file(GLOB_RECURSE lib_hdrs "include/opencv2/*.hpp")
 file(GLOB         lib_srcs "src/*.cpp")


### PR DESCRIPTION
`cudev` module does not explicitly depend on `core` and `hal` modules but uses some headers from them.