### PR TITLE
Prevent grabcut, houghcircles and houghlines python2 demos from running automatically

### DIFF
--- a/samples/python2/grabcut.py
+++ b/samples/python2/grabcut.py
@@ -95,80 +95,82 @@ def onmouse(event,x,y,flags,param):
             cv2.circle(img,(x,y),thickness,value['color'],-1)
             cv2.circle(mask,(x,y),thickness,value['val'],-1)
 
-# print documentation
-print __doc__
+if __name__ == '__main__':
 
-# Loading images
-if len(sys.argv) == 2:
-    filename = sys.argv[1] # for drawing purposes
-else:
-    print "No input image given, so loading default image, ../data/lena.jpg \n"
-    print "Correct Usage: python grabcut.py <filename> \n"
-    filename = '../data/lena.jpg'
+    # print documentation
+    print __doc__
 
-img = cv2.imread(filename)
-img2 = img.copy()                               # a copy of original image
-mask = np.zeros(img.shape[:2],dtype = np.uint8) # mask initialized to PR_BG
-output = np.zeros(img.shape,np.uint8)           # output image to be shown
+    # Loading images
+    if len(sys.argv) == 2:
+        filename = sys.argv[1] # for drawing purposes
+    else:
+        print "No input image given, so loading default image, ../data/lena.jpg \n"
+        print "Correct Usage: python grabcut.py <filename> \n"
+        filename = '../data/lena.jpg'
 
-# input and output windows
-cv2.namedWindow('output')
-cv2.namedWindow('input')
-cv2.setMouseCallback('input',onmouse)
-cv2.moveWindow('input',img.shape[1]+10,90)
+    img = cv2.imread(filename)
+    img2 = img.copy()                               # a copy of original image
+    mask = np.zeros(img.shape[:2],dtype = np.uint8) # mask initialized to PR_BG
+    output = np.zeros(img.shape,np.uint8)           # output image to be shown
 
-print " Instructions: \n"
-print " Draw a rectangle around the object using right mouse button \n"
+    # input and output windows
+    cv2.namedWindow('output')
+    cv2.namedWindow('input')
+    cv2.setMouseCallback('input',onmouse)
+    cv2.moveWindow('input',img.shape[1]+10,90)
 
-while(1):
+    print " Instructions: \n"
+    print " Draw a rectangle around the object using right mouse button \n"
 
-    cv2.imshow('output',output)
-    cv2.imshow('input',img)
-    k = 0xFF & cv2.waitKey(1)
+    while(1):
 
-    # key bindings
-    if k == 27:         # esc to exit
-        break
-    elif k == ord('0'): # BG drawing
-        print " mark background regions with left mouse button \n"
-        value = DRAW_BG
-    elif k == ord('1'): # FG drawing
-        print " mark foreground regions with left mouse button \n"
-        value = DRAW_FG
-    elif k == ord('2'): # PR_BG drawing
-        value = DRAW_PR_BG
-    elif k == ord('3'): # PR_FG drawing
-        value = DRAW_PR_FG
-    elif k == ord('s'): # save image
-        bar = np.zeros((img.shape[0],5,3),np.uint8)
-        res = np.hstack((img2,bar,img,bar,output))
-        cv2.imwrite('grabcut_output.png',res)
-        print " Result saved as image \n"
-    elif k == ord('r'): # reset everything
-        print "resetting \n"
-        rect = (0,0,1,1)
-        drawing = False
-        rectangle = False
-        rect_or_mask = 100
-        rect_over = False
-        value = DRAW_FG
-        img = img2.copy()
-        mask = np.zeros(img.shape[:2],dtype = np.uint8) # mask initialized to PR_BG
-        output = np.zeros(img.shape,np.uint8)           # output image to be shown
-    elif k == ord('n'): # segment the image
-        print """ For finer touchups, mark foreground and background after pressing keys 0-3
-        and again press 'n' \n"""
-        if (rect_or_mask == 0):         # grabcut with rect
-            bgdmodel = np.zeros((1,65),np.float64)
-            fgdmodel = np.zeros((1,65),np.float64)
-            cv2.grabCut(img2,mask,rect,bgdmodel,fgdmodel,1,cv2.GC_INIT_WITH_RECT)
-            rect_or_mask = 1
-        elif rect_or_mask == 1:         # grabcut with mask
-            bgdmodel = np.zeros((1,65),np.float64)
-            fgdmodel = np.zeros((1,65),np.float64)
-            cv2.grabCut(img2,mask,rect,bgdmodel,fgdmodel,1,cv2.GC_INIT_WITH_MASK)
+        cv2.imshow('output',output)
+        cv2.imshow('input',img)
+        k = 0xFF & cv2.waitKey(1)
 
