### PR TITLE
adding extra explanation for mask parameter

### DIFF
--- a/modules/core/doc/basic_structures.rst
+++ b/modules/core/doc/basic_structures.rst
@@ -1346,7 +1346,7 @@ Copies the matrix to another one.
 
     :param m: Destination matrix. If it does not have a proper size or type before the operation, it is reallocated.
 
-    :param mask: Operation mask. Its non-zero elements indicate which matrix elements need to be copied.
+    :param mask: Operation mask. Its non-zero elements indicate which matrix elements need to be copied. Keep in mind that the mask needs to be of type CV_8U and can have 1 or multiple channels.
 
 The method copies the matrix data to another matrix. Before copying the data, the method invokes ::
 


### PR DESCRIPTION
as suggested in http://answers.opencv.org/question/72920/shouldnt-matcopyto-be-documented-with-the-type-of-mask/