### PR TITLE
initialize padding of CvString with zeros

### DIFF
--- a/modules/core/src/datastructs.cpp
+++ b/modules/core/src/datastructs.cpp
@@ -346,6 +346,7 @@ CV_IMPL CvString
 cvMemStorageAllocString( CvMemStorage* storage, const char* ptr, int len )
 {
     CvString str;
+    memset(&str, 0, sizeof(CvString));
 
     str.len = len >= 0 ? len : (int)strlen(ptr);
     str.ptr = (char*)cvMemStorageAlloc( storage, str.len + 1 );


### PR DESCRIPTION
```
==24715== Conditional jump or move depends on uninitialised value(s)
==24715==    at 0x4502FC: CV_DetectorTest::prepareData(cv::FileStorage&) (/modules/objdetect/test/test_cascadeandhog.cpp:120)
==24715==    by 0x4506B3: CV_DetectorTest::run(int) (/modules/objdetect/test/test_cascadeandhog.cpp:160)
==24715==    by 0x462B5B: cvtest::BaseTest::safe_run(int) (/modules/ts/src/ts.cpp:214)
==24715==    by 0x4530CF: Objdetect_HOGDetector_regression_Test::TestBody() (in /home/nvidia/build_opencv/bin/opencv_test_objdetect)
==24715==    by 0x48A683: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/modules/ts/src/ts_gtest.cpp:3578)
==24715==    by 0x484ECB: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/modules/ts/src/ts_gtest.cpp:3614)
==24715==    by 0x470A3F: testing::Test::Run() (/modules/ts/src/ts_gtest.cpp:3651)
==24715==    by 0x4712BB: testing::TestInfo::Run() (/modules/ts/src/ts_gtest.cpp:3826)
==24715==    by 0x47197F: testing::TestCase::Run() (/modules/ts/src/ts_gtest.cpp:3944)
==24715==    by 0x478757: testing::internal::UnitTestImpl::RunAllTests() (/modules/ts/src/ts_gtest.cpp:5823)
==24715==    by 0x48B7A3: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/modules/ts/src/ts_gtest.cpp:3578)
==24715==    by 0x485C4F: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/modules/ts/src/ts_gtest.cpp:3614)
==24715==  Uninitialised value was created by a stack allocation
==24715==    at 0x4AB9B44: cvMemStorageAllocString (/modules/core/src/datastructs.cpp:347)
```