### PR TITLE
Disables TLS copy constructor; new gather method

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -520,6 +520,7 @@ protected:
     TLSDataContainer();
     virtual ~TLSDataContainer();
 
+    void  gatherData(std::vector<void*> &data) const;
 #if OPENCV_ABI_COMPATIBILITY > 300
     void* getData() const;
     void  release();
@@ -546,9 +547,20 @@ public:
     inline ~TLSData()       { release();            } // Release key and delete associated data
     inline T* get() const   { return (T*)getData(); } // Get data assosiated with key
 
+     // Get data from all threads
+    inline void gather(std::vector<T*> &data) const
+    {
+        std::vector<void*> &dataVoid = reinterpret_cast<std::vector<void*>&>(data);
+        gatherData(dataVoid);
+    }
+
 private:
     virtual void* createDataInstance() const {return new T;}                // Wrapper to allocate data by template
     virtual void  deleteDataInstance(void* pData) const {delete (T*)pData;} // Wrapper to release data by template
+
+    // Disable TLS copy operations
+    TLSData(TLSData &) {};
+    TLSData& operator =(const TLSData &) {return *this;};
 };
 
 /** @brief Designed for command line parsing


### PR DESCRIPTION
Disables TLS copy constructor and operator, as they can lead to errors and reservation of too much keys in TLS storage;

gather method was added to TLS to gather data from all threads;