### PR TITLE
fixed valgrind warning in polylines

### DIFF
--- a/modules/core/src/drawing.cpp
+++ b/modules/core/src/drawing.cpp
@@ -2216,6 +2216,7 @@ void cv::polylines(InputOutputArray _img, InputArrayOfArrays pts,
         Mat p = pts.getMat(manyContours ? i : -1);
         if( p.total() == 0 )
         {
+            ptsptr[i] = NULL;
             npts[i] = 0;
             continue;
         }


### PR DESCRIPTION
```
[ RUN      ] Core_Drawing.polylines_empty
==12960== Conditional jump or move depends on uninitialised value(s)
==12960==    at 0x4AD57E8: cv::PolyLine(cv::Mat&, cv::Point_<int> const*, int, bool, void const*, int, int, int) (drawing.cpp:1635)
==12960==    by 0x4AD77A3: cv::polylines(cv::Mat&, cv::Point_<int> const**, int const*, int, bool, cv::Scalar_<double> const&, int, int, int) (drawing.cpp:1856)
==12960==    by 0x4AD901B: cv::polylines(cv::_OutputArray const&, cv::_InputArray const&, bool, cv::Scalar_<double> const&, int, int, int) (drawing.cpp:2226)
==12960==    by 0x4FF95F: Core_Drawing_polylines_empty_Test::TestBody() (test_misc.cpp:56)
==12960==    by 0x60515F: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (ts_gtest.cpp:3578)
==12960==    by 0x5FFA67: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (ts_gtest.cpp:3614)
==12960==    by 0x5EB88F: testing::Test::Run() (ts_gtest.cpp:3651)
==12960==    by 0x5EC10B: testing::TestInfo::Run() (ts_gtest.cpp:3826)
==12960==    by 0x5EC7CF: testing::TestCase::Run() (ts_gtest.cpp:3944)
==12960==    by 0x5F35A7: testing::internal::UnitTestImpl::RunAllTests() (ts_gtest.cpp:5823)
==12960==    by 0x60627F: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (ts_gtest.cpp:3578)
==12960==    by 0x6007EB: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (ts_gtest.cpp:3614)
==12960== 
```