### PR TITLE
Fix segfault in adaptiveThreshold when src == dst.

### DIFF
--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -1310,7 +1310,7 @@ void cv::adaptiveThreshold( InputArray _src, OutputArray _dst, double maxValue,
         src.convertTo(srcfloat,CV_32F);
         meanfloat=srcfloat;
         GaussianBlur(srcfloat, meanfloat, Size(blockSize, blockSize), 0, 0, BORDER_REPLICATE);
-        meanfloat.convertTo(dst, src.type());
+        meanfloat.convertTo(mean, src.type());
     }
     else
         CV_Error( CV_StsBadFlag, "Unknown/unsupported adaptive threshold method" );


### PR DESCRIPTION
This fixes an issue in PR #4149 which resulted in segfault when adaptiveThreshold was called with src==dst.

Example:
    cv::adaptiveThreshold(src, src, 255, ADAPTIVE_THRESH_GAUSSIAN_C,
                          THRESH_BINARY, 127, 15);
