### PR TITLE
Fix for bug #5007

### DIFF
--- a/modules/core/perf/opencl/perf_channels.cpp
+++ b/modules/core/perf/opencl/perf_channels.cpp
@@ -156,6 +156,9 @@ OCL_PERF_TEST_P(MixChannelsFixture, MixChannels,
 
 ///////////// InsertChannel ////////////////////////
 
+typedef std::tr1::tuple<cv::Size, MatDepth> Size_MatDepth_t;
+typedef TestBaseWithParam<Size_MatDepth_t> Size_MatDepth;
+
 typedef Size_MatDepth InsertChannelFixture;
 
 OCL_PERF_TEST_P(InsertChannelFixture, InsertChannel,

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -477,9 +477,6 @@ template<typename T> class TestBaseWithParam: public TestBase, public ::testing:
 typedef std::tr1::tuple<cv::Size, MatType> Size_MatType_t;
 typedef TestBaseWithParam<Size_MatType_t> Size_MatType;
 
-typedef std::tr1::tuple<cv::Size, MatDepth> Size_MatDepth_t;
-typedef TestBaseWithParam<Size_MatDepth_t> Size_MatDepth;
-
 /*****************************************************************************************\
 *                              Print functions for googletest                             *
 \*****************************************************************************************/


### PR DESCRIPTION
moved definition of Size_MatDepth_t and Size_MatDepth from ts_perf.hpp to perf_channels.cpp. This way they are closer to where they are needed and live in a different namespace (possibly the reason why the fix works).