### PR TITLE
Match template demo error  when src or template image is null

### DIFF
--- a/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
+++ b/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
@@ -27,8 +27,13 @@ void MatchingMethod( int, void* );
 /**
  * @function main
  */
-int main( int, char** argv )
+int main( int argc, char** argv )
 {
+  if (argc < 3)
+  {
+    cerr << "Not enough parmeters" << endl;
+    return -1;
+  }
   /// Load image and template
   img = imread( argv[1], 1 );
   templ = imread( argv[2], 1 );

--- a/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
+++ b/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
@@ -31,7 +31,7 @@ int main( int argc, char** argv )
 {
   if (argc < 3)
   {
-    cerr << "Not enough parmeters" << endl;
+    cout << "Not enough parmeters" << endl;
     return -1;
   }
   /// Load image and template


### PR DESCRIPTION
segment fault at less parameters, first of all check argc.