### PR TITLE
fix for corrent modules dependencies

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -49,6 +49,8 @@ foreach(mod ${OPENCV_MODULES_BUILD} ${OPENCV_MODULES_DISABLED_USER} ${OPENCV_MOD
   if(HAVE_${mod})
     unset(HAVE_${mod} CACHE)
   endif()
+  unset(OPENCV_MODULE_${mod}_DEPS CACHE)
+  unset(OPENCV_MODULE_${mod}_DEPS_EXT CACHE)
   unset(OPENCV_MODULE_${mod}_REQ_DEPS CACHE)
   unset(OPENCV_MODULE_${mod}_OPT_DEPS CACHE)
   unset(OPENCV_MODULE_${mod}_PRIVATE_REQ_DEPS CACHE)


### PR DESCRIPTION
Case:
```
cmake -DWITH_CUDA=ON ../opencv
```
The line above adds CUDA libraries as a dependencies of `opencv_core` module. 
```
cmake -DWITH_CUDA=OFF .
```
I expect that this line removes CUDA libraries from `opencv_core` deps. But linker still expects CUDA libs during linkage.

The reason is that `__ocv_sort_modules_by_deps` returns empty value in case without CUDA and `__ocv_resolve_dependencies` must receive empty value too. ***BUT*** it takes value from `CACHE` for some unexpected reason. 