### PR TITLE
Core cvSeqRemoveSlice: do not proceed with removing zero-length slice

### DIFF
--- a/modules/core/src/datastructs.cpp
+++ b/modules/core/src/datastructs.cpp
@@ -1689,6 +1689,9 @@ cvSeqRemoveSlice( CvSeq* seq, CvSlice slice )
 
     slice.end_index = slice.start_index + length;
 
+    if ( slice.start_index == slice.end_index )
+        return;
+
     if( slice.end_index < total )
     {
         CvSeqReader reader_to, reader_from;


### PR DESCRIPTION
Fixing valgrind reported issue: call memcpy with source equals destination since slice length is 0.

[ RUN ] Core_DS_Seq.basic_operations
==974== Source and destination overlap in memcpy(0x504b4b0, 0x504b4b0, 28)
==974== at 0x48495F4: memcpy (/home/nvidia/ilya/valgrind/memcheck/../shared/vg_replace_strmem.c:1016)
==974== by 0x4AC07D3: cvSeqRemoveSlice (/modules/core/src/datastructs.cpp:1725)
==974== by 0x5496F3: Core_SeqBaseTest::test_seq_ops(int) (/modules/core/test/test_ds.cpp:911)
==974== by 0x54A1EB: Core_SeqBaseTest::run(int) (/modules/core/test/test_ds.cpp:1026)
==974== by 0x5DE0F3: cvtest::BaseTest::safe_run(int) (/modules/ts/src/ts.cpp:214)
==974== by 0x54FE47: Core_DS_Seq_basic_operations_Test::TestBody() (in /home/nvidia/build_opencv/bin/opencv_test_core)
==974== by 0x6051D7: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::)(), char const) (/modules/ts/src/ts_gtest.cpp:3578)
==974== by 0x5FFADF: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::)(), char const) (/modules/ts/src/ts_gtest.cpp:3614)
==974== by 0x5EB907: testing::Test::Run() (/modules/ts/src/ts_gtest.cpp:3651)
==974== by 0x5EC183: testing::TestInfo::Run() (/modules/ts/src/ts_gtest.cpp:3826)
==974== by 0x5EC847: testing::TestCase::Run() (/modules/ts/src/ts_gtest.cpp:3944)
==974== by 0x5F361F: testing::internal::UnitTestImpl::RunAllTests() (/modules/ts/src/ts_gtest.cpp:5823)
==974== 
==974== Source and destination overlap in memcpy(0x5072fe8, 0x5072fe8, 1)
==974== at 0x48495F4: memcpy (/home/nvidia/ilya/valgrind/memcheck/../shared/vg_replace_strmem.c:1016)
==974== by 0x4AC066B: cvSeqRemoveSlice (/modules/core/src/datastructs.cpp:1707)
==974== by 0x5496F3: Core_SeqBaseTest::test_seq_ops(int) (/modules/core/test/test_ds.cpp:911)
==974== by 0x54A1EB: Core_SeqBaseTest::run(int) (/modules/core/test/test_ds.cpp:1026)
==974== by 0x5DE0F3: cvtest::BaseTest::safe_run(int) (/modules/ts/src/ts.cpp:214)
==974== by 0x54FE47: Core_DS_Seq_basic_operations_Test::TestBody() (in /home/nvidia/build_opencv/bin/opencv_test_core)
==974== by 0x6051D7: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::)(), char const) (/modules/ts/src/ts_gtest.cpp:3578)
==974== by 0x5FFADF: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::)(), char const) (/modules/ts/src/ts_gtest.cpp:3614)
==974== by 0x5EB907: testing::Test::Run() (/modules/ts/src/ts_gtest.cpp:3651)
==974== by 0x5EC183: testing::TestInfo::Run() (/modules/ts/src/ts_gtest.cpp:3826)
==974== by 0x5EC847: testing::TestCase::Run() (/modules/ts/src/ts_gtest.cpp:3944)
==974== by 0x5F361F: testing::internal::UnitTestImpl::RunAllTests() (/modules/ts/src/ts_gtest.cpp:5823)
==974==