### PR TITLE
Scripts for building Android pack

### DIFF
--- a/3rdparty/ippicv/downloader.cmake
+++ b/3rdparty/ippicv/downloader.cmake
@@ -13,7 +13,7 @@ function(_icv_downloader)
     set(OPENCV_ICV_PLATFORM "macosx")
     set(OPENCV_ICV_PACKAGE_SUBDIR "/ippicv_osx")
   elseif(UNIX)
-    if(ANDROID AND (NOT ANDROID_ABI STREQUAL x86))
+    if(ANDROID AND NOT (ANDROID_ABI STREQUAL x86 OR ANDROID_ABI STREQUAL x86_64))
       return()
     endif()
     set(OPENCV_ICV_PACKAGE_NAME "ippicv_linux_20141027.tgz")
@@ -75,7 +75,7 @@ function(_icv_downloader)
       message(FATAL_ERROR "ICV: Failed to download ICV package: ${OPENCV_ICV_PACKAGE_NAME}. Status=${__status}")
     else()
       # Don't remove this code, because EXPECTED_MD5 parameter doesn't fail "file(DOWNLOAD)" step
-      # on wrong hash 
+      # on wrong hash
       file(MD5 "${OPENCV_ICV_PACKAGE_ARCHIVE}" archive_md5)
       if(NOT archive_md5 STREQUAL OPENCV_ICV_PACKAGE_HASH)
         message(FATAL_ERROR "ICV: Downloaded copy of ICV package has invalid MD5 hash: ${archive_md5} (expected: ${OPENCV_ICV_PACKAGE_HASH})")

--- a/platforms/android/build-tests/test_ant_build.py
+++ b/platforms/android/build-tests/test_ant_build.py
@@ -75,4 +75,3 @@ if __name__ == '__main__':
     res = unittest.TextTestRunner(verbosity=3).run(s)
     if not res.wasSuccessful():
         sys.exit(res)
-

