### PR TITLE
Fixed: Concurrency static scheduler release failed

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -238,7 +238,7 @@ public:
     }
 
     SchedPtr() : sched_(0) {}
-    ~SchedPtr() { *this = 0; }
+    ~SchedPtr() {}
 };
 static SchedPtr pplScheduler;
 


### PR DESCRIPTION
For Itseez/opencv_contrib#360

Steps to reproduce:
- OS is Windows
- call `setNumThreads` with threads > 1 to initialize static `pplScheduler` instance with new scheduler
- close program

Behaviour:
- `sched_->Release()` call causes a crash

This problem happens in accuracy tests for ximgproc module (many tests call `setNumThreads`).