### PR TITLE
remove sorted FuncInfo()

### DIFF
--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -821,8 +821,8 @@ class ClassInfo(GeneralInfo):
 
     def getAllMethods(self):
         result = []
-        result.extend([fi for fi in sorted(self.methods) if fi.isconstructor])
-        result.extend([fi for fi in sorted(self.methods) if not fi.isconstructor])
+        result.extend([fi for fi in self.methods if fi.isconstructor])
+        result.extend([fi for fi in self.methods if not fi.isconstructor])
         return result
 
     def addMethod(self, fi):


### PR DESCRIPTION
The sorted of type FuncInfo() will error in Python 3.4.0.
http://stackoverflow.com/questions/31773156/python3-opencv3-ubuntu-15-make-error