### PR TITLE
d3d-interop sample update

### DIFF
--- a/samples/directx/d3d11_interop.cpp
+++ b/samples/directx/d3d11_interop.cpp
@@ -111,6 +111,7 @@ public:
 
         m_pSurfaceRGBA = 0;
         m_pSurfaceNV12 = 0;
+        m_pSurfaceNV12_cpu_copy = 0;
 
         D3D11_TEXTURE2D_DESC desc_rgba;
 

--- a/samples/directx/d3dsample.hpp
+++ b/samples/directx/d3dsample.hpp
@@ -175,10 +175,10 @@ static const char* keys =
 template <typename TApp>
 int d3d_app(int argc, char** argv, std::string& title)
 {
-    cv::CommandLineParser parser(argc, argv, keys); \
-    bool   useCamera = parser.has("camera"); \
-    string file      = parser.get<string>("file"); \
-    bool   showHelp  = parser.get<bool>("help"); \
+    cv::CommandLineParser parser(argc, argv, keys);
+    bool   useCamera = parser.has("camera");
+    string file      = parser.get<string>("file");
+    bool   showHelp  = parser.get<bool>("help");
 
     if (showHelp)
         help();


### PR DESCRIPTION
fixed uninitialized nv12_cpu_copy surface, remove odd code