### PR TITLE
fix CvVideoCamera defaultFPS

### DIFF
--- a/modules/videoio/src/cap_ios_video_camera.mm
+++ b/modules/videoio/src/cap_ios_video_camera.mm
@@ -295,12 +295,27 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 
 
     // set default FPS
-    if ([self.videoDataOutput connectionWithMediaType:AVMediaTypeVideo].supportsVideoMinFrameDuration) {
-        [self.videoDataOutput connectionWithMediaType:AVMediaTypeVideo].videoMinFrameDuration = CMTimeMake(1, self.defaultFPS);
+    AVCaptureDeviceInput *currentInput = [self.captureSession.inputs objectAtIndex:0];
+    AVCaptureDevice *device = currentInput.device;
+
+    NSError *error = nil;
+    [device lockForConfiguration:&error];
+    
+    float maxRate = ((AVFrameRateRange*) [device.activeFormat.videoSupportedFrameRateRanges objectAtIndex:0]).maxFrameRate;
+    NSLog(@"%f, %d", maxRate, self.defaultFPS);
+    if (maxRate > self.defaultFPS - 1) {
+        [device setActiveVideoMinFrameDuration:CMTimeMake(1, self.defaultFPS)];
+        [device setActiveVideoMaxFrameDuration:CMTimeMake(1, self.defaultFPS)];
+        NSLog(@"[Camera] FPS set to %d", self.defaultFPS);
+    } else {
+        NSLog(@"[Camera] unable to set defaultFPS at %d FPS, max is %f FPS", self.defaultFPS, maxRate);
     }
-    if ([self.videoDataOutput connectionWithMediaType:AVMediaTypeVideo].supportsVideoMaxFrameDuration) {
-        [self.videoDataOutput connectionWithMediaType:AVMediaTypeVideo].videoMaxFrameDuration = CMTimeMake(1, self.defaultFPS);
+
+    if (error != nil) {
+        NSLog(@"[Camera] unable to set defaultFPS: %@", error);
     }
+    
+    [device unlockForConfiguration];
 
     // set video mirroring for front camera (more intuitive)
     if ([self.videoDataOutput connectionWithMediaType:AVMediaTypeVideo].supportsVideoMirroring) {
@@ -329,7 +344,7 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
     [self.videoDataOutput setSampleBufferDelegate:self queue:videoDataOutputQueue];
 
 
-    NSLog(@"[Camera] created AVCaptureVideoDataOutput at %d FPS", self.defaultFPS);
+    NSLog(@"[Camera] created AVCaptureVideoDataOutput");
 }
 
 


### PR DESCRIPTION
CvVideoCamera defaultFPS was using depreciated methods, which stopped the fps being changed and produced warnings.

Fixes issue #4822