### PR TITLE
fixed "Conditional jump or move depends on uninitialised value" warning

### DIFF
--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1420,6 +1420,8 @@ TEST(Imgproc_cvWarpAffine, regression)
     IplImage* src = cvCreateImage(cvSize(100, 100), IPL_DEPTH_8U, 1);
     IplImage* dst = cvCreateImage(cvSize(100, 100), IPL_DEPTH_8U, 1);
 
+    cvZero(src);
+
     float m[6];
     CvMat M = cvMat( 2, 3, CV_32F, m );
     int w = src->width;


### PR DESCRIPTION
see the description https://github.com/Itseez/opencv/issues/5211