### PR TITLE
[UMat] fix for #5259 (duplicated umat.getMat())

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -496,6 +496,7 @@ struct CV_EXPORTS UMatData
     void* handle;
     void* userdata;
     int allocatorFlags_;
+    int mapcount;
 };
 
 

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -658,7 +658,7 @@ Mat UMat::getMat(int accessFlags) const
     else
     {
         CV_XADD(&u->refcount, -1);
-        CV_Assert(u->data != 0);
+        CV_Assert(u->data != 0 && "Error mapping of UMat to host memory.");
         return Mat();
     }
 }

--- a/modules/core/test/ocl/test_dft.cpp
+++ b/modules/core/test/ocl/test_dft.cpp
@@ -100,7 +100,8 @@ PARAM_TEST_CASE(Dft, cv::Size, OCL_FFT_TYPE, MatDepth, bool, bool, bool, bool)
     void generateTestData()
     {
         src = randomMat(dft_size, CV_MAKE_TYPE(depth, cn), 0.0, 100.0);
-        usrc = src.getUMat(ACCESS_READ);
+        //usrc = src.getUMat(ACCESS_READ); // cv::dft() can call usrc.getMat() if use CPU path that causes error, so using copyTo()
+        src.copyTo(usrc);
     }
 };
 

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -101,7 +101,8 @@ TEST(Core_OutputArrayAssign, _Matxd_UMatd)
 TEST(Core_OutputArrayAssign, _Matxd_UMatf)
 {
     Mat expected = (Mat_<float>(2,3) << 1, 2, 3, .1, .2, .3);
-    UMat uexpected = expected.getUMat(ACCESS_READ);
+    UMat uexpected;// = expected.getUMat(ACCESS_READ);
+    expected.copyTo(uexpected); // OutputArray::assign() calls convertTo(double) that calls uexpected.getMat() on iGPU, so don't use temp UMat here, make copyTo()
     Matx23d actualx;
 
     {
@@ -117,7 +118,8 @@ TEST(Core_OutputArrayAssign, _Matxd_UMatf)
 TEST(Core_OutputArrayAssign, _Matxf_UMatd)
 {
     Mat expected = (Mat_<double>(2,3) << 1, 2, 3, .1, .2, .3);
-    UMat uexpected = expected.getUMat(ACCESS_READ);
+    UMat uexpected;// = expected.getUMat(ACCESS_READ);
+    expected.copyTo(uexpected); // OutputArray::assign() calls convertTo() that calls uexpected.getMat() on iGPU, so don't use temp UMat here, make copyTo()
     Matx23f actualx;
 
     {


### PR DESCRIPTION
adding cl_buffer map/unmap counter, preventing getMat/getUMat from temp object
(fix for #5259)