### PR TITLE
Update ml module data.cpp - loading samples training data without responses

### DIFF
--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -638,9 +638,9 @@ public:
 
         //If there are responses in the csv file, save them. If not, responses matrix will contain just zeros
         if (noutputvars != 0){ 
-            Mat(nsamples, noutputvars, CV_32F, &allresponses[0]).copyTo(tempResponses);
-            setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
-                    noArray(), Mat(vtypes).clone(), tempMissing);
+        Mat(nsamples, noutputvars, CV_32F, &allresponses[0]).copyTo(tempResponses);
+        setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
+                noArray(), Mat(vtypes).clone(), tempMissing);
         }
         else{
             Mat zero_mat(nsamples, 1, CV_32F, Scalar(0));

--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -637,7 +637,7 @@ public:
         }
 
         //If there are responses in the csv file, save them. If not, responses matrix will contain just zeros
-        if (noutputvars != 0){ 
+        if (noutputvars != 0){
         Mat(nsamples, noutputvars, CV_32F, &allresponses[0]).copyTo(tempResponses);
         setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
                 noArray(), Mat(vtypes).clone(), tempMissing);

--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -638,9 +638,9 @@ public:
 
         //If there are responses in the csv file, save them. If not, responses matrix will contain just zeros
         if (noutputvars != 0){
-        Mat(nsamples, noutputvars, CV_32F, &allresponses[0]).copyTo(tempResponses);
-        setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
-                noArray(), Mat(vtypes).clone(), tempMissing);
+            Mat(nsamples, noutputvars, CV_32F, &allresponses[0]).copyTo(tempResponses);
+            setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
+                    noArray(), Mat(vtypes).clone(), tempMissing);
         }
         else{
             Mat zero_mat(nsamples, 1, CV_32F, Scalar(0));

--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -636,9 +636,18 @@ public:
                 vtypes[ninputvars] = VAR_CATEGORICAL;
         }
 
-        Mat(nsamples, noutputvars, CV_32F, &allresponses[0]).copyTo(tempResponses);
-        setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
-                noArray(), Mat(vtypes).clone(), tempMissing);
+        //If there are responses in the csv file, save them. If not, responses matrix will contain just zeros
+        if (noutputvars != 0){ 
+            Mat(nsamples, noutputvars, CV_32F, &allresponses[0]).copyTo(tempResponses);
+            setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
+                    noArray(), Mat(vtypes).clone(), tempMissing);
+        }
+        else{
+            Mat zero_mat(nsamples, 1, CV_32F, Scalar(0));
+            zero_mat.copyTo(tempResponses);
+            setData(tempSamples, ROW_SAMPLE, tempResponses, noArray(), noArray(),
+                    noArray(), noArray(), tempMissing);
+        }
         bool ok = !samples.empty();
         if(ok)
             std::swap(tempNameMap, nameMap);


### PR DESCRIPTION
Update to allow loading data from a .csv file that only contains training samples values and not the associated responses. To allow this behavior, function must be called with parameters ResponsesStartIdx <= -2 and ResponsesEndIdx = 0