### PR TITLE
imread_reduced parameter change

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -138,7 +138,7 @@ CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 @param height height of the image.
 @param image loaded image.
 */
-typedef int (*ImreadCallback)( int width, int height, Mat* image );
+typedef int (*ImreadCallback)( int width, int height );
 
 /** @brief Loads an image from a file with Callback function support.
 @anchor imread_reduced

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -138,7 +138,7 @@ CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 @param height height of the image.
 @param image loaded image.
 */
-typedef int (*ImreadCallback)( int width, int height );
+typedef int (*ImreadCallback)( const Size& sz );
 
 /** @brief Loads an image from a file with Callback function support.
 @anchor imread_reduced

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -133,13 +133,51 @@ returns an empty matrix ( Mat::data==NULL ). Currently, the following file forma
  */
 CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 
-/** @brief Loads and resizes down an image from a file.
+/** @brief Callback function See cv::imread_reduced
+@param width width of the image.
+@param height height of the image.
+@param image loaded image.
+*/
+typedef int (*ImreadCallback)( int width, int height, Mat* image );
+
+/** @brief Loads an image from a file with Callback function support.
 @anchor imread_reduced
+The function imread_reduced loads an image from the specified file with Callback function support and returns it.
+You can see below code how to specify and use the callback.
+@code
+
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+
+using namespace cv;
+
+int onLoad( int width, int height, Mat* img )
+{
+    int scale = 1;
+    if( width > 80 )
+        scale =  width / 80;
+
+    if(img)
+    {
+        resize( *img, *img, Size( width/scale, height/scale ));
+    }
+
+    return scale;
+}
+
+int main( int argc, char** argv )
+{
+    Mat image = imread_reduced("lena.jpg", IMREAD_COLOR, onLoad );
+    imshow("imread_reduced test",image);
+    waitKey();
+    return 0;
+}
+@endcode
 @param filename Name of file to be loaded.
 @param flags Flag that can take values of @ref cv::ImreadModes
-@param scale_denom
+@param onLoad Callback function
  */
-CV_EXPORTS_W Mat imread_reduced( const String& filename, int flags = IMREAD_COLOR, int scale_denom=1 );
+CV_EXPORTS_W Mat imread_reduced( const String& filename, int flags = IMREAD_COLOR, ImreadCallback onLoad=0 );
 
 /** @brief Loads a multi-page image from a file. (see imread for details.)
 

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -157,10 +157,9 @@ int onLoad( int width, int height, Mat* img )
     if( width > 80 )
         scale =  width / 80;
 
-    if( img && (scale > 1 ))
+    if( img && (scale > 1 )) // you can do some operations on the image before imread_reduced returns it.
     {
         resize( *img, *img, Size( width/scale, height/scale ));
-     imshow("resized",*img);
     }
 
     return scale;

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -157,9 +157,10 @@ int onLoad( int width, int height, Mat* img )
     if( width > 80 )
         scale =  width / 80;
 
-    if(img)
+    if( img && (scale > 1 ))
     {
         resize( *img, *img, Size( width/scale, height/scale ));
+     imshow("resized",*img);
     }
 
     return scale;

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -138,7 +138,7 @@ CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 @param height height of the image.
 @param image loaded image.
 */
-typedef int (*ImreadCallback)( const Size& sz );
+typedef int (*ImreadCallback)( int pos, void* userdata );
 
 /** @brief Loads an image from a file with Callback function support.
 @anchor imread_reduced

--- a/modules/imgcodecs/src/grfmt_base.cpp
+++ b/modules/imgcodecs/src/grfmt_base.cpp
@@ -52,7 +52,7 @@ BaseImageDecoder::BaseImageDecoder()
     m_width = m_height = 0;
     m_type = -1;
     m_buf_supported = false;
-    m_scale_denom = 1;
+    m_callback = 0;
 }
 
 bool BaseImageDecoder::setSource( const String& filename )
@@ -82,11 +82,10 @@ bool BaseImageDecoder::checkSignature( const String& signature ) const
     return signature.size() >= len && memcmp( signature.c_str(), m_signature.c_str(), len ) == 0;
 }
 
-int BaseImageDecoder::setScale( const int& scale_denom )
+bool BaseImageDecoder::setCallback( const ImreadCallback& callback )
 {
-    int temp = m_scale_denom;
-    m_scale_denom = scale_denom;
-    return temp;
+    m_callback = callback;
+    return true;
 }
 
 ImageDecoder BaseImageDecoder::newDecoder() const

--- a/modules/imgcodecs/src/grfmt_base.hpp
+++ b/modules/imgcodecs/src/grfmt_base.hpp
@@ -67,7 +67,7 @@ public:
 
     virtual bool setSource( const String& filename );
     virtual bool setSource( const Mat& buf );
-    virtual int setScale( const int& scale_denom );
+    virtual bool setCallback( const ImreadCallback& callback );
     virtual bool readHeader() = 0;
     virtual bool readData( Mat& img ) = 0;
 
@@ -82,7 +82,7 @@ protected:
     int  m_width;  // width  of the image ( filled by readHeader )
     int  m_height; // height of the image ( filled by readHeader )
     int  m_type;
-    int  m_scale_denom;
+    ImreadCallback m_callback; // callback function
     String m_filename;
     String m_signature;
     Mat m_buf;

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -245,7 +245,7 @@ bool  JpegDecoder::readHeader()
             state->cinfo.scale_num=1;
             if(m_callback)
             {
-                state->cinfo.scale_denom = m_callback( state->cinfo.image_width, state->cinfo.image_height, NULL );
+                state->cinfo.scale_denom = m_callback( state->cinfo.image_width, state->cinfo.image_height );
             }
             else state->cinfo.scale_denom = 1;
 

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -243,8 +243,12 @@ bool  JpegDecoder::readHeader()
             jpeg_read_header( &state->cinfo, TRUE );
 
             state->cinfo.scale_num=1;
-            state->cinfo.scale_denom = m_scale_denom;
-            m_scale_denom=1; // trick! to know which decoder used scale_denom see imread_
+            if(m_callback)
+            {
+                state->cinfo.scale_denom = m_callback( state->cinfo.image_width, state->cinfo.image_height, NULL );
+            }
+            else state->cinfo.scale_denom = 1;
+
             jpeg_calc_output_dimensions(&state->cinfo);
             m_width = state->cinfo.output_width;
             m_height = state->cinfo.output_height;

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -245,7 +245,7 @@ bool  JpegDecoder::readHeader()
             state->cinfo.scale_num=1;
             if(m_callback)
             {
-                state->cinfo.scale_denom = m_callback( Size (state->cinfo.image_width, state->cinfo.image_height) );
+                state->cinfo.scale_denom = m_callback( Size(state->cinfo.image_width, state->cinfo.image_height) );
             }
             else state->cinfo.scale_denom = 1;
 

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -245,7 +245,7 @@ bool  JpegDecoder::readHeader()
             state->cinfo.scale_num=1;
             if(m_callback)
             {
-                state->cinfo.scale_denom = m_callback( state->cinfo.image_width, state->cinfo.image_height );
+                state->cinfo.scale_denom = m_callback( Size (state->cinfo.image_width, state->cinfo.image_height) );
             }
             else state->cinfo.scale_denom = 1;
 

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -245,7 +245,7 @@ bool  JpegDecoder::readHeader()
             state->cinfo.scale_num=1;
             if(m_callback)
             {
-                state->cinfo.scale_denom = m_callback( Size(state->cinfo.image_width, state->cinfo.image_height) );
+                state->cinfo.scale_denom = m_callback( 0, state );
             }
             else state->cinfo.scale_denom = 1;
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -238,7 +238,7 @@ enum { LOAD_CVMAT=0, LOAD_IMAGE=1, LOAD_MAT=2 };
  *
 */
 static void*