--- a/platforms/android/build-tests/test_ant_build.py
+++ b/platforms/android/build-tests/test_ant_build.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+import unittest
+import os, sys, subprocess, argparse, shutil, re
+from os.path import abspath
+
+class TestAntBuild(unittest.TestCase):
+    pass
+
+    def __init__(self, target, workdir, lib_dir, sample_dir, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.target = target
+        self.workdir = workdir
+        self.src_lib_dir = lib_dir
+        self.src_sample_dir = sample_dir
+        self.lib_dir = os.path.join(self.workdir, "opencv")
+        self.sample_dir = os.path.join(self.workdir, "project")
+
+    def shortDescription(self):
+        return "TARGET: %s, SAMPLE: %s" % (self.target, os.path.basename(self.src_sample_dir))
+
+    def setUp(self):
+        if os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
+        os.mkdir(self.workdir)
+        shutil.copytree(self.src_lib_dir, self.lib_dir)
+        shutil.copytree(self.src_sample_dir, self.sample_dir)
+        os.remove(os.path.join(self.sample_dir, "project.properties"))
+
+    def tearDown(self):
+        if os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
+
+    def runTest(self):
+        cmd = [os.path.join(os.environ["ANDROID_SDK"], "tools", "android"), "update", "project", "-p", self.lib_dir, "-t", self.target]
+        retcode = subprocess.call(cmd)
+        self.assertEqual(retcode, 0, "android update opencv project failed")
+
+        cmd = ["ant", "-f", os.path.join(self.lib_dir, "build.xml"), "debug"]
+        retcode = subprocess.call(cmd)
+        self.assertEqual(retcode, 0, "opencv ant build failed")
+
+        cmd = [os.path.join(os.environ["ANDROID_SDK"], "tools", "android"), "update", "project", "-p", self.sample_dir, "-t", self.target, "-l", os.path.relpath(self.lib_dir, self.sample_dir)]
+        retcode = subprocess.call(cmd)
+        self.assertEqual(retcode, 0, "android update sample project failed")
+
+        cmd = ["ant", "-f", os.path.join(self.sample_dir, "build.xml"), "debug"]
+        retcode = subprocess.call(cmd)
+        self.assertEqual(retcode, 0, "sample ant build failed")
+
+def suite(workdir, opencv_lib_path, opencv_samples_path):
+    suite = unittest.TestSuite()
+    for target in ["android-14", "android-17"]:
+        for item in os.listdir(opencv_samples_path):
+            item = os.path.join(opencv_samples_path, item)
+            if (os.path.exists(os.path.join(item, "AndroidManifest.xml"))):
+                suite.addTest(TestAntBuild(target, workdir, opencv_lib_path, item))
+    return suite
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test OpenCV for Android SDK with ant')
+    parser.add_argument('--sdk_path', help="Path to Android SDK to use for build")
+    parser.add_argument("--workdir", default="testspace", help="Working directory (and output)")
+    parser.add_argument("opencv_lib_path", help="Path to folder with SDK java library (usually <SDK>/sdk/java/)")
+    parser.add_argument("opencv_samples_path", help="Path to folder with SDK samples (usually <SDK>/samples/)")
+
+    args = parser.parse_args()
+
+    if args.sdk_path is not None:
+        os.environ["ANDROID_SDK"] = os.path.abspath(args.sdk_path)
+
+    print("Using SDK: %s" % os.environ["ANDROID_SDK"])
+
+    s = suite(abspath(args.workdir), abspath(args.opencv_lib_path), abspath(args.opencv_samples_path))
+    res = unittest.TextTestRunner(verbosity=3).run(s)
+    if not res.wasSuccessful():
+        sys.exit(res)
+

--- a/platforms/android/build-tests/test_cmake_build.py
+++ b/platforms/android/build-tests/test_cmake_build.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+
+import unittest
+import os, sys, subprocess, argparse, shutil, re
+
+CMAKE_TEMPLATE='''\
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+SET(PROJECT_NAME hello-android)
+PROJECT(${PROJECT_NAME})
+FIND_PACKAGE(OpenCV REQUIRED %(libset)s)
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
+FILE(GLOB srcs "*.cpp")
+ADD_EXECUTABLE(${PROJECT_NAME} ${srcs})
+TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${OpenCV_LIBS} dl z)
+'''
+
+CPP_TEMPLATE = '''\
+#include <opencv2/core.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+using namespace cv;
+const char* message = "Hello Android!";
+int main(int argc, char* argv[])
+{
+  (void)argc; (void)argv;
+  printf("%s\\n", message);
+  Size textsize = getTextSize(message, CV_FONT_HERSHEY_COMPLEX, 3, 5, 0);
+  Mat img(textsize.height + 20, textsize.width + 20, CV_32FC1, Scalar(230,230,230));
+  putText(img, message, Point(10, img.rows - 10), CV_FONT_HERSHEY_COMPLEX, 3, Scalar(0, 0, 0), 5);
+  imwrite("/mnt/sdcard/HelloAndroid.png", img);
+  return 0;
+}
+'''
+
+#===================================================================================================
+
+class TestCmakeBuild(unittest.TestCase):
+    def __init__(self, libset, abi, toolchain, opencv_cmake_path, workdir, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.libset = libset
+        self.abi = abi
+        self.toolchain = toolchain
+        self.opencv_cmake_path = opencv_cmake_path
+        self.workdir = workdir
+        self.srcdir = os.path.join(self.workdir, "src")
+        self.bindir = os.path.join(self.workdir, "build")
+
+    def shortDescription(self):
+        return "ABI: %s, TOOLCHAIN: %s, LIBSET: %s" % (self.abi, self.toolchain, self.libset)
+
+    def gen_cmakelists(self):
+        return CMAKE_TEMPLATE % {"libset": self.libset}
+
+    def gen_code(self):
+        return CPP_TEMPLATE
+
+    def write_src_file(self, fname, content):
+        with open(os.path.join(self.srcdir, fname), "w") as f:
+            f.write(content)
+
+    def setUp(self):
+        if os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
+        os.mkdir(self.workdir)
+        os.mkdir(self.srcdir)
+        os.mkdir(self.bindir)
+        self.write_src_file("CMakeLists.txt", self.gen_cmakelists())
+        self.write_src_file("main.cpp", self.gen_code())
+        os.chdir(self.bindir)
+
+    def tearDown(self):
+        if os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
+
+    def runTest(self):
+        cmd = [
+            "cmake",
+            "-GNinja",
+            "-DOpenCV_DIR=%s" % self.opencv_cmake_path,
+            "-DANDROID_ABI=%s" % self.abi,
+            "-DCMAKE_TOOLCHAIN_FILE=%s" % os.path.join(self.opencv_cmake_path, "android.toolchain.cmake"),
+            "-DANDROID_TOOLCHAIN_NAME=%s" % self.toolchain,
+            self.srcdir
+        ]
+        retcode = subprocess.call(cmd)
+        self.assertEqual(retcode, 0, "cmake failed")
+
+        cmd = ["ninja"]
+        retcode = subprocess.call(cmd)
+        self.assertEqual(retcode, 0, "make failed")
+
+def suite(workdir, opencv_cmake_path):
+    abis = {
+        "armeabi":"arm-linux-androideabi-4.8",
+        "armeabi-v7a":"arm-linux-androideabi-4.8",
+        "arm64-v8a":"aarch64-linux-android-4.9",
+        "x86":"x86-4.8",
+        "x86_64":"x86_64-4.9",
+        "mips":"mipsel-linux-android-4.8",
+        "mips64":"mips64el-linux-android-4.9"
+    }
+
+    suite = unittest.TestSuite()
+    for libset in ["", "opencv_java"]:
+        for abi, toolchain in abis.items():
+            suite.addTest(TestCmakeBuild(libset, abi, toolchain, opencv_cmake_path, workdir))
+    return suite
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test OpenCV for Android SDK with cmake')
+    parser.add_argument('--sdk_path', help="Path to Android SDK to use for build")
+    parser.add_argument('--ndk_path', help="Path to Android NDK to use for build")
+    parser.add_argument("--workdir", default="testspace", help="Working directory (and output)")
+    parser.add_argument("opencv_cmake_path", help="Path to folder with OpenCVConfig.cmake and android.toolchain.cmake (usually <SDK>/sdk/native/jni/")
+
+    args = parser.parse_args()
+
+    if args.sdk_path is not None:
+        os.environ["ANDROID_SDK"] = os.path.abspath(args.sdk_path)
+    if args.ndk_path is not None:
+        os.environ["ANDROID_NDK"] = os.path.abspath(args.ndk_path)
+
+    print("Using SDK: %s" % os.environ["ANDROID_SDK"])
+    print("Using NDK: %s" % os.environ["ANDROID_NDK"])
+
+    res = unittest.TextTestRunner(verbosity=3).run(suite(os.path.abspath(args.workdir), os.path.abspath(args.opencv_cmake_path)))
+    if not res.wasSuccessful():
+        sys.exit(res)

--- a/platforms/android/build-tests/test_ndk_build.py
+++ b/platforms/android/build-tests/test_ndk_build.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+import unittest
+import os, sys, subprocess, argparse, shutil, re
+
+TEMPLATE_ANDROID_MK = '''\
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+{cut}
+LOCAL_MODULE    := mixed_sample
+LOCAL_SRC_FILES := {cpp1}
+LOCAL_LDLIBS +=  -llog -ldl
+include $(BUILD_SHARED_LIBRARY)
+include $(CLEAR_VARS)
+{cut}
+LOCAL_MODULE    := mixed_sample2
+LOCAL_SRC_FILES := {cpp2}
+LOCAL_LDLIBS +=  -llog -ldl
+LOCAL_SHARED_LIBS := mixed_sample
+include $(BUILD_SHARED_LIBRARY)
+'''
+
+TEMPLATE_APPLICATION_MK = '''\
+APP_STL := gnustl_static
+APP_CPPFLAGS := -frtti -fexceptions
+APP_ABI := {abi}
+APP_PLATFORM := android-9
+'''
+
+TEMPLATE_JNI = '''\
+#include <jni.h>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/features2d.hpp>
+#include <vector>
+using namespace std;
+using namespace cv;
+extern "C" {
+JNIEXPORT void JNICALL Java_org_opencv_samples_tutorial4_Sample4Mixed_FindFeatures(JNIEnv*, jobject, jlong addrGray, jlong addrRgba);
+JNIEXPORT void JNICALL Java_org_opencv_samples_tutorial4_Sample4Mixed_FindFeatures(JNIEnv*, jobject, jlong addrGray, jlong addrRgba)
+{
+    Mat& mGr  = *(Mat*)addrGray;
+    Mat& mRgb = *(Mat*)addrRgba;
+    vector<KeyPoint> v;
+    Ptr<FastFeatureDetector> detector = FastFeatureDetector::create(50);
+    detector->detect(mGr, v);
+    for( unsigned int i = 0; i < v.size(); i++ )
+    {
+        const KeyPoint& kp = v[i];
+        circle(mRgb, Point(kp.pt.x, kp.pt.y), 10, Scalar(255,0,0,255));
+    }
+}
+}
+'''
+
+#===================================================================================================
+
+class TestNDKBuild(unittest.TestCase):
+    def __init__(self, abi, libtype, opencv_mk_path, workdir, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.abi = abi # official NDK ABI name or 'all'
+        self.libtype = libtype # 'static', etc
+        self.opencv_mk_path = opencv_mk_path
+        self.workdir = workdir
+        self.jnidir = os.path.join(self.workdir, "jni")
+        self.cpp1 = "jni_part1.cpp"
+        self.cpp2 = "jni_part2.cpp"
+
+    def shortDescription(self):
+        return "ABI: %s, LIBTYPE: %s" % (self.abi, self.libtype)
+
+    def gen_android_mk(self):
+        p = []
+        if self.libtype == "static":
+            p.append("OPENCV_LIB_TYPE := STATIC")
+        elif self.libtype == "shared_debug":
+            p.append("OPENCV_LIB_TYPE := SHARED")
+            p.append("OPENCV_CAMERA_MODULES:=on")
+            p.append("OPENCV_INSTALL_MODULES:=on")
+        elif self.libtype == "shared":
+            p.append("OPENCV_LIB_TYPE := SHARED")
+        p.append("include %s" % os.path.join(self.opencv_mk_path, "OpenCV.mk"))
+        return TEMPLATE_ANDROID_MK.format(cut = "\n".join(p), cpp1 = self.cpp1, cpp2 = self.cpp2)
+
+    def gen_jni_code(self):
+        return TEMPLATE_JNI
+
+    def gen_application_mk(self):
+        return TEMPLATE_APPLICATION_MK.format(abi = self.abi)
+
+    def write_jni_file(self, fname, contents):
+        with open(os.path.join(self.jnidir, fname), "w") as f:
+            f.write(contents)
+
+    def setUp(self):
+        if os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
+        os.mkdir(self.workdir)
+        os.mkdir(self.jnidir)
+        self.write_jni_file("Android.mk", self.gen_android_mk())
+        self.write_jni_file("Application.mk", self.gen_application_mk())
+        self.write_jni_file(self.cpp1, self.gen_jni_code())
+        self.write_jni_file(self.cpp2, self.gen_jni_code())
+        os.chdir(self.workdir)
+
+    def tearDown(self):
+        if os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
+
+    def runTest(self):
+        ndk_path = os.environ["ANDROID_NDK"]
+        retcode = subprocess.call([os.path.join(ndk_path, 'ndk-build'), "V=0"])
+        self.assertEqual(retcode, 0)
+
+def suite(workdir, opencv_mk_path):
+    abis = ["armeabi", "armeabi-v7a", "x86", "mips"]
+    ndk_path = os.environ["ANDROID_NDK"]
+    with open(os.path.join(ndk_path, "RELEASE.TXT"), "r") as f:
+        s = f.read()
+        if re.search(r'r10[b-e]', s):
+            abis.extend(["arm64-v8a", "x86", "x86_64"])
+    abis.append("all")
+
+    suite = unittest.TestSuite()
+    for libtype in  ["static", "shared", "shared_debug"]:
+        for abi in abis:
+            suite.addTest(TestNDKBuild(abi, libtype, opencv_mk_path, workdir))
+    return suite
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test OpenCV for Android SDK with NDK')
+    parser.add_argument('--ndk_path', help="Path to Android NDK to use for build")
+    parser.add_argument("--workdir", default="testspace", help="Working directory (and output)")
+    parser.add_argument("opencv_mk_path", help="Path to folder with OpenCV.mk file (usually <SDK>/sdk/native/jni/")
+
+    args = parser.parse_args()
+
+    if args.ndk_path is not None:
+        os.environ["ANDROID_NDK"] = os.path.abspath(args.ndk_path)
+
+    print("Using NDK: %s" % os.environ["ANDROID_NDK"])
+
+    res = unittest.TextTestRunner(verbosity=3).run(suite(os.path.abspath(args.workdir), os.path.abspath(args.opencv_mk_path)))
+    if not res.wasSuccessful():
+        sys.exit(res)

--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -316,5 +316,3 @@ if __name__ == "__main__":
     log.info("=====")
     log.info("SDK location: %s", builder.resultdest)
     log.info("Documentation location: %s", builder.docdest)
-
-

--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python
+
+import os, sys, subprocess, argparse, shutil, glob, re
+import logging as log
+import xml.etree.ElementTree as ET
+
+class Fail(Exception):
+    def __init__(self, text=None):
+        self.t = text
+    def __str__(self):
+        return "ERROR" if self.t is None else self.t
+
+def execute(cmd):
+    try:
+        log.info("Executing: %s" % cmd)
+        retcode = subprocess.call(cmd)
+        if retcode < 0:
+            raise Fail("Child was terminated by signal:" %s -retcode)
+        elif retcode > 0:
+            raise Fail("Child returned: %s" % retcode)
+    except OSError as e:
+        raise Fail("Execution failed: %s" % e)
+
+def rm_one(d):
+    d = os.path.abspath(d)
+    if os.path.exists(d):
+        if os.path.isdir(d):
+            log.info("Removing dir: %s", d)
+            shutil.rmtree(d)
+        elif os.path.isfile(d):
+            log.info("Removing file: %s", d)
+            os.remove(d)
+
+def check_dir(d, create=False, clean=False):
+    d = os.path.abspath(d)
+    log.info("Check dir %s (create: %s, clean: %s)", d, create, clean)
+    if os.path.exists(d):
+        if not os.path.isdir(d):
+            raise Fail("Not a directory: %s" % d)
+        if clean:
+            for x in glob.glob(os.path.join(d, "*")):
+                rm_one(x)
+    else:
+        if create:
+            os.makedirs(d)
+    return d
+
+def determine_engine_version(manifest_path):
+    with open(manifest_path, "rt") as f:
+        return re.search(r'android:versionName="(\d+\.\d+)"', f.read(), re.MULTILINE).group(1)
+
+def determine_opencv_version(version_hpp_path):
+    # version in 2.4 - CV_VERSION_EPOCH.CV_VERSION_MAJOR.CV_VERSION_MINOR.CV_VERSION_REVISION
+    # version in master - CV_VERSION_MAJOR.CV_VERSION_MINOR.CV_VERSION_REVISION-CV_VERSION_STATUS
+    with open(version_hpp_path, "rt") as f:
+        data = f.read()
+        major = re.search(r'^#define\W+CV_VERSION_MAJOR\W+(\d+)$', data, re.MULTILINE).group(1)
+        minor = re.search(r'^#define\W+CV_VERSION_MINOR\W+(\d+)$', data, re.MULTILINE).group(1)
+        revision = re.search(r'^#define\W+CV_VERSION_REVISION\W+(\d+)$', data, re.MULTILINE).group(1)
+        version_status = re.search(r'^#define\W+CV_VERSION_STATUS\W+"([^"]*)"', data, re.MULTILINE).group(1)
+        return "%(major)s.%(minor)s.%(revision)s%(version_status)s" % locals()
+
+#===================================================================================================
+
+class ABI:
+    def __init__(self, platform_id, name, toolchain, cmake_name=None):
+        self.platform_id = platform_id # platform code to add to apk version (for cmake)
+        self.name = name # general name (official Android ABI identifier)
+        self.toolchain = toolchain # toolchain identifier (for cmake)
+        self.cmake_name = cmake_name # name of android toolchain (for cmake)
+        if self.cmake_name is None:
+            self.cmake_name = self.name
+    def __str__(self):
+        return "%s (%s)" % (self.name, self.toolchain)
+    def haveIPP(self):
+        return False
+        # return self.name == "x86" or self.name == "x86_64"
+
+ABIs = [
+    ABI("2", "armeabi-v7a", "arm-linux-androideabi-4.8", cmake_name="armeabi-v7a with NEON"),
+    ABI("1", "armeabi",     "arm-linux-androideabi-4.8"),
+    ABI("3", "arm64-v8a",   "aarch64-linux-android-4.9"),
+    ABI("5", "x86_64",      "x86_64-4.9"),
+    ABI("4", "x86",         "x86-4.8"),
+    ABI("7", "mips64",      "mips64el-linux-android-4.9"),
+    ABI("6", "mips",        "mipsel-linux-android-4.8")
+]
+
+#===================================================================================================
+
+class Builder:
+    def __init__(self, workdir, opencvdir):
+        self.workdir = check_dir(workdir, create=True)
+        self.opencvdir = check_dir(opencvdir)
+        self.libdest = check_dir(os.path.join(self.workdir, "o4a"), create=True, clean=True)
+        self.docdest = check_dir(os.path.join(self.workdir, "javadoc"), create=True, clean=True)
+        self.resultdest = check_dir(os.path.join(self.workdir, "OpenCV-android-sdk"), create=True, clean=True)
+        self.extra_packs = []
+        self.opencv_version = determine_opencv_version(os.path.join(self.opencvdir, "modules", "core", "include", "opencv2", "core", "version.hpp"))
+        self.engine_version = determine_engine_version(os.path.join(self.opencvdir, "platforms", "android", "service", "engine", "AndroidManifest.xml"))
+        self.use_ccache = True
+
+    def get_toolchain_file(self):
+        return os.path.join(self.opencvdir, "platforms", "android", "android.toolchain.cmake")
+
+    def get_engine_apk_dest(self, engdest):
+        return os.path.join(engdest, "platforms", "android", "service", "engine", ".build")
+
+    def add_extra_pack(self, ver, path):
+        if path is None:
+            return
+        self.extra_packs.append((ver, check_dir(path)))
+
+    def clean_library_build_dir(self):
+        for d in ["CMakeCache.txt", "CMakeFiles/", "bin/", "libs/", "lib/", "package/", "install/samples/"]:
+            rm_one(d)
+
+    def build_library(self, abi, do_install):
+        cmd = [
+            "cmake",
+            "-GNinja",
+            "-DCMAKE_TOOLCHAIN_FILE='%s'" % self.get_toolchain_file(),
+            "-DWITH_OPENCL=OFF",
+            "-DWITH_CUDA=OFF",
+            "-DWITH_IPP=%s" % ("ON" if abi.haveIPP() else "OFF"),
+            "-DBUILD_EXAMPLES=OFF",
+            "-DBUILD_TESTS=OFF",
+            "-DBUILD_PERF_TESTS=OFF",
+            "-DBUILD_DOCS=OFF",
+            "-DBUILD_ANDROID_EXAMPLES=ON",
+            "-DINSTALL_ANDROID_EXAMPLES=ON",
+            "-DANDROID_STL=gnustl_static",
+            "-DANDROID_NATIVE_API_LEVEL=8",
+            "-DANDROID_ABI='%s'" % abi.cmake_name,
+            "-DWITH_TBB=ON",
+            "-DANDROID_TOOLCHAIN_NAME=%s" % abi.toolchain,
+            self.opencvdir
+        ]
+        if self.use_ccache == True:
+            cmd.extend(["-DNDK_CCACHE=ccache", "-DENABLE_PRECOMPILED_HEADERS=OFF"])
+        if do_install:
+            cmd.extend(["-DBUILD_TESTS=ON", "-DINSTALL_TESTS=ON"])
+        execute(cmd)
+        if do_install:
+            execute(["ninja"])
+            for c in ["libs", "dev", "java", "samples"]:
+                execute(["cmake", "-DCOMPONENT=%s" % c, "-P", "cmake_install.cmake"])
+        else:
+            execute(["ninja", "install/strip"])
+
+    def build_engine(self, abi, engdest):
+        cmd = [
+            "cmake",
+            "-GNinja",
+            "-DCMAKE_TOOLCHAIN_FILE='%s'" % self.get_toolchain_file(),
+            "-DANDROID_ABI='%s'" % abi.cmake_name,
+            "-DBUILD_ANDROID_SERVICE=ON",
+            "-DANDROID_PLATFORM_ID=%s" % abi.platform_id,
+            "-DWITH_CUDA=OFF",
+            "-DWITH_OPENCL=OFF",
+            "-DWITH_IPP=OFF",
+            self.opencvdir
+        ]
+        execute(cmd)
+        apkdest = self.get_engine_apk_dest(engdest)
+        # Add extra data
+        apkxmldest = check_dir(os.path.join(apkdest, "res", "xml"), create=True)
+        apklibdest = check_dir(os.path.join(apkdest, "libs", abi.name), create=True)
+        for ver, d in self.extra_packs + [("3.0.0", os.path.join(self.libdest, "lib"))]:
+            r = ET.Element("library", attrib={"version": ver})
+            log.info("Adding libraries from %s", d)
+            for f in glob.glob(os.path.join(d, abi.name, "*.so")):
+                log.info("Copy file: %s", f)
+                shutil.copy2(f, apklibdest)
+                if "libnative_camera" in f:
+                    continue
+                log.info("Register file: %s", os.path.basename(f))
+                n = ET.SubElement(r, "file", attrib={"name": os.path.basename(f)})
+            xmlname = os.path.join(apkxmldest, "config%s.xml" % ver.replace(".", ""))
+            log.info("Generating XML config: %s", xmlname)
+            ET.ElementTree(r).write(xmlname, encoding="utf-8")
+        execute(["ninja", "opencv_engine"])
+        execute(["ant", "-f", os.path.join(apkdest, "build.xml"), "debug"])
+        # TODO: Sign apk
+
+    def build_javadoc(self):
+        classpaths = [os.path.join(self.libdest, "bin", "classes")]
+        for dir, _, files in os.walk(os.environ["ANDROID_SDK"]):
+            for f in files:
+                if f == "android.jar" or f == "annotations.jar":
+                    classpaths.append(os.path.join(dir, f))
+        cmd = [
+            "javadoc",
+            "-header", "OpenCV %s" % self.opencv_version,
+            "-nodeprecated",
+            "-footer", '<a href="http://docs.opencv.org">OpenCV %s Documentation</a>' % self.opencv_version,
+            "-public",
+            "-sourcepath", os.path.join(self.libdest, "src"),
+            "-d", self.docdest,
+            "-classpath", ":".join(classpaths)
+        ]
+        for _, dirs, _ in os.walk(os.path.join(self.libdest, "src", "org", "opencv")):
+            cmd.extend(["org.opencv." + d for d in dirs])
+        execute(cmd)
+
+    def gather_results(self, engines):
+        # Copy all files
+        root = os.path.join(self.libdest, "install")
+        for item in os.listdir(root):
+            name = item
+            item = os.path.join(root, item)
+            if os.path.isdir(item):
+                log.info("Copy dir: %s", item)
+                shutil.copytree(item, os.path.join(self.resultdest, name))
+            elif os.path.isfile(item):
+                log.info("Copy file: %s", item)
+                shutil.copy2(item, os.path.join(self.resultdest, name))
+
+        # Copy engines for all platforms
+        for abi, engdest in engines:
+            log.info("Copy engine: %s (%s)", abi, engdest)
+            f = os.path.join(self.get_engine_apk_dest(engdest), "bin", "opencv_engine-debug.apk")
+            resname = "OpenCV_%s_Manager_%s_%s.apk" % (self.opencv_version, self.engine_version, abi)
+            shutil.copy2(f, os.path.join(self.resultdest, "apk", resname))
+
+        # Copy javadoc
+        log.info("Copy docs: %s", self.docdest)
+        shutil.copytree(self.docdest, os.path.join(self.resultdest, "sdk", "java", "javadoc"))
+
+        # Patch cmake config
+        with open(os.path.join(self.resultdest, "sdk", "native", "jni", "OpenCVConfig.cmake"), "r+t") as f:
+            contents = f.read()
+            contents, count = re.subn(r'OpenCV_ANDROID_NATIVE_API_LEVEL \d+', "OpenCV_ANDROID_NATIVE_API_LEVEL 8", contents)
+            f.seek(0)
+            f.write(contents)
+            f.truncate()
+            log.info("Patch cmake config: %s (%d changes)", f.name, count)
+
+        # Clean samples
+        path = os.path.join(self.resultdest, "samples")
+        for item in os.listdir(path):
+            item = os.path.join(path, item)
+            if os.path.isdir(item):
+                for name in ["build.xml", "local.properties", "proguard-project.txt"]:
+                    rm_one(os.path.join(item, name))
+
+
+#===================================================================================================
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Build OpenCV for Android SDK')
+    parser.add_argument("work_dir", help="Working directory (and output)")
+    parser.add_argument("opencv_dir", help="Path to OpenCV source dir")
+    parser.add_argument('--ndk_path', help="Path to Android NDK to use for build")
+    parser.add_argument('--sdk_path', help="Path to Android SDK to use for build")
+    parser.add_argument('--sign_with', help="Sertificate to sign the Manager apk")
+    parser.add_argument('--build_doc', action="store_true", help="Build javadoc")
+    parser.add_argument('--no_ccache', action="store_true", help="Do not use ccache during library build")
+    parser.add_argument('--extra_pack', action='append', help="provide extra OpenCV libraries for Manager apk in form <version>:<path-to-native-libs>, for example '2.4.11:unpacked/sdk/native/libs'")
+    args = parser.parse_args()
+
+    log.basicConfig(format='%(message)s', level=log.DEBUG)
+    log.debug("Args: %s", args)
+
+    if args.ndk_path is not None:
+        os.environ["ANDROID_NDK"] = args.ndk_path
+    if args.sdk_path is not None:
+        os.environ["ANDROID_SDK"] = args.sdk_path
+
+    log.info("Android NDK path: %s", os.environ["ANDROID_NDK"])
+    log.info("Android SDK path: %s", os.environ["ANDROID_SDK"])
+
+    builder = Builder(args.work_dir, args.opencv_dir)
+
+    if args.no_ccache:
+        builder.use_ccache = False
+
+    log.info("Detected OpenCV version: %s", builder.opencv_version)
+    log.info("Detected Engine version: %s", builder.engine_version)
+
+    for one in args.extra_pack:
+        i = one.find(":")
+        if i > 0 and i < len(one) - 1:
+            builder.add_extra_pack(one[:i], one[i+1:])
+        else:
+            raise Fail("Bad extra pack provided: %s, should be in form '<version>:<path-to-native-libs>'" % one)
+
+    engines = []
+    for i, abi in enumerate(ABIs):
+        do_install = (i == 0)
+        engdest = check_dir(os.path.join(builder.workdir, "build_service_%s" % abi.name), create=True, clean=True)
+
+        log.info("=====")
+        log.info("===== Building library for %s", abi)
+        log.info("=====")
+
+        os.chdir(builder.libdest)
+        builder.clean_library_build_dir()
+        builder.build_library(abi, do_install)
+
+        log.info("=====")
+        log.info("===== Building engine for %s", abi)
+        log.info("=====")
+
+        os.chdir(engdest)
+        builder.build_engine(abi, engdest)
+        engines.append((abi.name, engdest))
+
+    if args.build_doc:
+        builder.build_javadoc()
+
+    builder.gather_results(engines)
+
+    log.info("=====")
+    log.info("===== Build finished")
+    log.info("=====")
+    log.info("SDK location: %s", builder.resultdest)
+    log.info("Documentation location: %s", builder.docdest)
+
+

--- a/platforms/android/service/engine/AndroidManifest.xml
+++ b/platforms/android/service/engine/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.opencv.engine"
-    android:versionCode="3000"
+    android:versionCode="300@ANDROID_PLATFORM_ID@"
     android:versionName="3.00">
 
     <uses-sdk android:minSdkVersion="@ANDROID_NATIVE_API_LEVEL@" android:targetSdkVersion="22"/>


### PR DESCRIPTION
Initial version
Tested on linux (python2, python3), macosx (python2) with NDK r10e (all 7 ABIs).
Currently uses cmake + ninja for build.
IPPICV is temporarily disabled due to link errors during cmake test build.
Additionally:
- enabled IPPICV for x86_64 Android ABI
- restored ANDROID_PLATFORM_ID cmake parameter to control OpenCV Manager apk version number