### PR TITLE
Fix Android camera datarace (mCameraFrameReady)

### DIFF
--- a/modules/java/generator/src/java/android+JavaCameraView.java
+++ b/modules/java/generator/src/java/android+JavaCameraView.java
@@ -328,6 +328,7 @@ public class JavaCameraView extends CameraBridgeViewBase implements PreviewCallb
         @Override
         public void run() {
             do {
+                boolean hasFrame = false;
                 synchronized (JavaCameraView.this) {
                     try {
                         while (!mCameraFrameReady && !mStopThread) {
@@ -337,11 +338,14 @@ public class JavaCameraView extends CameraBridgeViewBase implements PreviewCallb
                         e.printStackTrace();
                     }
                     if (mCameraFrameReady)
+                    {
                         mChainIdx = 1 - mChainIdx;
+                        mCameraFrameReady = false;
+                        hasFrame = true;
+                    }
                 }
 
-                if (!mStopThread && mCameraFrameReady) {
-                    mCameraFrameReady = false;
+                if (!mStopThread && hasFrame) {
                     if (!mFrameChain[1 - mChainIdx].empty())
                         deliverAndDrawFrame(mCameraFrame[1 - mChainIdx]);
                 }


### PR DESCRIPTION
1) Write `false` here without any locks:
https://github.com/Itseez/opencv/blob/12f01b778b702071398ee70eb2979195a6cdbe6d/modules/java/generator/src/java/android%2BJavaCameraView.java#L344
2) Write `true` here under the lock of `JavaCameraView` object:
https://github.com/Itseez/opencv/blob/12f01b778b702071398ee70eb2979195a6cdbe6d/modules/java/generator/src/java/android%2BJavaCameraView.java#L289
