### PR TITLE
fix "unreachable code" warnings in cloning_gui.cpp

### DIFF
--- a/samples/cpp/tutorial_code/photo/seamless_cloning/cloning_gui.cpp
+++ b/samples/cpp/tutorial_code/photo/seamless_cloning/cloning_gui.cpp
@@ -542,5 +542,4 @@ int main()
         else if(key == 'q')
             exit(0);
     }
-    waitKey(0);
 }


### PR DESCRIPTION
issue #5288 , just for master, not 2.4, since sample is exclusive to 3.0