### PR TITLE
fix type mismatch error for MSVC2012

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -368,7 +368,7 @@ bool  PngEncoder::write( const Mat& img, const std::vector<int>& params )
                 {
                     f = fopen( m_filename.c_str(), "wb" );
                     if( f )
-                        png_init_io( png_ptr, f );
+                        png_init_io( png_ptr, (png_FILE_p)f );
                 }
 
                 int compression_level = -1; // Invalid value to allow setting 0-9 as valid
@@ -437,7 +437,7 @@ bool  PngEncoder::write( const Mat& img, const std::vector<int>& params )
     }
 
     png_destroy_write_struct( &png_ptr, &info_ptr );
-    if(f) fclose( f );
+    if(f) fclose( (FILE*)f );
 
     return result;
 }


### PR DESCRIPTION
the volatile qualifier needed elsewhere conflicts when calling functions that dont have it. let's strip it by an explicit type cast.