### PR TITLE
stereoRectifyUncalibrated: assertion of input points shape fixed

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -2453,8 +2453,6 @@ CV_IMPL int cvStereoRectifyUncalibrated(
     CvPoint3D64f* lines2;
 
     CV_Assert( CV_IS_MAT(_points1) && CV_IS_MAT(_points2) &&
-        (_points1->rows == 1 || _points1->cols == 1) &&
-        (_points2->rows == 1 || _points2->cols == 1) &&
         CV_ARE_SIZES_EQ(_points1, _points2) );
 
     npoints = _points1->rows * _points1->cols * CV_MAT_CN(_points1->type) / 2;


### PR DESCRIPTION
Fix for https://github.com/Itseez/opencv/issues/4426
Documentation says that input points format is the same to input for findFundamentalMat