### PR TITLE
OCL: workaround

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -496,6 +496,7 @@ struct CV_EXPORTS UMatData
     void* handle;
     void* userdata;
     int allocatorFlags_;
+    int mapcount;
 };
 
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -497,6 +497,7 @@ struct CV_EXPORTS UMatData
     void* userdata;
     int allocatorFlags_;
     int mapcount;
+    UMatData* originalUMatData;
 };
 
 

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -208,17 +208,14 @@ public:
         if(!u)
             return;
 
-        CV_Assert(u->urefcount >= 0);
-        CV_Assert(u->refcount >= 0);
-        if(u->refcount == 0)
+        CV_Assert(u->urefcount == 0);
+        CV_Assert(u->refcount == 0);
+        if( !(u->flags & UMatData::USER_ALLOCATED) )
         {
-            if( !(u->flags & UMatData::USER_ALLOCATED) )
-            {
-                fastFree(u->origdata);
-                u->origdata = 0;
-            }
-            delete u;
+            fastFree(u->origdata);
+            u->origdata = 0;
         }
+        delete u;
     }
 };
 

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -60,7 +60,7 @@ static Mutex umatLocks[UMAT_NLOCKS];
 UMatData::UMatData(const MatAllocator* allocator)
 {
     prevAllocator = currAllocator = allocator;
-    urefcount = refcount = 0;
+    urefcount = refcount = mapcount = 0;
     data = origdata = 0;
     size = 0;
     flags = 0;
@@ -73,6 +73,7 @@ UMatData::~UMatData()
 {
     prevAllocator = currAllocator = 0;
     urefcount = refcount = 0;
+    CV_Assert(mapcount == 0);
     data = origdata = 0;
     size = 0;
     flags = 0;
@@ -221,6 +222,7 @@ UMat Mat::getUMat(int accessFlags, UMatUsageFlags usageFlags) const
     UMat hdr;
     if(!data)
         return hdr;
+    CV_Assert((!u || u->mapcount==0) && "Don't get UMat from temp-Mat!");
     accessFlags |= ACCESS_RW;
     UMatData* temp_u = u;
     if(!temp_u)
@@ -637,18 +639,28 @@ Mat UMat::getMat(int accessFlags) const
 {
     if(!u)
         return Mat();
+    CV_Assert(!u->tempUMat() && "Don't get Mat from temp UMat! Use copyTo().");
     // TODO Support ACCESS_READ (ACCESS_WRITE) without unnecessary data transfers
     accessFlags |= ACCESS_RW;
-    u->currAllocator->map(u, accessFlags);
-    CV_Assert(u->data != 0);
-    Mat hdr(dims, size.p, type(), u->data + offset, step.p);
-    hdr.flags = flags;
-    hdr.u = u;
-    hdr.datastart = u->data;
-    hdr.data = u->data + offset;
-    hdr.datalimit = hdr.dataend = u->data + u->size;
-    CV_XADD(&hdr.u->refcount, 1);
-    return hdr;
+    UMatDataAutoLock autolock(u);
+    if(CV_XADD(&u->refcount, 1) == 0)
+        u->currAllocator->map(u, accessFlags);
+    if (u->data != 0)
+    {
+        Mat hdr(dims, size.p, type(), u->data + offset, step.p);
+        hdr.flags = flags;
+        hdr.u = u;
+        hdr.datastart = u->data;
+        hdr.data = u->data + offset;
+        hdr.datalimit = hdr.dataend = u->data + u->size;
+        return hdr;
+    }
+    else
+    {
+        CV_XADD(&u->refcount, -1);
+        CV_Assert(u->data != 0 && "Error mapping of UMat to host memory.");
+        return Mat();
+    }
 }
 
 void* UMat::handle(int accessFlags) const

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -243,9 +243,11 @@ TEST_P(UMatBasicTests, GetUMat)
         EXPECT_MAT_NEAR(ub, ua, 0);
     }
     {
-        Mat b;
-        b = a.getUMat(ACCESS_RW).getMat(ACCESS_RW);
-        EXPECT_MAT_NEAR(b, a, 0);
+        UMat u = a.getUMat(ACCESS_RW);
+        {
+            Mat b = u.getMat(ACCESS_RW);
+            EXPECT_MAT_NEAR(b, a, 0);
+        }
     }
     {
         Mat b;
@@ -253,9 +255,11 @@ TEST_P(UMatBasicTests, GetUMat)
         EXPECT_MAT_NEAR(b, a, 0);
     }
     {
-        UMat ub;
-        ub = ua.getMat(ACCESS_RW).getUMat(ACCESS_RW);
-        EXPECT_MAT_NEAR(ub, ua, 0);
+        Mat m = ua.getMat(ACCESS_RW);
+        {
+            UMat ub = m.getUMat(ACCESS_RW);
+            EXPECT_MAT_NEAR(ub, ua, 0);
+        }
     }
 }
 
