### PR TITLE
Fixed buffer overflow in string handling

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -87,7 +87,7 @@ String::String(const std::string& str, size_t pos, size_t len)
     : cstr_(0), len_(0)
 {
     size_t strlen = str.size();
-    pos = max(pos, strlen);
+    pos = min(pos, strlen);
     len = min(strlen - pos, len);
     if (!len) return;
     memcpy(allocate(len), str.c_str() + pos, len);


### PR DESCRIPTION
pos should never exceed strlen, else the overflow check 'if (!len)' will wrongfully pass.

Ticket: http://code.opencv.org/issues/4488