### PR TITLE
cap_v4l: implement focus, autofocus, width, height, mode, format and fps

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -133,7 +133,9 @@ enum { CAP_PROP_POS_MSEC       =0,
        CAP_PROP_TILT          =34,
        CAP_PROP_ROLL          =35,
        CAP_PROP_IRIS          =36,
-       CAP_PROP_SETTINGS      =37
+       CAP_PROP_SETTINGS      =37,
+       CAP_PROP_BUFFERSIZE    =38,
+       CAP_PROP_AUTOFOCUS     =39
      };
 
 

--- a/modules/videoio/include/opencv2/videoio/videoio_c.h
+++ b/modules/videoio/include/opencv2/videoio/videoio_c.h
@@ -189,6 +189,7 @@ enum
     CV_CAP_PROP_IRIS          =36,
     CV_CAP_PROP_SETTINGS      =37,
     CV_CAP_PROP_BUFFERSIZE    =38,
+    CV_CAP_PROP_AUTOFOCUS     =39,
 
     CV_CAP_PROP_AUTOGRAB      =1024, // property for videoio class CvCapture_Android only
     CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING=1025, // readonly, tricky property, returns cpnst char* indeed

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1516,49 +1516,10 @@ yuv411p_to_rgb24(int width, int height,
 
 #ifdef HAVE_CAMV4L2
 static void
-yuyv_to_rgb24 (int width, int height, unsigned char *src, unsigned char *dst)
-{
-   unsigned char *s;
-   unsigned char *d;
-   int l, c;
-   int r, g, b, cr, cg, cb, y1, y2;
-
-   l = height;
-   s = src;
-   d = dst;
-   while (l--) {
-      c = width >> 1;
-      while (c--) {
-         y1 = *s++;
-         cb = ((*s - 128) * 454) >> 8;
-         cg = (*s++ - 128) * 88;
-         y2 = *s++;
-         cr = ((*s - 128) * 359) >> 8;
-         cg = (cg + (*s++ - 128) * 183) >> 8;
-
-         r = y1 + cr;
-         b = y1 + cb;
-         g = y1 - cg;
-         SAT(r);
-         SAT(g);
-         SAT(b);
-
-     *d++ = b;
-     *d++ = g;
-     *d++ = r;
-
-         r = y2 + cr;
-         b = y2 + cb;
-         g = y2 - cg;
-         SAT(r);
-         SAT(g);
-         SAT(b);
-
-     *d++ = b;
-     *d++ = g;
-     *d++ = r;
-      }
-   }
+yuyv_to_rgb24(int width, int height, unsigned char* src, unsigned char* dst) {
+    using namespace cv;
+    cvtColor(Mat(height, width, CV_8UC2, src), Mat(height, width, CV_8UC3, dst),
+             COLOR_YUV2BGR_YUYV);
 }
 
 static void

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -280,24 +280,11 @@ static unsigned int n_buffers = 0;
 #define V4L2_PIX_FMT_SN9C10X  v4l2_fourcc('S','9','1','0') /* SN9C10x cmpr. */
 #endif
 
-#ifndef V4L2_PIX_FMT_SGBRG
-#define V4L2_PIX_FMT_SGBRG v4l2_fourcc('G','B','R','G') /* bayer GBRG   GBGB.. RGRG.. */
+#ifndef V4L2_PIX_FMT_SGBRG8
+#define V4L2_PIX_FMT_SGBRG8 v4l2_fourcc('G','B','R','G') /* bayer GBRG   GBGB.. RGRG.. */
 #endif
 
 #endif  /* HAVE_CAMV4L2 */
-
-enum PALETTE_TYPE {
-  PALETTE_BGR24 = 1,
-  PALETTE_YVU420,
-  PALETTE_YUV411P,
-  PALETTE_YUYV,
-  PALETTE_UYVY,
-  PALETTE_SBGGR8,
-  PALETTE_SN9C10X,
-  PALETTE_MJPEG,
-  PALETTE_SGBRG,
-  PALETTE_RGB24
-};
 
 typedef struct CvCaptureCAM_V4L
 {
@@ -315,7 +302,7 @@ typedef struct CvCaptureCAM_V4L
     IplImage frame;
 
 #ifdef HAVE_CAMV4L2
-   enum PALETTE_TYPE palette;
+   __u32 palette;
    int index;
    int width, height;
    __u32 fps;
@@ -564,17 +551,17 @@ static int autosetup_capture_mode_v4l2(CvCaptureCAM_V4L* capture)
 {
   if (try_palette_v4l2(capture, V4L2_PIX_FMT_BGR24) == 0)
   {
-    capture->palette = PALETTE_BGR24;
+    capture->palette = V4L2_PIX_FMT_BGR24;
   }
   else
   if (try_palette_v4l2(capture, V4L2_PIX_FMT_YVU420) == 0)
   {
-    capture->palette = PALETTE_YVU420;
+    capture->palette = V4L2_PIX_FMT_YVU420;
   }
   else
   if (try_palette_v4l2(capture, V4L2_PIX_FMT_YUV411P) == 0)
   {
-    capture->palette = PALETTE_YUV411P;
+    capture->palette = V4L2_PIX_FMT_YUV411P;
   }
   else
 
@@ -582,35 +569,35 @@ static int autosetup_capture_mode_v4l2(CvCaptureCAM_V4L* capture)
   if (try_palette_v4l2(capture, V4L2_PIX_FMT_MJPEG) == 0 ||
       try_palette_v4l2(capture, V4L2_PIX_FMT_JPEG) == 0)
   {
-    capture->palette = PALETTE_MJPEG;
+    capture->palette = V4L2_PIX_FMT_MJPEG;
   }
   else
 #endif
 
   if (try_palette_v4l2(capture, V4L2_PIX_FMT_YUYV) == 0)
   {
-    capture->palette = PALETTE_YUYV;
+    capture->palette = V4L2_PIX_FMT_YUYV;
   }
   else if (try_palette_v4l2(capture, V4L2_PIX_FMT_UYVY) == 0)
   {
-    capture->palette = PALETTE_UYVY;
+    capture->palette = V4L2_PIX_FMT_UYVY;
   }
   else
   if (try_palette_v4l2(capture, V4L2_PIX_FMT_SN9C10X) == 0)
   {
-    capture->palette = PALETTE_SN9C10X;
+    capture->palette = V4L2_PIX_FMT_SN9C10X;
   } else
   if (try_palette_v4l2(capture, V4L2_PIX_FMT_SBGGR8) == 0)
   {
-    capture->palette = PALETTE_SBGGR8;
+    capture->palette = V4L2_PIX_FMT_SBGGR8;
   } else
-  if (try_palette_v4l2(capture, V4L2_PIX_FMT_SGBRG) == 0)
+  if (try_palette_v4l2(capture, V4L2_PIX_FMT_SGBRG8) == 0)
   {
-    capture->palette = PALETTE_SGBRG;
+    capture->palette = V4L2_PIX_FMT_SGBRG8;
   }
   else if (try_palette_v4l2(capture, V4L2_PIX_FMT_RGB24) == 0)
   {
-    capture->palette = PALETTE_RGB24;
+    capture->palette = V4L2_PIX_FMT_RGB24;
   }
       else
   {
@@ -2103,27 +2090,28 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
   {
     switch (capture->palette)
     {
-    case PALETTE_BGR24:
+    case V4L2_PIX_FMT_BGR24:
         memcpy((char *)capture->frame.imageData,
                (char *)capture->buffers[capture->bufferIndex].start,
                capture->frame.imageSize);
         break;
 
-    case PALETTE_YVU420:
+    case V4L2_PIX_FMT_YVU420:
         yuv420p_to_rgb24(capture->form.fmt.pix.width,
                  capture->form.fmt.pix.height,
                  (unsigned char*)(capture->buffers[capture->bufferIndex].start),
                  (unsigned char*)capture->frame.imageData);
         break;
 
-    case PALETTE_YUV411P:
+    case V4L2_PIX_FMT_YUV411P:
         yuv411p_to_rgb24(capture->form.fmt.pix.width,
                  capture->form.fmt.pix.height,
                  (unsigned char*)(capture->buffers[capture->bufferIndex].start),
                  (unsigned char*)capture->frame.imageData);
         break;
 #ifdef HAVE_JPEG
-    case PALETTE_MJPEG:
+    case V4L2_PIX_FMT_MJPEG:
+    case V4L2_PIX_FMT_JPEG:
         if (!mjpeg_to_rgb24(capture->form.fmt.pix.width,
                     capture->form.fmt.pix.height,
                     (unsigned char*)(capture->buffers[capture->bufferIndex]
@@ -2134,26 +2122,26 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
         break;
 #endif
 
-    case PALETTE_YUYV:
+    case V4L2_PIX_FMT_YUYV:
         yuyv_to_rgb24(capture->form.fmt.pix.width,
                   capture->form.fmt.pix.height,
                   (unsigned char*)(capture->buffers[capture->bufferIndex].start),
                   (unsigned char*)capture->frame.imageData);
         break;
-    case PALETTE_UYVY:
+    case V4L2_PIX_FMT_UYVY:
         uyvy_to_rgb24(capture->form.fmt.pix.width,
                   capture->form.fmt.pix.height,
                   (unsigned char*)(capture->buffers[capture->bufferIndex].start),
                   (unsigned char*)capture->frame.imageData);
         break;
-    case PALETTE_SBGGR8:
+    case V4L2_PIX_FMT_SBGGR8:
         bayer2rgb24(capture->form.fmt.pix.width,
                 capture->form.fmt.pix.height,
                 (unsigned char*)capture->buffers[capture->bufferIndex].start,
                 (unsigned char*)capture->frame.imageData);
         break;
 
-    case PALETTE_SN9C10X:
+    case V4L2_PIX_FMT_SN9C10X:
         sonix_decompress_init();
         sonix_decompress(capture->form.fmt.pix.width,
                  capture->form.fmt.pix.height,
@@ -2166,13 +2154,13 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
                 (unsigned char*)capture->frame.imageData);
         break;
 
-    case PALETTE_SGBRG:
+    case V4L2_PIX_FMT_SGBRG8:
         sgbrg2rgb24(capture->form.fmt.pix.width,
                 capture->form.fmt.pix.height,
                 (unsigned char*)capture->buffers[(capture->bufferIndex+1) % capture->req.count].start,
                 (unsigned char*)capture->frame.imageData);
         break;
-    case PALETTE_RGB24:
+    case V4L2_PIX_FMT_RGB24:
         rgb24_to_rgb24(capture->form.fmt.pix.width,
                 capture->form.fmt.pix.height,
                 (unsigned char*)capture->buffers[(capture->bufferIndex+1) % capture->req.count].start,
@@ -2273,6 +2261,11 @@ static double icvGetPropertyCAM_V4L (CvCaptureCAM_V4L* capture,
           return capture->form.fmt.pix.width;
       case CV_CAP_PROP_FRAME_HEIGHT:
           return capture->form.fmt.pix.height;
+      case CV_CAP_PROP_FOURCC:
+      case CV_CAP_PROP_MODE:
+          return capture->palette;
+      case CV_CAP_PROP_FORMAT:
+          return CV_8UC3;
       }
 
       if(property_id == CV_CAP_PROP_FPS) {

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -2303,15 +2303,11 @@ static double icvGetPropertyCAM_V4L (CvCaptureCAM_V4L* capture,
           return -1;
       }
 
-      if(property_id == CV_CAP_PROP_AUTOFOCUS) {
-          return (double)capture->control.value;
-      }
-
       /* get the min/max values */
       cv::Range range = capture->getRange(property_id);
 
       /* all was OK, so convert to 0.0 - 1.0 range, and return the value */
-      return ((float)capture->control.value - range.start + 1) / range.size();
+      return ((float)capture->control.value - range.start) / range.size();
 
   }
 #endif /* HAVE_CAMV4L2 */

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1612,15 +1612,11 @@ uyvy_to_rgb24 (int width, int height, unsigned char *src, unsigned char *dst)
 
 /* convert from mjpeg to rgb24 */
 static bool
-mjpeg_to_rgb24 (int width, int height,
-        unsigned char *src, int length,
-        unsigned char *dst)
-{
-  cv::Mat temp=cv::imdecode(cv::Mat(std::vector<uchar>(src, src + length)), 1);
-  if( !temp.data || temp.cols != width || temp.rows != height )
-    return false;
-  memcpy(dst, temp.data, width*height*3);
-  return true;
+mjpeg_to_rgb24(int width, int height, unsigned char* src, int length, IplImage* dst) {
+    using namespace cv;
+    Mat temp = cvarrToMat(dst);
+    imdecode(Mat(1, length, CV_8U, src), IMREAD_COLOR, &temp);
+    return temp.data && temp.cols == width && temp.rows == height;
 }
 
 #endif
@@ -2068,7 +2064,7 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
                     (unsigned char*)(capture->buffers[capture->bufferIndex]
                              .start),
                     capture->buffers[capture->bufferIndex].length,
-                    (unsigned char*)capture->frame.imageData))
+                    &capture->frame))
           return 0;
         break;
 #endif

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -272,18 +272,6 @@ struct buffer
 
 static unsigned int n_buffers = 0;
 
-/* Additional V4L2 pixelformats support for Sonix SN9C10x base webcams */
-#ifndef V4L2_PIX_FMT_SBGGR8
-#define V4L2_PIX_FMT_SBGGR8  v4l2_fourcc('B','A','8','1') /* 8 BGBG.. GRGR.. */
-#endif
-#ifndef V4L2_PIX_FMT_SN9C10X
-#define V4L2_PIX_FMT_SN9C10X  v4l2_fourcc('S','9','1','0') /* SN9C10x cmpr. */
-#endif
-
-#ifndef V4L2_PIX_FMT_SGBRG8
-#define V4L2_PIX_FMT_SGBRG8 v4l2_fourcc('G','B','R','G') /* bayer GBRG   GBGB.. RGRG.. */
-#endif
-
 #endif  /* HAVE_CAMV4L2 */
 
 typedef struct CvCaptureCAM_V4L

--- a/modules/videoio/src/precomp.hpp
+++ b/modules/videoio/src/precomp.hpp
@@ -49,6 +49,7 @@
 
 #include "opencv2/imgcodecs.hpp"
 
+#include "opencv2/imgproc.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/imgcodecs/imgcodecs_c.h"
 #include "opencv2/videoio/videoio_c.h"


### PR DESCRIPTION
the outline of the changes is
* add new ` CAP_PROP_AUTOFOCUS` to query/ control the autofocus setting
* use `cv::Range` instead of  `*_min *_max`
* make `icvGetPropertyCAM_V4L` return values in range `[0; 1]` instead of `(0; 1]`
* use user provided frame size instead of hardcoded `DEFAULT_V4L_WIDTH/ HEIGHT`
* use `V4L2_PIX_FMT_*` fourcc enums internally and allow to query them
* use `cvtColor` instead of ad-hoc implementations (for the ones I could test)

also look at the individual commits when reviewing.