### PR TITLE
CommandLineParser: do not try to parse empty default values and improve error messages

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -607,6 +607,10 @@ For example:
 }
 @endcode
 
+Note that there are no default values for `help` and `timestamp` so we can check their presence using the `has()` method.
+Arguments with default values are considered to be always present. Use the `get()` method in these cases to check their
+actual value instead.
+
 ### Usage
 
 For the described keys:

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -618,7 +618,7 @@ For the described keys:
     # Bad call
     $ ./app -fps=aaa
     ERRORS:
-    Exception: can not convert: [aaa] to [double]
+    Parameter 'fps': can not convert: [aaa] to [double]
 @endcode
  */
 class CV_EXPORTS CommandLineParser

--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -334,9 +334,9 @@ bool CommandLineParser::has(const String& name) const
     {
         for (size_t j = 0; j < impl->data[i].keys.size(); j++)
         {
-            if (name.compare(impl->data[i].keys[j]) == 0 && String("true").compare(impl->data[i].def_value) == 0)
+            if (name == impl->data[i].keys[j])
             {
-                return true;
+                return !impl->cat_string(impl->data[i].def_value).empty();
             }
         }
     }

--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -97,23 +97,28 @@ void CommandLineParser::getByName(const String& name, bool space_delete, int typ
         {
             for (size_t j = 0; j < impl->data[i].keys.size(); j++)
             {
-                if (name.compare(impl->data[i].keys[j]) == 0)
+                if (name == impl->data[i].keys[j])
                 {
                     String v = impl->data[i].def_value;
                     if (space_delete)
                         v = impl->cat_string(v);
+
+                    // it is an error if we just got the default value here
+                    if(v.empty())
+                        break;
+
                     from_str(v, type, dst);
                     return;
                 }
             }
         }
         impl->error = true;
-        impl->error_message = impl->error_message + "Unknown parameter " + name + "\n";
+        impl->error_message = impl->error_message + "Missing parameter: '" + name + "'\n";
     }
-    catch (std::exception& e)
+    catch (Exception& e)
     {
         impl->error = true;
-        impl->error_message = impl->error_message + "Exception: " + String(e.what()) + "\n";
+        impl->error_message = impl->error_message + "Parameter '"+ name + "': " + e.err + "\n";
     }
 }
 
@@ -128,17 +133,22 @@ void CommandLineParser::getByIndex(int index, bool space_delete, int type, void*
             {
                 String v = impl->data[i].def_value;
                 if (space_delete == true) v = impl->cat_string(v);
+
+                // it is an error if we just got the default value here
+                if(v.empty())
+                    break;
+
                 from_str(v, type, dst);
                 return;
             }
         }
         impl->error = true;
-        impl->error_message = impl->error_message + "Unknown parameter #" + format("%d", index) + "\n";
+        impl->error_message = impl->error_message + "Missing parameter #" + format("%d", index) + "\n";
     }
-    catch(std::exception & e)
+    catch(Exception& e)
     {
         impl->error = true;
-        impl->error_message = impl->error_message + "Exception: " + String(e.what()) + "\n";
+        impl->error_message = impl->error_message + format("Parameter #%d: ", index) + e.err + "\n";
     }
 }
 

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -783,7 +783,7 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
     ;
 
     cv::CommandLineParser args(argc, argv, command_line_keys);
