### PR TITLE
svm: update kernel params when doing final training in auto train

### DIFF
--- a/modules/ml/src/svm.cpp
+++ b/modules/ml/src/svm.cpp
@@ -1824,6 +1824,8 @@ public:
 
         params = best_params;
         class_labels = class_labels0;
+        // make sure we updated the kernel and other parameters
+        setParams(params);
         return do_train( samples, responses );
     }
 


### PR DESCRIPTION
After finding out the best params, the best params should be passed to kernel. Without this patch, the final step of training will keep using the last set of params instead of best params.