### PR TITLE
UMat fixes (getUMat & 'map_unmap_counting')

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4572,16 +4572,13 @@ public:
                     else
                     {
                         // CL_MEM_USE_HOST_PTR (nothing is required) and OTHER cases
-                        if (u->flags & UMatData::USER_ALLOCATED)
-                        {
-                            cl_int retval = 0;
-                            void* data = clEnqueueMapBuffer(q, (cl_mem)u->handle, CL_TRUE,
-                                (CL_MAP_READ | CL_MAP_WRITE),
-                                0, u->size, 0, 0, 0, &retval);
-                            CV_OclDbgAssert(retval == CL_SUCCESS);
-                            CV_OclDbgAssert(clEnqueueUnmapMemObject(q, (cl_mem)u->handle, data, 0, 0, 0) == CL_SUCCESS);
-                            CV_OclDbgAssert(clFinish(q) == CL_SUCCESS);
-                        }
+                        cl_int retval = 0;
+                        void* data = clEnqueueMapBuffer(q, (cl_mem)u->handle, CL_TRUE,
+                                                        (CL_MAP_READ | CL_MAP_WRITE),
+                                                        0, u->size, 0, 0, 0, &retval);
+                        CV_OclDbgAssert(retval == CL_SUCCESS);
+                        CV_OclDbgAssert(clEnqueueUnmapMemObject(q, (cl_mem)u->handle, data, 0, 0, 0) == CL_SUCCESS);
+                        CV_OclDbgAssert(clFinish(q) == CL_SUCCESS);
                     }
                 }
                 u->markHostCopyObsolete(false);

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4571,7 +4571,6 @@ public:
                     }
                     else
                     {
-                        // CL_MEM_USE_HOST_PTR (nothing is required) and OTHER cases
                         cl_int retval = 0;
                         void* data = clEnqueueMapBuffer(q, (cl_mem)u->handle, CL_TRUE,
                                                         (CL_MAP_READ | CL_MAP_WRITE),

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -1036,7 +1036,7 @@ TEST(UMat, map_unmap_counting)
     UMat um = m.getUMat(ACCESS_RW);
     {
         Mat d1 = um.getMat(ACCESS_RW);
-        //Mat d2 = um.getMat(ACCESS_RW);
+        Mat d2 = um.getMat(ACCESS_RW);
         d1.release();
     }
     void* h = NULL;

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -1035,8 +1035,9 @@ TEST(UMat, map_unmap_counting)
     Mat m(Size(10, 10), CV_8UC1);
     UMat um = m.getUMat(ACCESS_RW);
     {
-        Mat d = um.getMat(ACCESS_RW);
-        d.release();
+        Mat d1 = um.getMat(ACCESS_RW);
+        //Mat d2 = um.getMat(ACCESS_RW);
+        d1.release();
     }
     void* h = NULL;
     EXPECT_NO_THROW(h = um.handle(ACCESS_RW));


### PR DESCRIPTION
fixes for the following failing UMat tests: `Core_UMat.getUMat` (#5010), `UMat.map_unmap_counting` (#5259)