### PR TITLE
fix crash when reading bw TIF

### DIFF
--- a/modules/highgui/src/grfmt_tiff.cpp
+++ b/modules/highgui/src/grfmt_tiff.cpp
@@ -221,6 +221,11 @@ bool  TiffDecoder::readData( Mat& img )
                 (!is_tiled && tile_height0 == std::numeric_limits<uint32>::max()) )
                 tile_height0 = m_height;
 
+            if(dst_bpp == 8) {
+                // we will use TIFFReadRGBA* functions, so allocate temporary buffer for 32bit RGBA
+                bpp = 8;
+                ncn = 4;
+            }
             const size_t buffer_size = bpp * ncn * tile_height0 * tile_width0;
             AutoBuffer<uchar> _buffer( buffer_size );
             uchar* buffer = _buffer;

--- a/modules/highgui/src/grfmt_tiff.cpp
+++ b/modules/highgui/src/grfmt_tiff.cpp
@@ -226,7 +226,7 @@ bool  TiffDecoder::readData( Mat& img )
                 bpp = 8;
                 ncn = 4;
             }
-            const size_t buffer_size = bpp * ncn * tile_height0 * tile_width0;
+            const size_t buffer_size = (bpp/bitsPerByte) * ncn * tile_height0 * tile_width0;
             AutoBuffer<uchar> _buffer( buffer_size );
             uchar* buffer = _buffer;
             ushort* buffer16 = (ushort*)buffer;


### PR DESCRIPTION
Hello,

first off, thank you for the excellent opencv library :)

I had a problem where one large black&white TIF image would crash imread. I tracked this down to the fact that you use TIFFReadRGBAStrip or TIFFReadRGBATile, both of which assume the buffer to be scaled appropriately for 8-bit RGBA. But for my black&white image, bpp was 1 and ncn was 1, so buffer_size was calculated as 1 byte * width * height, therefore leading to memory corruption in TIFFReadRGBAStrip. 

To fix this, for dst_bpp == 8 (so when TIFFReadRGBA* will be used), I'll now set a hardcoded bpp = 8; ncn = 4; because those are the values assumed by TIFFReadRGBA*. 

When looking into this, I also noticed that the buffer size should be calculated in bytes, not bits. So I also changed
const size_t buffer_size = bpp * ncn * tile_height0 * tile_width0;
to
const size_t buffer_size = (bpp/bitsPerByte) * ncn * tile_height0 * tile_width0;

BTW, this also seems to be the underlying effect causing https://trac.macports.org/ticket/47549
Or at least, I can confirm that my 2.4.11 with this patch will load their t6_0000.tif example file just fine, whereas the unpatched 2.4.11 crashes.

All the best,
Hajo
