### PR TITLE
repaired gstreamer v4l2 camera capture

### DIFF
--- a/cmake/OpenCVFindLibsVideo.cmake
+++ b/cmake/OpenCVFindLibsVideo.cmake
@@ -12,8 +12,8 @@ endif(WITH_VFW)
 
 # --- GStreamer ---
 ocv_clear_vars(HAVE_GSTREAMER)
-# try to find gstreamer 1.x first
-if(WITH_GSTREAMER)
+# try to find gstreamer 1.x first if 0.10 was not requested
+if(WITH_GSTREAMER AND NOT WITH_GSTREAMER_0_10)
   CHECK_MODULE(gstreamer-base-1.0 HAVE_GSTREAMER_BASE)
   CHECK_MODULE(gstreamer-video-1.0 HAVE_GSTREAMER_VIDEO)
   CHECK_MODULE(gstreamer-app-1.0 HAVE_GSTREAMER_APP)
@@ -29,7 +29,7 @@ if(WITH_GSTREAMER)
       set(GSTREAMER_PBUTILS_VERSION ${ALIASOF_gstreamer-pbutils-1.0_VERSION})
   endif()
 
-endif(WITH_GSTREAMER)
+endif()
 
 # gstreamer support was requested but could not find gstreamer 1.x,
 # so fallback/try to find gstreamer 0.10

--- a/modules/highgui/src/cap.cpp
+++ b/modules/highgui/src/cap.cpp
@@ -238,10 +238,12 @@ CV_IMPL CvCapture * cvCreateCameraCapture (int index)
 #endif
 
 #ifdef HAVE_GSTREAMER
-            capture = cvCreateCapture_GStreamer(CV_CAP_GSTREAMER_V4L2, 0);
+            capture = cvCreateCapture_GStreamer(CV_CAP_GSTREAMER_V4L2,
+                                                reinterpret_cast<char *>(index));
             if (capture)
                 return capture;
-            capture = cvCreateCapture_GStreamer(CV_CAP_GSTREAMER_V4L, 0);
+            capture = cvCreateCapture_GStreamer(CV_CAP_GSTREAMER_V4L,
+                                                reinterpret_cast<char *>(index));
             if (capture)
                 return capture;
 #endif


### PR DESCRIPTION
1. Enabled property retrieval: height, width, FPS
2. Fixed issue when isOpened returns always true even for non-existing devices
3. Ability to work with non-0 device. Camera capture index is taken into account
4. The camera capture support works for both GStreamer 0.10 and 1.0
5. Enabled hue, saturation, contrast, brightness setting and getting.