### PR TITLE
OCL: [UMat::convertTo]It is unnecessary to use fma() if no scaling.

### DIFF
--- a/modules/core/src/opencl/convert.cl
+++ b/modules/core/src/opencl/convert.cl
@@ -53,7 +53,10 @@
 
 __kernel void convertTo(__global const uchar * srcptr, int src_step, int src_offset,
                         __global uchar * dstptr, int dst_step, int dst_offset, int dst_rows, int dst_cols,
-                        WT alpha, WT beta, int rowsPerWI)
+#ifndef NO_SCALE
+                        WT alpha, WT beta,
+#endif
+                        int rowsPerWI)
 {
     int x = get_global_id(0);
     int y0 = get_global_id(1) * rowsPerWI;
@@ -68,7 +71,11 @@ __kernel void convertTo(__global const uchar * srcptr, int src_step, int src_off
             __global const srcT * src = (__global const srcT *)(srcptr + src_index);
             __global dstT * dst = (__global dstT *)(dstptr + dst_index);
 
+#ifdef NO_SCALE
+            dst[0] = convertToDT(src[0]);
+#else
             dst[0] = convertToDT(fma(convertToWT(src[0]), alpha, beta));
+#endif
         }
     }
 }

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -746,7 +746,7 @@ void UMat::convertTo(OutputArray _dst, int _type, double alpha, double beta) con
                              ocl::typeToStr(sdepth), ocl::typeToStr(wdepth), ocl::typeToStr(ddepth),
                              ocl::convertTypeStr(sdepth, wdepth, 1, cvt[0]),
                              ocl::convertTypeStr(wdepth, ddepth, 1, cvt[1]),
-                             doubleSupport ? " -D DOUBLE_SUPPORT" : ""));
+                             doubleSupport ? " -D DOUBLE_SUPPORT" : "", noScale ? " -D NO_SCALE" : ""));
         if (!k.empty())
         {
             UMat src = *this;
@@ -757,7 +757,9 @@ void UMat::convertTo(OutputArray _dst, int _type, double alpha, double beta) con
             ocl::KernelArg srcarg = ocl::KernelArg::ReadOnlyNoSize(src),
                     dstarg = ocl::KernelArg::WriteOnly(dst, cn);
 
-            if (wdepth == CV_32F)
+            if (noScale)
+                k.args(srcarg, dstarg, rowsPerWI);
+            else if (wdepth == CV_32F)
                 k.args(srcarg, dstarg, alphaf, betaf, rowsPerWI);
             else
                 k.args(srcarg, dstarg, alpha, beta, rowsPerWI);


### PR DESCRIPTION
Signed-off-by: Yan Wang <yan.wang@linux.intel.com>