### PR TITLE
ffmpeg: fix invalid NULL pointer access

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1269,7 +1269,8 @@ static AVStream *icv_add_video_stream_FFMPEG(AVFormatContext *oc,
       c->gop_size = -1;
       c->qmin = -1;
       c->bit_rate = 0;
-      av_opt_set(c->priv_data,"crf","23", 0);
+      if (c->priv_data)
+          av_opt_set(c->priv_data,"crf","23", 0);
     }
 #endif
 


### PR DESCRIPTION
Catched on Ubuntu 12.04 with FFMPEG:
```
  codec:                     YES (ver 53.35.0)
  format:                    YES (ver 53.21.1)
  util:                      YES (ver 51.22.3)
  swscale:                   YES (ver 2.1.0)
  resample:                  NO
  gentoo-style:              YES
```