### PR TITLE
fixed uninitialized memory writing/reading in flann

### DIFF
--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -384,6 +384,8 @@ public:
         }
 
         root_ = pool_.allocate<KMeansNode>();
+        std::memset(root_, 0, sizeof(KMeansNode));
+
         computeNodeStatistics(root_, indices_, (int)size_);
         computeClustering(root_, indices_, (int)size_, branching_,0);
     }
@@ -823,11 +825,11 @@ private:
             variance -= distance_(centers[c], ZeroIterator<ElementType>(), veclen_);
 
             node->childs[c] = pool_.allocate<KMeansNode>();
+            std::memset(node->childs[c], 0, sizeof(KMeansNode));
             node->childs[c]->radius = radiuses[c];
             node->childs[c]->pivot = centers[c];
             node->childs[c]->variance = variance;
             node->childs[c]->mean_radius = mean_radius;
-            node->childs[c]->indices = NULL;
             computeClustering(node->childs[c],indices+start, end-start, branching, level+1);
             start=end;
         }


### PR DESCRIPTION
`KMeansNode` is 48 byte structure, but sum of its fields sizes is 44 bytes. So, padded 4 bytes contain junk. We need to initialize the rest 4 bytes to eliminate valgrind warning when this structure is saved to file.