-imread_( const String& filename, int flags, int hdrtype, Mat* mat=0, int scale_denom=1 )
+imread_( const String& filename, int flags, int hdrtype, Mat* mat=0, ImreadCallback onLoad=0 )
 {
     IplImage* image = 0;
     CvMat *matrix = 0;
@@ -262,8 +262,8 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0, int scale_d
         return 0;
     }
 
-    /// set the scale_denom in the driver
-    decoder->setScale( scale_denom );
+    /// set callback function in the driver
+    decoder->setCallback( onLoad );
 
     /// set the filename in the driver
     decoder->setSource(filename);
@@ -320,10 +320,9 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0, int scale_d
         return 0;
     }
 
-    int testdecoder = decoder->setScale( scale_denom ); // if decoder is JpegDecoder then testdecoder will be 1
-    if( (scale_denom > 1 ) & ( testdecoder > 1 ) )
+    if( onLoad ) //if callback function specified call it.
     {
-        resize(*mat,*mat,Size(size.width/scale_denom,size.height/scale_denom));
+        onLoad( size.width, size.height, mat );
     }
 
     return hdrtype == LOAD_CVMAT ? (void*)matrix :
@@ -430,13 +429,13 @@ Mat imread( const String& filename, int flags )
  * @param[in] flags Flags you wish to set.
  * @param[in] scale_denom Scale value
 */
-Mat imread_reduced( const String& filename, int flags, int scale_denom )
+Mat imread_reduced( const String& filename, int flags, ImreadCallback onLoad )
 {
     /// create the basic container
     Mat img;
 
     /// load the data
-    imread_( filename, flags, LOAD_MAT, &img, scale_denom );
+    imread_( filename, flags, LOAD_MAT, &img, onLoad );
 
     /// return a reference to the data
     return img;

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -320,11 +320,6 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0, ImreadCallb
         return 0;
     }
 
-    if( onLoad ) //if callback function specified call it.
-    {
-        onLoad( size.width, size.height );
-    }
-
     return hdrtype == LOAD_CVMAT ? (void*)matrix :
         hdrtype == LOAD_IMAGE ? (void*)image : (void*)mat;
 }

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -322,7 +322,7 @@ imread_( const String& filename, int flags, int hdrtype, Mat* mat=0, ImreadCallb
 
     if( onLoad ) //if callback function specified call it.
     {
-        onLoad( size.width, size.height, mat );
+        onLoad( size.width, size.height );
     }
 
     return hdrtype == LOAD_CVMAT ? (void*)matrix :

--- a/modules/imgcodecs/src/precomp.hpp
+++ b/modules/imgcodecs/src/precomp.hpp
@@ -47,7 +47,6 @@
 #include "opencv2/core/utility.hpp"
 #include "opencv2/core/private.hpp"
 
-#include "opencv2/imgproc.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/imgcodecs/imgcodecs_c.h"
 


### PR DESCRIPTION
 **imread_reduced** uses the internal libjpeg facilities to get the reduced image. but, by current solution you have to set **scale_denom** parameter without knowing dimensions of the image.

by proposed solution you can set **scale_denom** parameter knowing dimensions before loading image

example usage:


    using namespace cv;

    int onLoad( int width, int height, Mat* img )
    {
        int scale = 1;
        if( width > 80 )
            {           
            scale =  width / 80;
            if( img && (scale > 1 ))
               {
                resize( *img, *img, Size( width/scale, height/scale ));
               }
            }
        return scale;
    }
    
    int main( int argc, char** argv )
    {
        Mat image = imread_reduced("lena.jpg", IMREAD_COLOR, onLoad );
        imshow("imread_reduced test",image);
        waitKey();
        return 0;
    }