### PR TITLE
kmeans and one-dimensional vectors

### DIFF
--- a/modules/core/src/kmeans.cpp
+++ b/modules/core/src/kmeans.cpp
@@ -221,9 +221,9 @@ double cv::kmeans( InputArray _data, int K,
 {
     const int SPP_TRIALS = 3;
     Mat data0 = _data.getMat();
-    bool isrow = data0.rows == 1 && data0.channels() > 1;
-    int N = !isrow ? data0.rows : data0.cols;
-    int dims = (!isrow ? data0.cols : 1)*data0.channels();
+    bool isrow = data0.rows == 1;
+    int N = isrow ? data0.cols : data0.rows;
+    int dims = (isrow ? 1 : data0.cols)*data0.channels();
     int type = data0.depth();
 
     attempts = std::max(attempts, 1);


### PR DESCRIPTION
Clustering one-dimensional data was only possible when storing it column-based. But a std::vector is interpreted as matrix with height=1.

See http://stackoverflow.com/questions/25077878/using-opencv-cvkmeans-with-one-dimensional-input

Backport to 2.4 may be needed