### PR TITLE
using -fembed-bitcode to include bit code for iOS9

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -49,7 +49,7 @@ def build_opencv(srcroot, buildroot, target, arch):
     currdir = os.getcwd()
     os.chdir(builddir)
     # for some reason, if you do not specify CMAKE_BUILD_TYPE, it puts libs to "RELEASE" rather than "Release"
-    cmakeargs = ("-GXcode " +
+    cmakeargs = ("-GXcode -fembed-bitcode " +
                 "-DCMAKE_BUILD_TYPE=Release " +
                 "-DCMAKE_TOOLCHAIN_FILE=%s/platforms/ios/cmake/Toolchains/Toolchain-%s_Xcode.cmake " +
                 "-DCMAKE_C_FLAGS=\"-Wno-implicit-function-declaration\" " +


### PR DESCRIPTION
using iOS9 App thinning I added a make argument that allows for the inclusion of the bit code when the framework gets created using the python script. The framework build product will be about 1MB larger in size.