### PR TITLE
calib3d and cudastereo: couple of small improvements

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1375,7 +1375,8 @@ CV_EXPORTS_W void validateDisparity( InputOutputArray disparity, InputArray cost
 /** @brief Reprojects a disparity image to 3D space.
 
 @param disparity Input single-channel 8-bit unsigned, 16-bit signed, 32-bit signed or 32-bit
-floating-point disparity image.
+floating-point disparity image. If 16-bit signed format is used, the values are assumed to have no
+fractional bits.
 @param _3dImage Output 3-channel floating-point image of the same size as disparity . Each
 element of _3dImage(x,y) contains 3D coordinates of the point (x,y) computed from the disparity
 map.

--- a/modules/cudastereo/include/opencv2/cudastereo.hpp
+++ b/modules/cudastereo/include/opencv2/cudastereo.hpp
@@ -295,7 +295,9 @@ CV_EXPORTS Ptr<cuda::DisparityBilateralFilter>
 
 /** @brief Reprojects a disparity image to 3D space.
 
-@param disp Input disparity image. CV_8U and CV_16S types are supported.
+@param disp Input single-channel 8-bit unsigned, 16-bit signed, 32-bit signed or 32-bit
+floating-point disparity image. If 16-bit signed format is used, the values are assumed to have no
+fractional bits.
 @param xyzw Output 3- or 4-channel floating-point image of the same size as disp . Each element of
 xyzw(x,y) contains 3D coordinates (x,y,z) or (x,y,z,1) of the point (x,y) , computed from the
 disparity map.
@@ -309,8 +311,10 @@ CV_EXPORTS void reprojectImageTo3D(InputArray disp, OutputArray xyzw, InputArray
 
 /** @brief Colors a disparity image.
 
-@param src_disp Source disparity image. CV_8UC1 and CV_16SC1 types are supported.
-@param dst_disp Output disparity image. It has the same size as src_disp . The type is CV_8UC4
+@param src_disp Input single-channel 8-bit unsigned, 16-bit signed, 32-bit signed or 32-bit
+floating-point disparity image. If 16-bit signed format is used, the values are assumed to have no
+fractional bits.
+@param dst_disp Output disparity image. It has the same size as src_disp. The type is CV_8UC4
 in BGRA format (alpha = 255).
 @param ndisp Number of disparities.
 @param stream Stream for the asynchronous version.

--- a/modules/cudastereo/include/opencv2/cudastereo.hpp
+++ b/modules/cudastereo/include/opencv2/cudastereo.hpp
@@ -138,7 +138,8 @@ public:
     @param data User-specified data cost, a matrix of msg_type type and
     Size(\<image columns\>\*ndisp, \<image rows\>) size.
     @param disparity Output disparity map. If disparity is empty, the output type is CV_16SC1 .
-    Otherwise, the type is retained.
+    Otherwise, the type is retained. In 16-bit signed format, the disparity values do not have
+    fractional bits.
     @param stream Stream for the asynchronous version.
      */
     virtual void compute(InputArray data, OutputArray disparity, Stream& stream = Stream::Null()) = 0;

--- a/modules/cudastereo/src/cuda/util.cu
+++ b/modules/cudastereo/src/cuda/util.cu
@@ -98,6 +98,10 @@ namespace cv { namespace cuda { namespace device
     template void reprojectImageTo3D_gpu<uchar, float4>(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
     template void reprojectImageTo3D_gpu<short, float3>(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
     template void reprojectImageTo3D_gpu<short, float4>(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
+    template void reprojectImageTo3D_gpu<int, float3>(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
+    template void reprojectImageTo3D_gpu<int, float4>(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
+    template void reprojectImageTo3D_gpu<float, float3>(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
+    template void reprojectImageTo3D_gpu<float, float4>(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
 
     /////////////////////////////////// drawColorDisp ///////////////////////////////////////////////
 

--- a/modules/cudastereo/src/util.cpp
+++ b/modules/cudastereo/src/util.cpp
@@ -66,16 +66,16 @@ void cv::cuda::reprojectImageTo3D(InputArray _disp, OutputArray _xyz, InputArray
     using namespace cv::cuda::device;
 
     typedef void (*func_t)(const PtrStepSzb disp, PtrStepSzb xyz, const float* q, cudaStream_t stream);
-    static const func_t funcs[2][4] =
+    static const func_t funcs[2][6] =
     {
-        {reprojectImageTo3D_gpu<uchar, float3>, 0, 0, reprojectImageTo3D_gpu<short, float3>},
-        {reprojectImageTo3D_gpu<uchar, float4>, 0, 0, reprojectImageTo3D_gpu<short, float4>}
+        {reprojectImageTo3D_gpu<uchar, float3>, 0, 0, reprojectImageTo3D_gpu<short, float3>, reprojectImageTo3D_gpu<int, float3>, reprojectImageTo3D_gpu<float, float3>},
+        {reprojectImageTo3D_gpu<uchar, float4>, 0, 0, reprojectImageTo3D_gpu<short, float4>, reprojectImageTo3D_gpu<int, float4>, reprojectImageTo3D_gpu<float, float4>}
     };
 
     GpuMat disp = _disp.getGpuMat();
     Mat Q = _Q.getMat();
 
-    CV_Assert( disp.type() == CV_8U || disp.type() == CV_16S );
+    CV_Assert( disp.type() == CV_8U || disp.type() == CV_16S || disp.type() == CV_32S || disp.type() == CV_32F );
     CV_Assert( Q.type() == CV_32F && Q.rows == 4 && Q.cols == 4 && Q.isContinuous() );
     CV_Assert( dst_cn == 3 || dst_cn == 4 );
 

--- a/modules/cudastereo/src/util.cpp
+++ b/modules/cudastereo/src/util.cpp
@@ -92,6 +92,8 @@ namespace cv { namespace cuda { namespace device
 {
     void drawColorDisp_gpu(const PtrStepSzb& src, const PtrStepSzb& dst, int ndisp, const cudaStream_t& stream);
     void drawColorDisp_gpu(const PtrStepSz<short>& src, const PtrStepSzb& dst, int ndisp, const cudaStream_t& stream);
+    void drawColorDisp_gpu(const PtrStepSz<int>& src, const PtrStepSzb& dst, int ndisp, const cudaStream_t& stream);
+    void drawColorDisp_gpu(const PtrStepSz<float>& src, const PtrStepSzb& dst, int ndisp, const cudaStream_t& stream);
 }}}
 
 namespace
@@ -111,11 +113,11 @@ namespace
 void cv::cuda::drawColorDisp(InputArray _src, OutputArray dst, int ndisp, Stream& stream)
 {
     typedef void (*drawColorDisp_caller_t)(const GpuMat& src, OutputArray dst, int ndisp, const cudaStream_t& stream);
-    const drawColorDisp_caller_t drawColorDisp_callers[] = {drawColorDisp_caller<unsigned char>, 0, 0, drawColorDisp_caller<short>, 0, 0, 0, 0};
+    const drawColorDisp_caller_t drawColorDisp_callers[] = {drawColorDisp_caller<unsigned char>, 0, 0, drawColorDisp_caller<short>, drawColorDisp_caller<int>, drawColorDisp_caller<float>, 0, 0};
 
     GpuMat src = _src.getGpuMat();
 
-    CV_Assert( src.type() == CV_8U || src.type() == CV_16S );
+    CV_Assert( src.type() == CV_8U || src.type() == CV_16S || src.type() == CV_32S || src.type() == CV_32F );
 
     drawColorDisp_callers[src.type()](src, dst, ndisp, StreamAccessor::getStream(stream));
 }


### PR DESCRIPTION
This PR aims to address couple of minor annoyances that I encountered in calib3d/cudastereo modules while working with OpenCV's stereo functionality.

In particular, there are appears to be inconsistency among stereo methods when returning 16-bit signed disparity; CPU methods from calib3d (BM and SGBM) use fractional bits for extra precision, while the GPU methods from cudastereo do not. Similarly, when passing the 16-bit signed disparity to cv::reprojectImageTo3D() and cv::cuda::reprojectImageTo3D(), as well as to cv::cuda::drawColorDisp(), it is assumed that the values have no fractional bits.

So the only way to actually use the extra precision from CPU methods' 16-bit disparity values is to convert them to floating point values, and operate on them. However, the CUDA methods - cv::cuda::reprojectImageTo3D() and cv::cuda::drawColorDisp() do not appear to support 32-bit float format at the moment.

So this PR:
a) adds support for 32-bit float and 32-bit signed int format to cv::cuda::reprojectImageTo3D() and cv::cuda::drawColorDisp()
b) explicitly documents the lack of fractional bits for 16-bit signed disparity wherever applicable