### PR TITLE
Fixing GCC 4.9 warnings

### DIFF
--- a/3rdparty/libwebp/CMakeLists.txt
+++ b/3rdparty/libwebp/CMakeLists.txt
@@ -40,7 +40,7 @@ if(UNIX)
   endif()
 endif()
 
-ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-variable -Wshadow -Wmaybe-uninitialized)
+ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-variable -Wunused-function -Wshadow -Wmaybe-uninitialized)
 ocv_warnings_disable(CMAKE_C_FLAGS /wd4244 /wd4267) # vs2005
 
 set_target_properties(${WEBP_LIBRARY}

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -395,7 +395,7 @@ int my_jpeg_load_dht (struct jpeg_decompress_struct *info, unsigned char *dht,
 
 bool  JpegDecoder::readData( Mat& img )
 {
-    bool result = false;
+    volatile bool result = false;
     int step = (int)img.step;
     bool color = img.channels() > 1;
 
@@ -557,7 +557,7 @@ bool JpegEncoder::write( const Mat& img, const std::vector<int>& params )
         fileWrapper() : f(0) {}
         ~fileWrapper() { if(f) fclose(f); }
     };
-    bool result = false;
+    volatile bool result = false;
     fileWrapper fw;
     int width = img.cols, height = img.rows;
 

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -224,7 +224,7 @@ bool  PngDecoder::readHeader()
 
 bool  PngDecoder::readData( Mat& img )
 {
-    bool result = false;
+    volatile bool result = false;
     AutoBuffer<uchar*> _buffer(m_height);
     uchar** buffer = _buffer;
     int color = img.channels() > 1;
@@ -342,10 +342,10 @@ bool  PngEncoder::write( const Mat& img, const std::vector<int>& params )
 {
     png_structp png_ptr = png_create_write_struct( PNG_LIBPNG_VER_STRING, 0, 0, 0 );
     png_infop info_ptr = 0;
-    FILE* f = 0;
+    FILE * volatile f = 0;
     int y, width = img.cols, height = img.rows;
     int depth = img.depth(), channels = img.channels();
-    bool result = false;
+    volatile bool result = false;
     AutoBuffer<uchar*> buffer;
 
     if( depth != CV_8U && depth != CV_16U )

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -1426,7 +1426,7 @@ protected:
     void run_func(void);
     int validate_test_results( int test_case_idx );
     double max_noise;
-    float line[6], line0[6];
+    AutoBuffer<float> line, line0;
     int dist_type;
     double reps, aeps;
 };
@@ -1438,11 +1438,6 @@ CV_FitLineTest::CV_FitLineTest()
     max_log_size = 10;
     max_noise = 0.05;
 }
-
-#if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ == 8)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
 
 void CV_FitLineTest::generate_point_set( void* pointsSet )
 {
@@ -1515,14 +1510,12 @@ void CV_FitLineTest::generate_point_set( void* pointsSet )
     }
 }
 
-#if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ == 8)
-# pragma GCC diagnostic pop
-#endif
-
 int CV_FitLineTest::prepare_test_case( int test_case_idx )
 {
     RNG& rng = ts->get_rng();
     dims = cvtest::randInt(rng) % 2 + 2;
+    line.allocate(dims * 2);
+    line0.allocate(dims * 2);
     min_log_size = MAX(min_log_size,5);
     max_log_size = MAX(min_log_size,max_log_size);
     int code = CV_BaseShapeDescrTest::prepare_test_case( test_case_idx );
@@ -1542,11 +1535,6 @@ void CV_FitLineTest::run_func()
     else
         cv::fitLine(cv::cvarrToMat(points), (cv::Vec6f&)line[0], dist_type, 0, reps, aeps);
 }
-
-#if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ == 8)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
 
 int CV_FitLineTest::validate_test_results( int test_case_idx )
 {
@@ -1625,10 +1613,6 @@ _exit_:
     }
     return code;
 }
-
-#if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ == 8)
-# pragma GCC diagnostic pop
-#endif
 
 /****************************************************************************************\
 *                                   ContourMoments Test                                  *

--- a/modules/imgproc/test/test_distancetransform.cpp
+++ b/modules/imgproc/test/test_distancetransform.cpp
@@ -158,7 +158,7 @@ cvTsDistTransform( const CvMat* _src, CvMat* _dst, int dist_type,
     const float init_val = 1e6;
     float mask[3];
     CvMat* temp;
-    int ofs[16];
+    int ofs[16] = {0};
     float delta[16];
     int tstep, count;
 

--- a/modules/videoio/test/test_positioning.cpp
+++ b/modules/videoio/test/test_positioning.cpp
@@ -106,7 +106,7 @@ void CV_VideoPositioningTest::generate_idx_seq(CvCapture* cap, int method)
         {
             RNG rng(N);
             idx.clear();
-            for( int i = 0; i < N-1; i++ )
+            for( int i = 0; i > 0 && i < N-1; i++ )
                 idx.push_back(rng.uniform(0, N));
             idx.push_back(N-1);
             std::swap(idx.at(rng.uniform(0, N-1)), idx.at(N-1));

--- a/modules/videoio/test/test_positioning.cpp
+++ b/modules/videoio/test/test_positioning.cpp
@@ -106,7 +106,7 @@ void CV_VideoPositioningTest::generate_idx_seq(CvCapture* cap, int method)
         {
             RNG rng(N);
             idx.clear();
-            for( int i = 0; i > 0 && i < N-1; i++ )
+            for( int i = 0; i >= 0 && i < N-1; i++ )
                 idx.push_back(rng.uniform(0, N));
             idx.push_back(N-1);
             std::swap(idx.at(rng.uniform(0, N-1)), idx.at(N-1));


### PR DESCRIPTION
```.txt
imgcodecs/src/grfmt_jpeg.cpp:560:10: warning: variable 'result' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
imgcodecs/src/grfmt_jpeg.cpp:398:10: warning: variable 'result' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
imgcodecs/src/grfmt_png.cpp:345:11: warning: variable 'f' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
imgcodecs/src/grfmt_png.cpp:348:10: warning: variable 'result' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
imgcodecs/src/grfmt_png.cpp:227:10: warning: variable 'result' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
imgproc/test/test_convhull.cpp:1508:92: warning: array subscript is above array bounds [-Warray-bounds]
imgproc/test/test_convhull.cpp:1508:92: warning: array subscript is above array bounds [-Warray-bounds]
imgproc/test/test_distancetransform.cpp:161:9: warning: 'ofs[7]' may be used uninitialized in this function [-Wmaybe-uninitialized]
imgproc/test/test_distancetransform.cpp:161:9: warning: 'ofs[6]' may be used uninitialized in this function [-Wmaybe-uninitialized]
imgproc/test/test_distancetransform.cpp:161:9: warning: 'ofs[5]' may be used uninitialized in this function [-Wmaybe-uninitialized]
imgproc/test/test_distancetransform.cpp:161:9: warning: 'ofs[4]' may be used uninitialized in this function [-Wmaybe-uninitialized]
warning: iteration 2147483647u invokes undefined behavior [-Waggressive-loop-optimizations]
xfeatures2d/src/stardetector.cpp:332:49: warning: array subscript is below array bounds [-Warray-bounds]
xfeatures2d/src/stardetector.cpp:338:30: warning: array subscript is below array bounds [-Warray-bounds]
xfeatures2d/src/stardetector.cpp:332:49: warning: array subscript is below array bounds [-Warray-bounds]
xfeatures2d/src/stardetector.cpp:338:30: warning: array subscript is below array bounds [-Warray-bounds]
```