-    if (args.has("help"))
+    if (args.get<bool>("help"))
     {
         args.printMessage();
         return;
@@ -791,7 +791,7 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
 
     ::testing::AddGlobalTestEnvironment(new PerfEnvironment);
 
-    param_impl          = args.has("perf_run_cpu") ? "plain" : args.get<std::string>("perf_impl");
+    param_impl          = args.get<bool>("perf_run_cpu") ? "plain" : args.get<std::string>("perf_impl");
     std::string perf_strategy = args.get<std::string>("perf_strategy");
     if (perf_strategy == "default")
     {
@@ -816,24 +816,24 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
     param_seed          = args.get<unsigned int>("perf_seed");
     param_time_limit    = std::max(0., args.get<double>("perf_time_limit"));
     param_force_samples = args.get<unsigned int>("perf_force_samples");
-    param_write_sanity  = args.has("perf_write_sanity");
-    param_verify_sanity = args.has("perf_verify_sanity");
+    param_write_sanity  = args.get<bool>("perf_write_sanity");
+    param_verify_sanity = args.get<bool>("perf_verify_sanity");
 
 #ifndef WINRT
-    test_ipp_check      = !args.has("perf_ipp_check") ? getenv("OPENCV_IPP_CHECK") != NULL : true;
+    test_ipp_check      = !args.get<bool>("perf_ipp_check") ? getenv("OPENCV_IPP_CHECK") != NULL : true;
 #else
     test_ipp_check = false;
 #endif
     param_threads       = args.get<int>("perf_threads");
 #ifdef CV_COLLECT_IMPL_DATA
-    param_collect_impl  = args.has("perf_collect_impl");
+    param_collect_impl  = args.get<bool>("perf_collect_impl");
 #endif
 #ifdef ANDROID
     param_affinity_mask   = args.get<int>("perf_affinity_mask");
     log_power_checkpoints = args.has("perf_log_power_checkpoints");
 #endif
 
-    bool param_list_impls = args.has("perf_list_impls");
+    bool param_list_impls = args.get<bool>("perf_list_impls");
 
     if (param_list_impls)
     {
@@ -861,7 +861,7 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
 
 #ifdef HAVE_CUDA
 
-    bool printOnly        = args.has("perf_cuda_info_only");
+    bool printOnly        = args.get<bool>("perf_cuda_info_only");
 
     if (printOnly)
         exit(0);


### PR DESCRIPTION
## part1: do not try to parse empty default arguments
example
```bash
# correct ./myapp image.png 1 2 --sl=3 --ml=4 -d=5
./myapp -d=foo
```

before
```
ERRORS:
Exception: ../modules/core/src/command_line_parser.cpp:88: error: (-5) can not convert: [] to [int]

Exception: ../modules/core/src/command_line_parser.cpp:88: error: (-5) can not convert: [] to [int]

Exception: ../modules/core/src/command_line_parser.cpp:88: error: (-5) can not convert: [] to [int]

Exception: ../modules/core/src/command_line_parser.cpp:88: error: (-5) can not convert: [] to [int]

Exception: ../modules/core/src/command_line_parser.cpp:88: error: (-5) can not convert: [foo] to [int]

```
note how `""` got accepted as parameter#0 although it was not specified.

after
```
ERRORS:
Missing parameter #1
Missing parameter #2
Missing parameter: 'sl'
Missing parameter: 'ml'
Parameter 'd': can not convert: [foo] to [int]
Missing parameter #0

```

## part 2: check only the presence of an argument in has()
```
./foo               # CommandLineParser::has("bar") -> false
./foo --bar         # CommandLineParser::has("bar") -> true
./foo --bar=true    # CommandLineParser::has("bar") -> true
./foo --bar=1       # CommandLineParser::has("bar") -> false
./foo --bar=baz.txt # CommandLineParser::has("bar") -> false
```
the function currently only works as expected with fields without values.
Of course the simpler solution to clarify the description as:
> Check if **a binary** field was provided in the command line

however then there is no way to check the presence of an arbitrary valued field without triggering an error.
i.e. the following usecase is currently not possible:
```c++
CommandLineParser parser(argc, argv);
float bar = parser.has("bar") ? parser.get<float>("bar") : compute();
```

I also think that the current implementation is wrong as my interpretation of the documentation is:
1. `CommandLineParser::has`: check for argument presence (does not trigger error)
2. `CommandLineParser::get`: check for argument value (triggers error when not present or not convertible)