### PR TITLE
OCL: fix bug 4006

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -51,8 +51,11 @@
 
 namespace cv {
 
-void MatAllocator::map(UMatData*, int) const
+void MatAllocator::map(UMatData* u, int) const
 {
+    // VD-FIX: when useOpenCL == false and UMat created from Mat with user allocated memory
+    if (u->data == 0)
+        u->data = u->origdata;
 }
 
 void MatAllocator::unmap(UMatData* u) const
@@ -189,7 +192,8 @@ public:
         }
         uchar* data = data0 ? (uchar*)data0 : (uchar*)fastMalloc(total);
         UMatData* u = new UMatData(this);
-        u->data = u->origdata = data;
+        u->data = data0 ? 0 : data; // VD-FIX bug 4006 - create UMat from user host memory (USE_HOST_PTR)
+        u->origdata = data;
         u->size = total;
         if(data0)
             u->flags |= UMatData::USER_ALLOCATED;

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4397,7 +4397,7 @@ public:
 #endif
             {
                 tempUMatFlags = UMatData::TEMP_UMAT;
-                handle = clCreateBuffer(ctx_handle, CL_MEM_USE_HOST_PTR|createFlags,
+                handle = clCreateBuffer(ctx_handle, CL_MEM_USE_HOST_PTR | createFlags,
                                            u->size, u->origdata, &retval);
                 if((!handle || retval < 0) && !(accessFlags & ACCESS_FAST))
                 {
@@ -4510,7 +4510,7 @@ public:
                     {
                         AlignedDataPtr<false, true> alignedPtr(u->origdata, u->size, CV_OPENCL_DATA_PTR_ALIGNMENT);
                         CV_OclDbgAssert(clEnqueueReadBuffer(q, (cl_mem)u->handle, CL_TRUE, 0,
-                                            u->size, alignedPtr.getAlignedPtr(), 0, 0, 0) == CL_SUCCESS);
+                            u->size, alignedPtr.getAlignedPtr(), 0, 0, 0) == CL_SUCCESS);
                     }
                     else
                     {
@@ -4653,7 +4653,8 @@ public:
                 if (u->data) // FIXIT Workaround for UMat synchronization issue
                 {
                     //CV_Assert(u->hostCopyObsolete() == false);
-                    return;
+// VD_FIX: bug 4006
+//                    return;
                 }
 
                 cl_int retval = 0;

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -526,7 +526,7 @@ INSTANTIATE_TEST_CASE_P(UMat, UMatTestUMatOperations, Combine(OCL_ALL_DEPTHS, OC
 // UMat created from user allocated host memory (USE_HOST_PTR)
 PARAM_TEST_CASE(UseHostPtr, int, int, Size, bool)
 {
-    void* pData;
+    unsigned char* pData;
     int total;
 //    Mat m;
 //    Mat d;


### PR DESCRIPTION
create UMat from user allocated host memory using `USE_HOST_PTR` flag when create cl buffer)

http://code.opencv.org/issues/4006