### PR TITLE
Vector processing issue

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -222,6 +222,7 @@ public:
     bool isMatVector() const;
     bool isUMatVector() const;
     bool isMatx() const;
+    bool isVector() const;
 
     ~_InputArray();
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -130,6 +130,7 @@ inline bool _InputArray::isUMat() const  { return kind() == _InputArray::UMAT; }
 inline bool _InputArray::isMatVector() const { return kind() == _InputArray::STD_VECTOR_MAT; }
 inline bool _InputArray::isUMatVector() const  { return kind() == _InputArray::STD_VECTOR_UMAT; }
 inline bool _InputArray::isMatx() const { return kind() == _InputArray::MATX; }
+inline bool _InputArray::isVector() const { return kind() == _InputArray::STD_VECTOR || kind() == _InputArray::STD_BOOL_VECTOR; }
 
 ////////////////////////////////////////////////////////////////////////////////////////
 

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -285,6 +285,11 @@ void Mat::copyTo( OutputArray _dst ) const
 
         if( rows > 0 && cols > 0 )
         {
+            // For some cases (with vector) dst.size != src.size, so force to column-based form
+            // It prevents memory corruption in case of column-based src
+            if (_dst.isVector())
+                dst = dst.reshape(0, (int)dst.total());
+
             const uchar* sptr = data;
             uchar* dptr = dst.data;
 

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1320,7 +1320,8 @@ TEST(Core_SparseMat, footprint)
 }
 
 
-TEST(Core_Mat_vector, OutputArray_create_getMat)
+// Can't fix without duty hacks or broken user code (PR #4159)
+TEST(Core_Mat_vector, DISABLED_OutputArray_create_getMat)
 {
     cv::Mat_<uchar> src_base(5, 1);
     std::vector<uchar> dst8;
@@ -1347,6 +1348,7 @@ TEST(Core_Mat_vector, copyTo_roi_column)
 
     Mat src_full(src_base);
     Mat src(src_full.col(0));
+#if 0 // Can't fix without duty hacks or broken user code (PR #4159)
     OutputArray _dst(dst1);
     {
         _dst.create(src.rows, src.cols, src.type());
@@ -1355,6 +1357,7 @@ TEST(Core_Mat_vector, copyTo_roi_column)
         EXPECT_EQ(src.cols, dst.cols);
         EXPECT_EQ(src.rows, dst.rows);
     }
+#endif
 
     std::vector<uchar> dst2;
     src.copyTo(dst2);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1318,3 +1318,82 @@ TEST(Core_SparseMat, footprint)
     ASSERT_LE((int)m.hdr->nodeSize, 32);
     ASSERT_LE(dataSize1, threshold);
 }
+
+
+TEST(Core_Mat_vector, OutputArray_create_getMat)
+{
+    cv::Mat_<uchar> src_base(5, 1);
+    std::vector<uchar> dst8;
+
+    src_base << 1, 2, 3, 4, 5;
+
+    Mat src(src_base);
+    OutputArray _dst(dst8);
+    {
+        _dst.create(src.rows, src.cols, src.type());
+        Mat dst = _dst.getMat();
+        EXPECT_EQ(src.dims, dst.dims);
+        EXPECT_EQ(src.cols, dst.cols);
+        EXPECT_EQ(src.rows, dst.rows);
+    }
+}
+
+TEST(Core_Mat_vector, copyTo_roi_column)
+{
+    cv::Mat_<uchar> src_base(5, 2);
+    std::vector<uchar> dst1;
+
+    src_base << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
+
+    Mat src_full(src_base);
+    Mat src(src_full.col(0));
+    OutputArray _dst(dst1);
+    {
+        _dst.create(src.rows, src.cols, src.type());
+        Mat dst = _dst.getMat();
+        EXPECT_EQ(src.dims, dst.dims);
+        EXPECT_EQ(src.cols, dst.cols);
+        EXPECT_EQ(src.rows, dst.rows);
+    }
+
+    std::vector<uchar> dst2;
+    src.copyTo(dst2);
+    std::cout << "src = " << src << std::endl;
+    std::cout << "dst = " << Mat(dst2) << std::endl;
+    EXPECT_EQ((size_t)5, dst2.size());
+    EXPECT_EQ(1, (int)dst2[0]);
+    EXPECT_EQ(3, (int)dst2[1]);
+    EXPECT_EQ(5, (int)dst2[2]);
+    EXPECT_EQ(7, (int)dst2[3]);
+    EXPECT_EQ(9, (int)dst2[4]);
+}
+
+TEST(Core_Mat_vector, copyTo_roi_row)
+{
+    cv::Mat_<uchar> src_base(2, 5);
+    std::vector<uchar> dst1;
+
+    src_base << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
+
+    Mat src_full(src_base);
+    Mat src(src_full.row(0));
+    OutputArray _dst(dst1);
+    {
+        _dst.create(src.rows, src.cols, src.type());
+        Mat dst = _dst.getMat();
+        EXPECT_EQ(src.dims, dst.dims);
+        EXPECT_EQ(src.cols, dst.cols);
+        EXPECT_EQ(src.rows, dst.rows);
+    }
+
+    std::vector<uchar> dst2;
+    src.copyTo(dst2);
+    std::cout << "src = " << src << std::endl;
+    std::cout << "dst = " << Mat(dst2) << std::endl;
+    EXPECT_EQ((size_t)5, dst2.size());
+    EXPECT_EQ(1, (int)dst2[0]);
+    EXPECT_EQ(2, (int)dst2[1]);
+    EXPECT_EQ(3, (int)dst2[2]);
+    EXPECT_EQ(4, (int)dst2[3]);
+    EXPECT_EQ(5, (int)dst2[4]);
+}


### PR DESCRIPTION
Problem is in layout mismatch of `src` and `dst` for some cases:
```
OutputArray _dst(dst1);
{
    _dst.create(src.rows, src.cols, src.type());
    Mat dst = _dst.getMat();
    EXPECT_EQ(src.dims, dst.dims);
    EXPECT_EQ(src.cols, dst.cols);
    EXPECT_EQ(src.rows, dst.rows);
}
```

Only `copyTo()` memory corruption problem was fixed.