### PR TITLE
bug fix fro the TickMeter class

### DIFF
--- a/samples/gpu/tick_meter.hpp
+++ b/samples/gpu/tick_meter.hpp
@@ -26,8 +26,8 @@ std::ostream& operator << (std::ostream& out, const TickMeter& tm);
 
 TickMeter::TickMeter() { reset(); }
 int64 TickMeter::getTimeTicks() const { return sumTime; }
-double TickMeter::getTimeMicro() const { return  getTimeMilli()*1e-3;}
-double TickMeter::getTimeMilli() const { return getTimeSec()*1e-3; }
+double TickMeter::getTimeMicro() const { return  getTimeMilli()*1e3;}
+double TickMeter::getTimeMilli() const { return getTimeSec()*1e3; }
 double TickMeter::getTimeSec() const { return (double)getTimeTicks()/cv::getTickFrequency();}
 int64 TickMeter::getCounter() const { return counter; }
 void TickMeter::reset() {startTime = 0; sumTime = 0; counter = 0; }

--- a/samples/gpu/tick_meter.hpp
+++ b/samples/gpu/tick_meter.hpp
@@ -26,9 +26,9 @@ std::ostream& operator << (std::ostream& out, const TickMeter& tm);
 
 TickMeter::TickMeter() { reset(); }
 int64 TickMeter::getTimeTicks() const { return sumTime; }
-double TickMeter::getTimeMicro() const { return (double)getTimeTicks()/cv::getTickFrequency(); }
-double TickMeter::getTimeMilli() const { return getTimeMicro()*1e-3; }
-double TickMeter::getTimeSec() const { return getTimeMilli()*1e-3; }
+double TickMeter::getTimeMicro() const { return  getTimeMilli()*1e-3;}
+double TickMeter::getTimeMilli() const { return getTimeSec()*1e-3; }
+double TickMeter::getTimeSec() const { return (double)getTimeTicks()/cv::getTickFrequency();}
 int64 TickMeter::getCounter() const { return counter; }
 void TickMeter::reset() {startTime = 0; sumTime = 0; counter = 0; }
 


### PR DESCRIPTION
I fixed the calculations for the .getTimeSec(), .getTimeMilli(), and .getTimeMicro() methods which seemed to be wrongly declared. Moreover, I there is an open question in the official forum which it would interesting to be answered. The open question is here: http://answers.opencv.org/question/67009/why-tickmeter-class-only-used-in-the-gpu-samples/