### PR TITLE
Fixed conditional compilation of RGB2Gray<ushort> template specialization.

### DIFF
--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -1674,7 +1674,9 @@ struct RGB2Gray<float>
     bool haveSIMD;
 };
 
-#else
+#endif // CV_SSE2
+
+#if !CV_NEON && !CV_SSE4_1
 
 template<> struct RGB2Gray<ushort>
 {
@@ -1698,7 +1700,7 @@ template<> struct RGB2Gray<ushort>
     int coeffs[3];
 };
 
-#endif
+#endif // !CV_NEON && !CV_SSE4_1
 
 ///////////////////////////////////// RGB <-> YCrCb //////////////////////////////////////
 


### PR DESCRIPTION
Currently if `CV_SSE2` is defined but not `CV_SSE4_1` then the un-vectorized `RGB2Gray<ushort>` specialization is _not_ compiled and ushort RGB2Gray color space conversions revert to the default `RGB2Gray<>` floating-point implementation. This seems to be an unintended regression introduced by @ilya-lavrenov in 6bce6ee34a7bf23d19d2df37bc44a47072a8f6e0.

There are two vectorized implementations of `RGB2Gray<ushort>` (for `CV_NEON` and `CV_SSE4_1`) and so the fix is to enable the unvectorized version otherwise.