### PR TITLE
fixed memory leak caused by illegal memory access

### DIFF
--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -644,8 +644,7 @@ private:
 };
 
 CV_Remap_Test::CV_Remap_Test() :
-    CV_ImageWarpBaseTest(), mapx(), mapy(),
-    borderType(-1), borderValue()
+    CV_ImageWarpBaseTest(), borderType(-1)
 {
     funcs[0] = &CV_Remap_Test::remap_nearest;
     funcs[1] = &CV_Remap_Test::remap_generic;
@@ -666,7 +665,7 @@ void CV_Remap_Test::generate_test_data()
     // generating the mapx, mapy matrices
     static const int mapx_types[] = { CV_16SC2, CV_32FC1, CV_32FC2 };
     mapx.create(dst.size(), mapx_types[rng.uniform(0, sizeof(mapx_types) / sizeof(int))]);
-    mapy = Mat();
+    mapy.release();
 
     const int n = std::min(std::min(src.cols, src.rows) / 10 + 1, 2);
     float _n = 0; //static_cast<float>(-n);
@@ -693,7 +692,7 @@ void CV_Remap_Test::generate_test_data()
                     {
                         MatIterator_<ushort> begin_y = mapy.begin<ushort>(), end_y = mapy.end<ushort>();
                         for ( ; begin_y != end_y; ++begin_y)
-                            begin_y[0] = static_cast<short>(rng.uniform(0, 1024));
+                            *begin_y = static_cast<ushort>(rng.uniform(0, 1024));
                     }
                     break;
 
@@ -701,7 +700,7 @@ void CV_Remap_Test::generate_test_data()
                     {
                         MatIterator_<short> begin_y = mapy.begin<short>(), end_y = mapy.end<short>();
                         for ( ; begin_y != end_y; ++begin_y)
-                            begin_y[0] = static_cast<short>(rng.uniform(0, 1024));
+                            *begin_y = static_cast<short>(rng.uniform(0, 1024));
                     }
                     break;
                 }
@@ -718,8 +717,8 @@ void CV_Remap_Test::generate_test_data()
             MatIterator_<float> begin_y = mapy.begin<float>();
             for ( ; begin_x != end_x; ++begin_x, ++begin_y)
             {
-                begin_x[0] = rng.uniform(_n, fscols);
-                begin_y[0] = rng.uniform(_n, fsrows);
+                *begin_x = rng.uniform(_n, fscols);
+                *begin_y = rng.uniform(_n, fsrows);
             }
         }
         break;
@@ -731,8 +730,8 @@ void CV_Remap_Test::generate_test_data()
                     fsrows = static_cast<float>(std::max(src.rows - 1 + n, 0));
             for ( ; begin_x != end_x; ++begin_x)
             {
-                begin_x[0] = rng.uniform(_n, fscols);
-                begin_x[1] = rng.uniform(_n, fsrows);
+                (*begin_x)[0] = rng.uniform(_n, fscols);
+                (*begin_x)[1] = rng.uniform(_n, fsrows);
             }
         }
         break;
@@ -777,23 +776,6 @@ void CV_Remap_Test::prepare_test_data_for_reference_func()
 {
     CV_ImageWarpBaseTest::prepare_test_data_for_reference_func();
     convert_maps();
-/*
-    const int ksize = 3;
-    Mat kernel = getStructuringElement(CV_MOP_ERODE, Size(ksize, ksize));
-    Mat mask(src.size(), CV_8UC1, Scalar::all(255)), dst_mask;
-    cv::erode(src, erode_src, kernel);
-    cv::erode(mask, dst_mask, kernel, Point(-1, -1), 1, BORDER_CONSTANT, Scalar::all(0));
-    bitwise_not(dst_mask, mask);
-    src.copyTo(erode_src, mask);
-    dst_mask.release();
-
-    mask = Scalar::all(0);
-    kernel = getStructuringElement(CV_MOP_DILATE, kernel.size());
-    cv::dilate(src, dilate_src, kernel);
-    cv::dilate(mask, dst_mask, kernel, Point(-1, -1), 1, BORDER_CONSTANT, Scalar::all(255));
-    src.copyTo(dilate_src, dst_mask);
-    dst_mask.release();
-*/
 }
 
 void CV_Remap_Test::run_reference_func()


### PR DESCRIPTION
```
==26213== 880,176 bytes in 14 blocks are definitely lost in loss record 15 of 15
==26213==    at 0x4844C2C: malloc (vg_replace_malloc.c:299)
==26213==    by 0x4A2EB1B: cv::fastMalloc(unsigned long) (alloc.cpp:64)
==26213==    by 0x4A30DB3: cv::Mat::create(int, int const*, int) (matrix.cpp:215)
==26213==    by 0x4B94CF: cv::Mat::create(int, int, int) (mat.hpp:353)
==26213==    by 0x4B9527: cv::Mat::create(cv::Size_<int>, int) (mat.hpp:358)
==26213==    by 0x4FB187: CV_Remap_Test::generate_test_data() (test_imgwarp_strict.cpp:668)
==26213==    by 0x4FD057: CV_WarpAffine_Test::generate_test_data() (test_imgwarp_strict.cpp:993)
==26213==    by 0x4F8433: CV_ImageWarpBaseTest::run(int) (test_imgwarp_strict.cpp:217)
==26213==    by 0x54FEEB: cvtest::BaseTest::safe_run(int) (ts.cpp:214)
==26213==    by 0x4FEECB: Imgproc_WarpAffine_Test_accuracy_Test::TestBody() (in /home/nvidia/build_opencv/bin/opencv_test_imgproc)
==26213==    by 0x577ADF: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (ts_gtest.cpp:3578)
==26213==    by 0x5721AF: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (ts_gtest.cpp:3614)
==26213== 
==26213== LEAK SUMMARY:
==26213==    definitely lost: 880,176 bytes in 14 blocks
==26213==    indirectly lost: 0 bytes in 0 blocks
==26213==      possibly lost: 4,676 bytes in 83 blocks
==26213==    still reachable: 131,780 bytes in 788 blocks
==26213==         suppressed: 0 bytes in 0 blocks
```