### PR TITLE
CommandLineParser: throw on programmer error

### DIFF
--- a/modules/core/test/test_utils.cpp
+++ b/modules/core/test/test_utils.cpp
@@ -137,12 +137,14 @@ TEST(CommandLineParser, testPositional_noArgs)
     const char* argv[] = {"<bin>"};
     const int argc = 1;
     cv::CommandLineParser parser(argc, argv, keys2);
-    //EXPECT_FALSE(parser.has("arg1"));
-    //EXPECT_FALSE(parser.has("arg2"));
-    //EXPECT_EQ("default1", parser.get<String>("arg1"));
+    EXPECT_TRUE(parser.has("@arg1"));
+    EXPECT_FALSE(parser.has("@arg2"));
+    EXPECT_EQ("default1", parser.get<String>("@arg1"));
     EXPECT_EQ("default1", parser.get<String>(0));
-    //??? EXPECT_ANY_THROW(parser.get<String>("arg2"));
-    //??? EXPECT_ANY_THROW(parser.get<String>(1));
+
+    parser.get<String>("@arg2");
+    parser.get<String>(1);
+    EXPECT_TRUE(parser.check());
 }
 
 TEST(CommandLineParser, testPositional_default)
@@ -150,10 +152,10 @@ TEST(CommandLineParser, testPositional_default)
     const char* argv[] = {"<bin>", "test1", "test2"};
     const int argc = 3;
     cv::CommandLineParser parser(argc, argv, keys2);
-    //EXPECT_TRUE(parser.has("arg1"));
-    //EXPECT_TRUE(parser.has("arg2"));
-    //EXPECT_EQ("test1", parser.get<String>("arg1"));
-    //EXPECT_EQ("test2", parser.get<String>("arg2"));
+    EXPECT_TRUE(parser.has("@arg1"));
+    EXPECT_TRUE(parser.has("@arg2"));
+    EXPECT_EQ("test1", parser.get<String>("@arg1"));
+    EXPECT_EQ("test2", parser.get<String>("@arg2"));
     EXPECT_EQ("test1", parser.get<String>(0));
     EXPECT_EQ("test2", parser.get<String>(1));
 }
@@ -163,10 +165,10 @@ TEST(CommandLineParser, testPositional_withFlagsBefore)
     const char* argv[] = {"<bin>", "-h", "test1", "test2"};
     const int argc = 4;
     cv::CommandLineParser parser(argc, argv, keys2);
-    //EXPECT_TRUE(parser.has("arg1"));
-    //EXPECT_TRUE(parser.has("arg2"));
-    //EXPECT_EQ("test1", parser.get<String>("arg1"));
-    //EXPECT_EQ("test2", parser.get<String>("arg2"));
+    EXPECT_TRUE(parser.has("@arg1"));
+    EXPECT_TRUE(parser.has("@arg2"));
+    EXPECT_EQ("test1", parser.get<String>("@arg1"));
+    EXPECT_EQ("test2", parser.get<String>("@arg2"));
     EXPECT_EQ("test1", parser.get<String>(0));
     EXPECT_EQ("test2", parser.get<String>(1));
 }
@@ -176,10 +178,10 @@ TEST(CommandLineParser, testPositional_withFlagsAfter)
     const char* argv[] = {"<bin>", "test1", "test2", "-h"};
     const int argc = 4;
     cv::CommandLineParser parser(argc, argv, keys2);
-    //EXPECT_TRUE(parser.has("arg1"));
-    //EXPECT_TRUE(parser.has("arg2"));
-    //EXPECT_EQ("test1", parser.get<String>("arg1"));
-    //EXPECT_EQ("test2", parser.get<String>("arg2"));
+    EXPECT_TRUE(parser.has("@arg1"));
+    EXPECT_TRUE(parser.has("@arg2"));
+    EXPECT_EQ("test1", parser.get<String>("@arg1"));
+    EXPECT_EQ("test2", parser.get<String>("@arg2"));
     EXPECT_EQ("test1", parser.get<String>(0));
     EXPECT_EQ("test2", parser.get<String>(1));
 }

--- a/modules/core/test/test_utils.cpp
+++ b/modules/core/test/test_utils.cpp
@@ -15,6 +15,18 @@ static const char * const keys =
     "{ n unused  |       | dummy }"
 ;
 
+TEST(CommandLineParser, testFailure)
+{
+    const char* argv[] = {"<bin>", "-q"};
+    const int argc = 2;
+    cv::CommandLineParser parser(argc, argv, keys);
+    EXPECT_ANY_THROW(parser.has("q"));
+    EXPECT_ANY_THROW(parser.get<bool>("q"));
+    EXPECT_ANY_THROW(parser.get<bool>(0));
+
+    parser.get<bool>("h");
+    EXPECT_FALSE(parser.check());
+}
 TEST(CommandLineParser, testHas_noValues)
 {
     const char* argv[] = {"<bin>", "-h", "--info"};
@@ -26,7 +38,6 @@ TEST(CommandLineParser, testHas_noValues)
     EXPECT_TRUE(parser.has("i"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
-    EXPECT_FALSE(parser.has("q")); // TODO Throw ???
 }
 TEST(CommandLineParser, testHas_TrueValues)
 {
@@ -39,7 +50,6 @@ TEST(CommandLineParser, testHas_TrueValues)
     EXPECT_TRUE(parser.has("i"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
-    EXPECT_FALSE(parser.has("q")); // TODO Throw ???
 }
 TEST(CommandLineParser, testHas_TrueValues1)
 {
@@ -52,7 +62,6 @@ TEST(CommandLineParser, testHas_TrueValues1)
     EXPECT_TRUE(parser.has("i"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
-    EXPECT_FALSE(parser.has("q")); // TODO Throw ???
 }
 TEST(CommandLineParser, testHas_FalseValues0)
 {
@@ -65,7 +74,6 @@ TEST(CommandLineParser, testHas_FalseValues0)
     EXPECT_TRUE(parser.has("i"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
-    EXPECT_FALSE(parser.has("q")); // TODO Throw ???
 }
 
 TEST(CommandLineParser, testBoolOption_noArgs)


### PR DESCRIPTION
requesting a previously undeclared key is most likely an programming
error. e.g. a typo "--unused vs --unsued".
So throw in those cases.

Add an according failure testcase.