-    mask2 = np.where((mask==1) + (mask==3),255,0).astype('uint8')
-    output = cv2.bitwise_and(img2,img2,mask=mask2)
+        # key bindings
+        if k == 27:         # esc to exit
+            break
+        elif k == ord('0'): # BG drawing
+            print " mark background regions with left mouse button \n"
+            value = DRAW_BG
+        elif k == ord('1'): # FG drawing
+            print " mark foreground regions with left mouse button \n"
+            value = DRAW_FG
+        elif k == ord('2'): # PR_BG drawing
+            value = DRAW_PR_BG
+        elif k == ord('3'): # PR_FG drawing
+            value = DRAW_PR_FG
+        elif k == ord('s'): # save image
+            bar = np.zeros((img.shape[0],5,3),np.uint8)
+            res = np.hstack((img2,bar,img,bar,output))
+            cv2.imwrite('grabcut_output.png',res)
+            print " Result saved as image \n"
+        elif k == ord('r'): # reset everything
+            print "resetting \n"
+            rect = (0,0,1,1)
+            drawing = False
+            rectangle = False
+            rect_or_mask = 100
+            rect_over = False
+            value = DRAW_FG
+            img = img2.copy()
+            mask = np.zeros(img.shape[:2],dtype = np.uint8) # mask initialized to PR_BG
+            output = np.zeros(img.shape,np.uint8)           # output image to be shown
+        elif k == ord('n'): # segment the image
+            print """ For finer touchups, mark foreground and background after pressing keys 0-3
+            and again press 'n' \n"""
+            if (rect_or_mask == 0):         # grabcut with rect
+                bgdmodel = np.zeros((1,65),np.float64)
+                fgdmodel = np.zeros((1,65),np.float64)
+                cv2.grabCut(img2,mask,rect,bgdmodel,fgdmodel,1,cv2.GC_INIT_WITH_RECT)
+                rect_or_mask = 1
+            elif rect_or_mask == 1:         # grabcut with mask
+                bgdmodel = np.zeros((1,65),np.float64)
+                fgdmodel = np.zeros((1,65),np.float64)
+                cv2.grabCut(img2,mask,rect,bgdmodel,fgdmodel,1,cv2.GC_INIT_WITH_MASK)
 
-cv2.destroyAllWindows()
+        mask2 = np.where((mask==1) + (mask==3),255,0).astype('uint8')
+        output = cv2.bitwise_and(img2,img2,mask=mask2)
+
+    cv2.destroyAllWindows()

--- a/samples/python2/houghcircles.py
+++ b/samples/python2/houghcircles.py
@@ -10,24 +10,25 @@ import cv2
 import numpy as np
 import sys
 
+if __name__ == '__main__':
 
-print __doc__
-try:
-    fn = sys.argv[1]
-except:
-    fn = "../data/board.jpg"
+    print __doc__
+    try:
+        fn = sys.argv[1]
+    except:
+        fn = "../data/board.jpg"
 
-src = cv2.imread(fn, 1)
-img = cv2.cvtColor(src, cv2.COLOR_BGR2GRAY)
-img = cv2.medianBlur(img, 5)
-cimg = src.copy() # numpy function
+    src = cv2.imread(fn, 1)
+    img = cv2.cvtColor(src, cv2.COLOR_BGR2GRAY)
+    img = cv2.medianBlur(img, 5)
+    cimg = src.copy() # numpy function
 
-circles = cv2.HoughCircles(img, cv2.HOUGH_GRADIENT, 1, 10, np.array([]), 100, 30, 1, 30)
-a, b, c = circles.shape
-for i in range(b):
-    cv2.circle(cimg, (circles[0][i][0], circles[0][i][1]), circles[0][i][2], (0, 0, 255), 3, cv2.LINE_AA)
-    cv2.circle(cimg, (circles[0][i][0], circles[0][i][1]), 2, (0, 255, 0), 3, cv2.LINE_AA) # draw center of circle
+    circles = cv2.HoughCircles(img, cv2.HOUGH_GRADIENT, 1, 10, np.array([]), 100, 30, 1, 30)
+    a, b, c = circles.shape
+    for i in range(b):
+        cv2.circle(cimg, (circles[0][i][0], circles[0][i][1]), circles[0][i][2], (0, 0, 255), 3, cv2.LINE_AA)
+        cv2.circle(cimg, (circles[0][i][0], circles[0][i][1]), 2, (0, 255, 0), 3, cv2.LINE_AA) # draw center of circle
 
