### PR TITLE
cvCreateCameraCapture: fix using preffered interface

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -129,6 +129,9 @@ CV_IMPL CvCapture * cvCreateCameraCapture (int index)
     // interpret preferred interface (0 = autodetect)
     int pref = (index / 100) * 100;
 
+    // remove pref from index
+    index -= pref;
+
     // local variable to memorize the captured device
     CvCapture *capture = 0;
 


### PR DESCRIPTION
The provided interface id must be removed from the index. Otherwise, the
underlying implementations are using a wrong camera id.

Example:
VideoCapture(800) fails because PvAPI tries to open a camera
on position 800