### PR TITLE
Adding version note in SVM tutorials

### DIFF
--- a/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.markdown
+++ b/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.markdown
@@ -94,6 +94,8 @@ the weight vector \f$\beta\f$ and the bias \f$\beta_{0}\f$ of the optimal hyperp
 Source Code
 -----------
 
+@note The following code has been implemented with OpenCV 3.0 classes and functions. An equivalent version of the code using OpenCV 2.4 can be found in [this page.](http://docs.opencv.org/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.html#introductiontosvms)
+
 @include cpp/tutorial_code/ml/introduction_to_svm/introduction_to_svm.cpp
 
 Explanation

--- a/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.markdown
+++ b/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.markdown
@@ -94,7 +94,7 @@ the weight vector \f$\beta\f$ and the bias \f$\beta_{0}\f$ of the optimal hyperp
 Source Code
 -----------
 
-@note The following code has been implemented with OpenCV 3.0 classes and functions. An equivalent version of the code using OpenCV 2.4 can be found in [this page.](http://docs.opencv.org/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.html#introductiontosvms)
+@note The following code has been implemented with OpenCV 3.0 classes and functions. An equivalent version of the code using OpenCV 2.4 can be found in [this page.](http://docs.opencv.org/2.4/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.html#introductiontosvms)
 
 @include cpp/tutorial_code/ml/introduction_to_svm/introduction_to_svm.cpp
 

--- a/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
+++ b/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
@@ -90,7 +90,7 @@ You may also find the source code in `samples/cpp/tutorial_code/ml/non_linear_sv
 [download it from here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ml/non_linear_svms/non_linear_svms.cpp).
 
 @note The following code has been implemented with OpenCV 3.0 classes and functions. An equivalent version of the code
-using OpenCV 2.4 can be found in [this page.](http://docs.opencv.org/doc/tutorials/ml/non_linear_svms/non_linear_svms.html#nonlinearsvms)
+using OpenCV 2.4 can be found in [this page.](http://docs.opencv.org/2.4/doc/tutorials/ml/non_linear_svms/non_linear_svms.html#nonlinearsvms)
 
 @include cpp/tutorial_code/ml/non_linear_svms/non_linear_svms.cpp
 

--- a/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
+++ b/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
@@ -89,6 +89,9 @@ Source Code
 You may also find the source code in `samples/cpp/tutorial_code/ml/non_linear_svms` folder of the OpenCV source library or
 [download it from here](https://github.com/Itseez/opencv/tree/master/samples/cpp/tutorial_code/ml/non_linear_svms/non_linear_svms.cpp).
 
+@note The following code has been implemented with OpenCV 3.0 classes and functions. An equivalent version of the code
+using OpenCV 2.4 can be found in [this page.](http://docs.opencv.org/doc/tutorials/ml/non_linear_svms/non_linear_svms.html#nonlinearsvms)
+
 @include cpp/tutorial_code/ml/non_linear_svms/non_linear_svms.cpp
 
 Explanation


### PR DESCRIPTION
Right now, in [table of contents of ml tutorials] (http://docs.opencv.org/master/d1/d69/tutorial_table_of_content_ml.html#gsc.tab=0), both SVM tutorials show compatibility > 2.0. However, code inside such tutorials have been upgraded to version 3.0.

My suggestion in this PR is to keep compatibility > 2.0 as theory is valid for both versions but point out in a note that source code is meant for 3.0 (also give link to 2.4 tutorial code)