### PR TITLE
overload imread

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -340,6 +340,8 @@ videos, it will display the video frame-by-frame)
 
 [Windows Backend Only] Pressing Ctrl+C will copy the image to the clipboard.
 
+[Windows Backend Only] Pressing Ctrl+S will show a dialog to save the image.
+
  */
 CV_EXPORTS_W void imshow(const String& winname, InputArray mat);
 

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -110,9 +110,11 @@ returns an empty matrix ( Mat::data==NULL ). Currently, the following file forma
 -   JPEG 2000 files - \*.jp2 (see the *Notes* section)
 -   Portable Network Graphics - \*.png (see the *Notes* section)
 -   WebP - \*.webp (see the *Notes* section)
--   Portable image format - \*.pbm, \*.pgm, \*.ppm (always supported)
+-   Portable image format - \*.pbm, \*.pgm, \*.ppm \*.pxm, \*.pnm (always supported)
 -   Sun rasters - \*.sr, \*.ras (always supported)
 -   TIFF files - \*.tiff, \*.tif (see the *Notes* section)
+-   OpenEXR Image files - \*.exr (see the *Notes* section)
+-   Radiance HDR - \*.hdr, \*.pic (always supported)
 
 @note
 
@@ -131,13 +133,15 @@ returns an empty matrix ( Mat::data==NULL ). Currently, the following file forma
  */
 CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 
-/** @brief Loads and resizes down an image from a file.
-@anchor imread_reduced
-@param filename Name of file to be loaded.
-@param flags Flag that can take values of @ref cv::ImreadModes
-@param scale_denom
- */
-CV_EXPORTS_W Mat imread_reduced( const String& filename, int flags = IMREAD_COLOR, int scale_denom=1 );
+/** @overload
+
+example usage:
+imread( "fruits.jpg", IMREAD_COLOR, Size(8,8) ) when the width and height are smaller than 9 load image scaled 1/given value
+imread( "fruits.jpg", IMREAD_COLOR, Size(320,240) ) load image and resize it according given width and height
+imread( "fruits.jpg", IMREAD_COLOR, Size(320,0) ) load image and resize it according given width and calculate height
+imread( "fruits.jpg", IMREAD_COLOR, Size(0,200) ) load image and resize it according given height and calculate width
+*/
+CV_EXPORTS_W Mat imread( const String& filename, int flags, Size dsize );
 
 /** @brief Loads a multi-page image from a file. (see imread for details.)
 

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -136,10 +136,10 @@ CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 /** @overload
 
 example usage:
-imread( "fruits.jpg", IMREAD_COLOR, Size(8,8) ) when the width and height are smaller than 9 load image scaled 1/given value
-imread( "fruits.jpg", IMREAD_COLOR, Size(320,240) ) load image and resize it according given width and height
-imread( "fruits.jpg", IMREAD_COLOR, Size(320,0) ) load image and resize it according given width and calculate height
-imread( "fruits.jpg", IMREAD_COLOR, Size(0,200) ) load image and resize it according given height and calculate width
+-   imread( "fruits.jpg", IMREAD_COLOR, Size(8,8) ) when the width and height are smaller than 9 load image scaled 1/given value
+-   imread( "fruits.jpg", IMREAD_COLOR, Size(320,240) ) load image and resize it according given width and height
+-   imread( "fruits.jpg", IMREAD_COLOR, Size(320,0) ) load image and resize it according given width and calculate height
+-   imread( "fruits.jpg", IMREAD_COLOR, Size(0,200) ) load image and resize it according given height and calculate width
 */
 CV_EXPORTS_W Mat imread( const String& filename, int flags, Size dsize );
 

--- a/modules/imgcodecs/src/grfmt_base.cpp
+++ b/modules/imgcodecs/src/grfmt_base.cpp
@@ -52,7 +52,7 @@ BaseImageDecoder::BaseImageDecoder()
     m_width = m_height = 0;
     m_type = -1;
     m_buf_supported = false;
-    m_scale_denom = 1;
+    m_size = Size();
 }
 
 bool BaseImageDecoder::setSource( const String& filename )
@@ -82,10 +82,10 @@ bool BaseImageDecoder::checkSignature( const String& signature ) const
     return signature.size() >= len && memcmp( signature.c_str(), m_signature.c_str(), len ) == 0;
 }
 
-int BaseImageDecoder::setScale( const int& scale_denom )
+Size BaseImageDecoder::setSize( const Size& dsize )
 {
-    int temp = m_scale_denom;
-    m_scale_denom = scale_denom;
+    Size temp = m_size;
+    m_size = dsize;
     return temp;
 }
 

--- a/modules/imgcodecs/src/grfmt_base.hpp
+++ b/modules/imgcodecs/src/grfmt_base.hpp
@@ -67,7 +67,7 @@ public:
 
     virtual bool setSource( const String& filename );
     virtual bool setSource( const Mat& buf );
-    virtual int setScale( const int& scale_denom );
+    virtual Size setSize( const Size& dsize );
     virtual bool readHeader() = 0;
     virtual bool readData( Mat& img ) = 0;
 
@@ -82,7 +82,7 @@ protected:
     int  m_width;  // width  of the image ( filled by readHeader )
     int  m_height; // height of the image ( filled by readHeader )
     int  m_type;
-    int  m_scale_denom;
+    Size m_size;
     String m_filename;
     String m_signature;
     Mat m_buf;

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -242,9 +242,26 @@ bool  JpegDecoder::readHeader()
         {
             jpeg_read_header( &state->cinfo, TRUE );
 
-            state->cinfo.scale_num=1;
-            state->cinfo.scale_denom = m_scale_denom;
-            m_scale_denom=1; // trick! to know which decoder used scale_denom see imread_
+            int m_scale_denom = max( m_size.width , m_size.height );
+            if ( (m_size.width | m_size.height ) == 0 )
+            {
+                m_scale_denom = 1;
+            }
+            else if( m_scale_denom < 9 )
+            {
+                m_size = Size(); // trick! to know JpegDecoder used scale_denom see imread_
+            }
+            else if( m_scale_denom == m_size.width )
+            {
+                m_scale_denom = state->cinfo.image_width / m_size.width;
+            }
+            else if( m_scale_denom == m_size.height )
+            {
+                m_scale_denom = state->cinfo.image_height / m_size.height;
+            }
+
+            state->cinfo.scale_num = 1;
+            state->cinfo.scale_denom = m_scale_denom > 1 ? m_scale_denom : 1;
             jpeg_calc_output_dimensions(&state->cinfo);
             m_width = state->cinfo.output_width;
             m_height = state->cinfo.output_height;


### PR DESCRIPTION
https://github.com/Itseez/opencv/pull/4228
example usage :
1) when the Size(w,h) values < 9
imread(filename,flags,Size(2,0)) -> imagesize = originaldimensions / 2
imread(filename,flags,Size(0,2)) -> imagesize = originaldimensions / 2
imread(filename,flags,Size(2,2)) -> imagesize = originaldimensions / 2
.
.
imread(filename,flags,Size(8,0)) -> imagesize = originaldimensions / 8
imread(filename,flags,Size(0,8)) -> imagesize = originaldimensions / 8
imread(filename,flags,Size(8,8)) -> imagesize = originaldimensions / 8

2) when the Size(w,h) values > 8
imread(filename,flags,Size(800,0))     -> width= 800 , height = calculated
imread(filename,flags,Size(0,800))     -> width= calculated , height = 800
imread(filename,flags,Size(800,600)) -> width= 800 , height = 600