### PR TITLE
adding extra explanation for mask parameter

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1073,6 +1073,7 @@ public:
     @param m Destination matrix. If it does not have a proper size or type before the operation, it is
     reallocated.
     @param mask Operation mask. Its non-zero elements indicate which matrix elements need to be copied.
+    The mask has to be of type CV_8U and can have 1 or multiple channels.
     */
     void copyTo( OutputArray m, InputArray mask ) const;
 


### PR DESCRIPTION
as suggested in http://answers.opencv.org/question/72920/shouldnt-matcopyto-be-documented-with-the-type-of-mask/