### PR TITLE
Hit And Miss morphological operation

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -225,8 +225,10 @@ enum MorphTypes{
                         //!< \f[\texttt{dst} = \mathrm{morph\_grad} ( \texttt{src} , \texttt{element} )= \mathrm{dilate} ( \texttt{src} , \texttt{element} )- \mathrm{erode} ( \texttt{src} , \texttt{element} )\f]
     MORPH_TOPHAT   = 5, //!< "top hat"
                         //!< \f[\texttt{dst} = \mathrm{tophat} ( \texttt{src} , \texttt{element} )= \texttt{src} - \mathrm{open} ( \texttt{src} , \texttt{element} )\f]
-    MORPH_BLACKHAT = 6  //!< "black hat"
+    MORPH_BLACKHAT = 6, //!< "black hat"
                         //!< \f[\texttt{dst} = \mathrm{blackhat} ( \texttt{src} , \texttt{element} )= \mathrm{close} ( \texttt{src} , \texttt{element} )- \texttt{src}\f]
+    MORPH_HITMISS  = 7  //!< "hit and miss"
+                        //!<   .- Only supported for CV_8UC1 binary images. Tutorial can be found in [this page](http://opencv-code.com/tutorials/hit-or-miss-transform-in-opencv/)
 };
 
 //! shape of the structuring element

--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1908,10 +1908,9 @@ void cv::morphologyEx( InputArray _src, OutputArray _dst, int op,
         dst = temp - src;
         break;
     case MORPH_HITMISS:
-        k1 = (kernel == 1) / 255;
-        k2 = (kernel == -1) / 255;
-        normalize(src, src, 0, 1, NORM_MINMAX);
         CV_Assert(src.type() == CV_8UC1);
+        k1 = (kernel == 1);
+        k2 = (kernel == -1);
         if (countNonZero(k1) <= 0)
             e1 = src;
         else
@@ -1919,9 +1918,12 @@ void cv::morphologyEx( InputArray _src, OutputArray _dst, int op,
         if (countNonZero(k2) <= 0)
             e2 = src;
         else
-            erode(1 - src, e2, k2, anchor, iterations, borderType, borderValue);
+        {
+            Mat src_complement;
+            bitwise_not(src, src_complement);
+            erode(src_complement, e2, k2, anchor, iterations, borderType, borderValue);
+        }
         dst = e1 & e2;
-        normalize(dst, dst, 0, 255, NORM_MINMAX);
         break;
     default:
         CV_Error( CV_StsBadArg, "unknown morphological operation" );

--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1908,10 +1908,10 @@ void cv::morphologyEx( InputArray _src, OutputArray _dst, int op,
         dst = temp - src;
         break;
     case MORPH_HITMISS:
-        CV_Assert(src.type() == CV_8U && src.channels() == 1);
         k1 = (kernel == 1) / 255;
         k2 = (kernel == -1) / 255;
         normalize(src, src, 0, 1, NORM_MINMAX);
+        CV_Assert(src.type() == CV_8UC1);
         if (countNonZero(k1) <= 0)
             e1 = src;
         else


### PR DESCRIPTION
Implementation of Hit And Miss morphological operation

- Based on the code provided in this page: http://opencv-code.com/tutorials/hit-or-miss-transform-in-opencv/ . Minor fixes added to prevent incorrect results due to erosion with all-zeros kernel (refer to this [Q&A post](http://answers.opencv.org/question/28344/working-hit-or-miss-implementation/))

- New documentation refers to upper link, but I plan to modify such tutorial to publish in OpenCV site, showing new functionality of morphologyEx function.

- ocl version not implemented

- If everything is alright and gets merged, I will provide 2.4.x PR

- Code sample showing functionality [here](https://gist.github.com/LorenaGdL/ad3d7fc5ca070a549715)