### PR TITLE
Fix LineAA in case of 4 channel

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -610,12 +610,12 @@ LineAA( Mat& img, Point pt1, Point pt2, const void* color )
                 ICV_PUT_POINT();
                 ICV_PUT_POINT();
 
-                tptr += step;
+                tptr += 4;
                 a = (ep_corr * FilterTable[dist] >> 8) & 0xff;
                 ICV_PUT_POINT();
                 ICV_PUT_POINT();
 
-                tptr += step;
+                tptr += 4;
                 a = (ep_corr * FilterTable[63 - dist] >> 8) & 0xff;
                 ICV_PUT_POINT();
                 ICV_PUT_POINT();


### PR DESCRIPTION
Fix bug when enter 4 channel image to LineAA function.

```cpp
#include <iostream>
#include <opencv2/opencv.hpp>

bool test( cv::Mat& image )
{
	// Test Loop
	// (Crash in pixel around the bottom right.)
	for( int y = image.rows - 10; y < image.rows; y++ ){
		for( int x = image.cols / 2; x < image.cols; x++ ){
			cv::circle( image, cv::Point( x, y ), 5, cv::Scalar( 255, 255, 255 ), -1, CV_AA );
		}
	}

	return true;
}

int main()
{
	// Test 1 channel Image ... Success
	cv::Mat c1 = cv::Mat::zeros( cv::Size( 1920, 1080 ), CV_8UC1 );
	std::cout << "test 1ch. : " << ( test( c1 ) ? "success" : "failure" ) << std::endl;

	// Test 3 channel Image ... Success
	cv::Mat c3 = cv::Mat::zeros( cv::Size( 1920, 1080 ), CV_8UC3 );
	std::cout << "test 3ch. : " << ( test( c3 ) ? "success" : "failure" ) << std::endl;

	// Test 4 channel Image ... Failure (Clash)
	// (This test will succeed when apply this pull request.)
	cv::Mat c4 = cv::Mat::zeros( cv::Size( 1920, 1080 ), CV_8UC4 );
	std::cout << "test 4ch. : " << ( test( c4 ) ? "success" : "failure" ) << std::endl;

	return 0;
}
```