### PR TITLE
Fixing typo in variable name.

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -282,7 +282,7 @@ static bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo info)
 
     if( type < 0 )
     {
-        if( typenum == NPY_INT64 || typenum == NPY_UINT64 || type == NPY_LONG )
+        if( typenum == NPY_INT64 || typenum == NPY_UINT64 || typenum == NPY_LONG )
         {
             needcopy = needcast = true;
             new_typenum = NPY_INT;


### PR DESCRIPTION
I think that it is typo in variable name (variable `type` will have value -1 ). It's probably harmless because `NPY_LONG` == `NPY_INT` or `NPY_LONG` == `NPY_INT64` depending from machine.  