### PR TITLE
copyTo: fix for big data (4Gb+)

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -288,10 +288,16 @@ void Mat::copyTo( OutputArray _dst ) const
             const uchar* sptr = data;
             uchar* dptr = dst.data;
 
+            CV_IPP_RUN(
+                    (size_t)cols*elemSize() <= (size_t)INT_MAX &&
+                    (size_t)step <= (size_t)INT_MAX &&
+                    (size_t)dst.step <= (size_t)INT_MAX
+                    ,
+                    ippiCopy_8u_C1R(sptr, (int)step, dptr, (int)dst.step, ippiSize((int)(cols*elemSize()), rows)) >= 0
+            )
+
             Size sz = getContinuousSize(*this, dst);
             size_t len = sz.width*elemSize();
-
-            CV_IPP_RUN(true, ippiCopy_8u_C1R(sptr, (int)step, dptr, (int)dst.step, ippiSize((int)len, sz.height)) >= 0)
 
             for( ; sz.height--; sptr += step, dptr += dst.step )
                 memcpy( dptr, sptr, len );


### PR DESCRIPTION
Similar to #4148 but don't disable IPP for 4Gb+ transfers.
Also added check for src & dst steps (in case of ROI).