### PR TITLE
Fixes for IPP integration

### DIFF
--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -241,6 +241,26 @@ static inline IppDataType ippiGetDataType(int depth)
         depth == CV_64F ? ipp64f : (IppDataType)-1;
 }
 
+// IPP temporary buffer hepler
+template<typename T>
+class IppAutoBuffer
+{
+public:
+    IppAutoBuffer() { m_pBuffer = NULL; }
+    IppAutoBuffer(int size) { Alloc(size); }
+    ~IppAutoBuffer() { Release(); }
+    T* Alloc(int size) { m_pBuffer = (T*)ippMalloc(size); return m_pBuffer; }
+    void Release() { if(m_pBuffer) ippFree(m_pBuffer); }
+    inline operator T* () { return (T*)m_pBuffer;}
+    inline operator const T* () const { return (const T*)m_pBuffer;}
+private:
+    // Disable copy operations
+    IppAutoBuffer(IppAutoBuffer &) {};
+    IppAutoBuffer& operator =(const IppAutoBuffer &) {return *this;};
+
+    T* m_pBuffer;
+};
+
 #else
 #define IPP_VERSION_X100 0
 #endif

--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -3131,7 +3131,7 @@ static double dotProd_16u(const ushort* src1, const ushort* src2, int len)
 
 static double dotProd_16s(const short* src1, const short* src2, int len)
 {
-#if (ARITHM_USE_IPP == 1)
+#if (ARITHM_USE_IPP == 1) && (IPP_VERSION_X100 != 900) // bug in IPP 9.0.0
     CV_IPP_CHECK()
     {
         double r = 0;

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1318,6 +1318,12 @@ public:
                 ippFeatures = ippCPUID_SSE;
             else if(env == "sse2")
                 ippFeatures = ippCPUID_SSE2;
+            else if(env == "sse3")
+                ippFeatures = ippCPUID_SSE3;
+            else if(env == "ssse3")
+                ippFeatures = ippCPUID_SSSE3;
+            else if(env == "sse41")
+                ippFeatures = ippCPUID_SSE41;
             else if(env == "sse42")
                 ippFeatures = ippCPUID_SSE42;
             else if(env == "avx")

--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -4579,7 +4579,7 @@ static bool ipp_filter2D( InputArray _src, OutputArray _dst, int ddepth,
     int stype = src.type(), sdepth = CV_MAT_DEPTH(stype), cn = CV_MAT_CN(stype),
         ktype = kernel.type(), kdepth = CV_MAT_DEPTH(ktype);
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
-    Point ippAnchor(kernel.cols >> 1, kernel.rows >> 1);
+    Point ippAnchor((kernel.cols-1)/2, (kernel.rows-1)/2);
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
     IppiBorderType ippBorderType = ippiGetBorderType(borderTypeNI);
 
@@ -4610,24 +4610,48 @@ static bool ipp_filter2D( InputArray _src, OutputArray _dst, int ddepth,
 
             if ((status = ippiFilterBorderGetSize(kernelSize, dstRoiSize, dataType, kernelType, cn, &specSize, &bufsize)) >= 0)
             {
-                IppiFilterBorderSpec * spec = (IppiFilterBorderSpec *)ippMalloc(specSize);
-                Ipp8u * buffer = ippsMalloc_8u(bufsize);
+                IppAutoBuffer<IppiFilterBorderSpec> spec(specSize);
+                IppAutoBuffer<Ipp8u> buffer(bufsize);
                 Ipp32f borderValue[4] = { 0, 0, 0, 0 };
 
-                Mat reversedKernel;
-                flip(kernel, reversedKernel, -1);
-
-                if ((kdepth == CV_32F && (status = ippiFilterBorderInit_32f((const Ipp32f *)reversedKernel.data, kernelSize,
-                    dataType, cn, ippRndFinancial, spec)) >= 0 ) ||
-                    (kdepth == CV_16S && (status = ippiFilterBorderInit_16s((const Ipp16s *)reversedKernel.data,
-                    kernelSize, 0, dataType, cn, ippRndFinancial, spec)) >= 0))
+                if(kdepth == CV_32F)
                 {
-                    status = ippFunc(src.data, (int)src.step, dst.data, (int)dst.step, dstRoiSize,
-                        ippBorderType, borderValue, spec, buffer);
-                }
+                    Ipp32f *pKerBuffer = (Ipp32f*)kernel.data;
+                    IppAutoBuffer<Ipp32f> kerTmp;
+                    if(kernel.step != kernel.cols)
+                    {
+                        kerTmp.Alloc(sizeof(Ipp32f)*kernelSize.width*kernelSize.height);
+                        if(ippiCopy_32f_C1R((Ipp32f*)kernel.data, (int)kernel.step, kerTmp, kernelSize.width*sizeof(Ipp32f), kernelSize) < 0)
+                            return false;
+                        pKerBuffer = kerTmp;
+                    }
 
-                ippsFree(buffer);
-                ippsFree(spec);
+                    if((status = ippiFilterBorderInit_32f(pKerBuffer, kernelSize,
+                        dataType, cn, ippRndFinancial, spec)) >= 0 )
+                    {
+                        status = ippFunc(src.data, (int)src.step, dst.data, (int)dst.step, dstRoiSize,
+                            ippBorderType, borderValue, spec, buffer);
+                    }
+                }
+                else if(kdepth == CV_16S)
+                {
+                    Ipp16s *pKerBuffer = (Ipp16s*)kernel.data;
+                    IppAutoBuffer<Ipp16s> kerTmp;
+                    if(kernel.step != kernel.cols)
+                    {
+                        kerTmp.Alloc(sizeof(Ipp16s)*kernelSize.width*kernelSize.height);
+                        if(ippiCopy_16s_C1R((Ipp16s*)kernel.data, (int)kernel.step, kerTmp, kernelSize.width*sizeof(Ipp16s), kernelSize) < 0)
+                            return false;
+                        pKerBuffer = kerTmp;
+                    }
+
+                    if((status = ippiFilterBorderInit_16s(pKerBuffer, kernelSize,
+                        0, dataType, cn, ippRndFinancial, spec)) >= 0)
+                    {
+                        status = ippFunc(src.data, (int)src.step, dst.data, (int)dst.step, dstRoiSize,
+                            ippBorderType, borderValue, spec, buffer);
+                    }
+                }
             }
 
             if (status >= 0)

--- a/modules/imgproc/src/sumpixels.cpp
+++ b/modules/imgproc/src/sumpixels.cpp
@@ -425,7 +425,7 @@ namespace cv
 {
 static bool ipp_integral(InputArray _src, OutputArray _sum, OutputArray _sqsum, OutputArray _tilted, int sdepth, int sqdepth)
 {
-#if !defined(HAVE_IPP_ICV_ONLY) // Disabled on ICV due invalid results
+#if !defined(HAVE_IPP_ICV_ONLY) && (IPP_VERSION_X100 != 900) // Disabled on ICV due invalid results
     int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     if( sdepth <= 0 )
         sdepth = depth == CV_8U ? CV_32S : CV_64F;


### PR DESCRIPTION
Fixes for IPP integration:
dotProd_16s - disabled for IPP 9.0.0;
filter2D - fixed kernel preparation;
morphology - conditions fix and disabled FilterMin and FilterMax for IPP 9.0.0;
GaussianBlur - disabled for CV_8UC1 due to buffer overflow;
integral - disabled for IPP 9.0.0;

IppAutoBuffer class was added;