### PR TITLE
Update em.cpp

### DIFF
--- a/modules/ml/src/em.cpp
+++ b/modules/ml/src/em.cpp
@@ -379,7 +379,7 @@ public:
             }
             else if(covMatType == COV_MAT_DIAGONAL)
             {
-                covsEigenValues[clusterIndex] = svd.w;
+                covsEigenValues[clusterIndex] = covs[clusterIndex].diag().clone(); //Preserve the original order of eigen values.
             }
             else //COV_MAT_GENERIC
             {


### PR DESCRIPTION
Fix a bug. When reading from a saved model, function decomposeCovs() will be called. And if covMatType is COV_MAT_DIAGONAL, covsEigenValues is computed using SVD and eigen values are sorted so that the order of eigen values is not preserved. This would lead to different result when calling function predict2. This issues is discussed here: http://stackoverflow.com/questions/23485982/got-different-empredict-results-after-emread-saved-model-in-opencv.