@@ -1268,5 +1272,17 @@ TEST(UMat, DISABLED_Test_same_behaviour_write_and_write)
     ASSERT_TRUE(exceptionDetected); // data race
 }
 
+TEST(UMat, mat_umat_sync)
+{
+    UMat u(10, 10, CV_8UC1, Scalar(1));
+    {
+        Mat m = u.getMat(ACCESS_RW).reshape(1);
+        m.setTo(Scalar(255));
+    }
+
+    UMat uDiff;
+    compare(u, 255, uDiff, CMP_NE);
+    ASSERT_EQ(0, countNonZero(uDiff));
+}
 
 } } // namespace cvtest::ocl

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -263,7 +263,7 @@ TEST_P(UMatBasicTests, GetUMat)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(UMat, UMatBasicTests, Combine(testing::Values(CV_8U), testing::Values(1, 2),
+INSTANTIATE_TEST_CASE_P(UMat, UMatBasicTests, Combine(testing::Values(CV_8U, CV_64F), testing::Values(1, 2),
     testing::Values(cv::Size(1, 1), cv::Size(1, 128), cv::Size(128, 1), cv::Size(128, 128), cv::Size(640, 480)), Bool()));
 
 //////////////////////////////////////////////////////////////// Reshape ////////////////////////////////////////////////////////////////////////
@@ -1084,7 +1084,7 @@ TEST(UMat, unmap_in_class)
                 Mat dst;
                 m.convertTo(dst, CV_32FC1);
                 // some additional CPU-based per-pixel processing into dst
-                intermediateResult = dst.getUMat(ACCESS_READ);
+                intermediateResult = dst.getUMat(ACCESS_READ); // this violates lifetime of base(dst) / derived (intermediateResult) objects. Use copyTo?
                 std::cout << "data processed..." << std::endl;
             } // problem is here: dst::~Mat()
             std::cout << "leave ProcessData()" << std::endl;
@@ -1283,6 +1283,50 @@ TEST(UMat, mat_umat_sync)
     UMat uDiff;
     compare(u, 255, uDiff, CMP_NE);
     ASSERT_EQ(0, countNonZero(uDiff));
+}
+
+TEST(UMat, testTempObjects_UMat)
+{
+    UMat u(10, 10, CV_8UC1, Scalar(1));
+    {
+        UMat u2 = u.getMat(ACCESS_RW).getUMat(ACCESS_RW);
+        u2.setTo(Scalar(255));
+    }
+
+    UMat uDiff;
+    compare(u, 255, uDiff, CMP_NE);
+    ASSERT_EQ(0, countNonZero(uDiff));
+}
+
+TEST(UMat, testTempObjects_Mat)
+{
+    Mat m(10, 10, CV_8UC1, Scalar(1));
+    {
+        Mat m2;
+        ASSERT_ANY_THROW(m2 = m.getUMat(ACCESS_RW).getMat(ACCESS_RW));
+    }
+}
+
+TEST(UMat, testWrongLifetime_UMat)
+{
+    UMat u(10, 10, CV_8UC1, Scalar(1));
+    {
+        UMat u2 = u.getMat(ACCESS_RW).getUMat(ACCESS_RW);
+        u.release(); // base object
+        u2.release(); // derived object, should show warning message
+    }
+}
+
+TEST(UMat, testWrongLifetime_Mat)
+{
+    Mat m(10, 10, CV_8UC1, Scalar(1));
+    {
+        UMat u = m.getUMat(ACCESS_RW);
+        Mat m2 = u.getMat(ACCESS_RW);
+        m.release(); // base object
+        m2.release(); // map of derived object
+        u.release(); // derived object, should show warning message
+    }
 }
 
 } } // namespace cvtest::ocl

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -1009,7 +1009,7 @@ namespace cv
             idxArg = kernel.set(idxArg, (int)winSize.height); // int c_winSize_y
             idxArg = kernel.set(idxArg, (int)iters); // int c_iters
             idxArg = kernel.set(idxArg, (char)calcErr); //char calcErr
-            return kernel.run(2, globalThreads, localThreads, false);
+            return kernel.run(2, globalThreads, localThreads, true); // sync=true because ocl::Image2D lifetime is not handled well for temp UMat
         }
     private:
         inline static bool isDeviceCPU()


### PR DESCRIPTION
- `getUMat()` creates new `UMatData` (detach from previous Mat (and clones), include their refcounters)
- MatAllocator::deallocate() must be called with `refcount = 0` and `urefcount = 0`
- `mat_roi.getUMat()` creates UMat for original Mat without roi (there are some issues in OpenCL runtime with data alignment in case of USE_HOST_PTR).

```
check_regression=*UMatTest*CustomPtr*
```