### PR TITLE
NearestNeighborTest: use ts->get_rng() instead of (implicit) theRNG()

### DIFF
--- a/modules/features2d/test/test_nearestneighbors.cpp
+++ b/modules/features2d/test/test_nearestneighbors.cpp
@@ -125,7 +125,7 @@ int NearestNeighborTest::checkFind( const Mat& data )
 void NearestNeighborTest::run( int /*start_from*/ ) {
     int code = cvtest::TS::OK, tempCode;
     Mat desc( featuresCount, dims, CV_32FC1 );
-    randu( desc, Scalar(minValue), Scalar(maxValue) );
+    ts->get_rng().fill( desc, RNG::UNIFORM, minValue, maxValue );
 
     createModel( desc );
 


### PR DESCRIPTION
This ensures that test data is not dependent on the order the tests are executed in.