### PR TITLE
fixed the URL under Additional Resources

### DIFF
--- a/doc/py_tutorials/py_ml/py_svm/py_svm_basics/py_svm_basics.markdown
+++ b/doc/py_tutorials/py_ml/py_svm/py_svm_basics/py_svm_basics.markdown
@@ -129,7 +129,7 @@ Additional Resources
 --------------------
 
 -#  [NPTEL notes on Statistical Pattern Recognition, Chapters
-    25-29](http://www.nptel.iitm.ac.in/courses/106108057/26).
+    25-29](http://www.nptel.ac.in/courses/106108057/26).
 
 Exercises
 ---------


### PR DESCRIPTION
The URL http://www.nptel.iitm.ac.in/courses/106108057/26 under Additional Resource section gives a 404. I've added the updated one i.e. http://www.nptel.ac.in/courses/106108057/26