### PR TITLE
Fix python cross-compilation

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -85,9 +85,9 @@ function(find_python preferred_version min_version library_env include_dir_env
       # not using _version_string here, because it might not conform to the CMake version format
       if(CMAKE_CROSSCOMPILING)
         # builder version can differ from target, matching base version (e.g. 2.7)
-        find_host_package(PythonLibs "${_version_major_minor}")
+        find_package(PythonLibs "${_version_major_minor}")
       else()
-        find_host_package(PythonLibs "${_version_major_minor}.${_version_patch}" EXACT)
+        find_package(PythonLibs "${_version_major_minor}.${_version_patch}" EXACT)
       endif()
 
       if(PYTHONLIBS_FOUND)
@@ -105,7 +105,7 @@ function(find_python preferred_version min_version library_env include_dir_env
         set(_include_dir ${PYTHON_INCLUDE_DIR})
         set(_include_dir2 ${PYTHON_INCLUDE_DIR2})
 
-        # Clear find_host_package side effects
+        # Clear find_package side effects
         unset(PYTHONLIBS_FOUND)
         unset(PYTHON_LIBRARIES)
         unset(PYTHON_INCLUDE_PATH)


### PR DESCRIPTION
Python libs should use `find_package`.
Python executable uses `find_host_package` (Is it used only to parse headers and generate bindings?).

**WIP**