### PR TITLE
disable String(int) ctor

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.hpp
+++ b/modules/core/include/opencv2/core/cvstd.hpp
@@ -576,6 +576,8 @@ private:
 
     char* allocate(size_t len); // len without trailing 0
     void deallocate();
+
+    String(int); // disabled and invalid. Catch invalid usages like, commandLineParser.has(0) problem
 };
 
 //! @} core_basic


### PR DESCRIPTION
**Contrib**: https://github.com/Itseez/opencv_contrib/pull/387

MSVC and GCC compilers interprets cv::String a(0) as a valid
statement with conversion of "int" argument to "const char*".
This patch forbids this expected behaviour.