-cv2.imshow("source", src)
-cv2.imshow("detected circles", cimg)
-cv2.waitKey(0)
+    cv2.imshow("source", src)
+    cv2.imshow("detected circles", cimg)
+    cv2.waitKey(0)

--- a/samples/python2/houghlines.py
+++ b/samples/python2/houghlines.py
@@ -9,35 +9,37 @@ import numpy as np
 import sys
 import math
 
-try:
-    fn = sys.argv[1]
-except:
-    fn = "../data/pic1.png"
-print __doc__
-src = cv2.imread(fn)
-dst = cv2.Canny(src, 50, 200)
-cdst = cv2.cvtColor(dst, cv2.COLOR_GRAY2BGR)
+if __name__ == '__main__':
 
-if True: # HoughLinesP
-    lines = cv2.HoughLinesP(dst, 1, math.pi/180.0, 40, np.array([]), 50, 10)
-    a,b,c = lines.shape
-    for i in range(a):
-        cv2.line(cdst, (lines[i][0][0], lines[i][0][1]), (lines[i][0][2], lines[i][0][3]), (0, 0, 255), 3, cv2.LINE_AA)
+    try:
+        fn = sys.argv[1]
+    except:
+        fn = "../data/pic1.png"
+    print __doc__
+    src = cv2.imread(fn)
+    dst = cv2.Canny(src, 50, 200)
+    cdst = cv2.cvtColor(dst, cv2.COLOR_GRAY2BGR)
 
-else:    # HoughLines
-    lines = cv2.HoughLines(dst, 1, math.pi/180.0, 50, np.array([]), 0, 0)
-    a,b,c = lines.shape
-    for i in range(a):
-        rho = lines[i][0][0]
-        theta = lines[i][0][1]
-        a = math.cos(theta)
-        b = math.sin(theta)
-        x0, y0 = a*rho, b*rho
-        pt1 = ( int(x0+1000*(-b)), int(y0+1000*(a)) )
-        pt2 = ( int(x0-1000*(-b)), int(y0-1000*(a)) )
-        cv2.line(cdst, pt1, pt2, (0, 0, 255), 3, cv2.LINE_AA)
+    if True: # HoughLinesP
+        lines = cv2.HoughLinesP(dst, 1, math.pi/180.0, 40, np.array([]), 50, 10)
+        a,b,c = lines.shape
+        for i in range(a):
+            cv2.line(cdst, (lines[i][0][0], lines[i][0][1]), (lines[i][0][2], lines[i][0][3]), (0, 0, 255), 3, cv2.LINE_AA)
+
+    else:    # HoughLines
+        lines = cv2.HoughLines(dst, 1, math.pi/180.0, 50, np.array([]), 0, 0)
+        a,b,c = lines.shape
+        for i in range(a):
+            rho = lines[i][0][0]
+            theta = lines[i][0][1]
+            a = math.cos(theta)
+            b = math.sin(theta)
+            x0, y0 = a*rho, b*rho
+            pt1 = ( int(x0+1000*(-b)), int(y0+1000*(a)) )
+            pt2 = ( int(x0-1000*(-b)), int(y0-1000*(a)) )
+            cv2.line(cdst, pt1, pt2, (0, 0, 255), 3, cv2.LINE_AA)
 
 
-cv2.imshow("source", src)
-cv2.imshow("detected lines", cdst)
-cv2.waitKey(0)
+    cv2.imshow("source", src)
+    cv2.imshow("detected lines", cdst)
+    cv2.waitKey(0)


### PR DESCRIPTION
This is a simple clean-up of a bug in the python2 samples.

The /samples/python2 directory includes `demo.py`, a Demo Browser application:

<img width="515" alt="screen shot 2015-08-04 at 2 05 43 pm" src="https://cloud.githubusercontent.com/assets/896692/9072767/e88225f6-3ab1-11e5-9d88-da93d66da8af.png">

This lets you easily browse a list of demos and launch the one you want to see by clicking `Run`. 

However, there was a problem with the `grabcut`, `houghcircles` and `houghlines` demos. Just by highlighting on their names in the list, those demos were launched. The demos aren't supposed to launch until the user clicks the `Run` button. Those demos were missing a proper check for `__main__`.

The required fix is to simply add this line to those three demos:
```python
if __name__ == '__main__':
```
The functionality and code is completely unchanged otherwise. The rest of the diff is just shifting the code over by four spaces.