### PR TITLE
Extension of the camera distortion model for tilted image sensors 

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -415,6 +415,16 @@
   pages = {2548--2555},
   organization = {IEEE}
 }
+@ARTICLE{Louhichi07,
+  author = {Louhichi, H. and Fournel, T. and Lavest, J. M. and Ben Aissia, H.},
+  title = {Self-calibration of Scheimpflug cameras: an easy protocol},
+  year = {2007},
+  pages = {2616–2622},
+  journal = {Meas. Sci. Technol.},
+  volume = {18},
+  number = {8},
+  publisher = {IOP Publishing Ltd}
+}
 @ARTICLE{LibSVM,
   author = {Chang, Chih-Chung and Lin, Chih-Jen},
   title = {LIBSVM: a library for support vector machines},

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -99,14 +99,50 @@ v = f_y*y' + c_y
 Real lenses usually have some distortion, mostly radial distortion and slight tangential distortion.
 So, the above model is extended as:
 
-\f[\begin{array}{l} \vecthree{x}{y}{z} = R  \vecthree{X}{Y}{Z} + t \\ x' = x/z \\ y' = y/z \\ x'' = x'  \frac{1 + k_1 r^2 + k_2 r^4 + k_3 r^6}{1 + k_4 r^2 + k_5 r^4 + k_6 r^6} + 2 p_1 x' y' + p_2(r^2 + 2 x'^2) + s_1 r^2 + s_2 r^4 \\ y'' = y'  \frac{1 + k_1 r^2 + k_2 r^4 + k_3 r^6}{1 + k_4 r^2 + k_5 r^4 + k_6 r^6} + p_1 (r^2 + 2 y'^2) + 2 p_2 x' y' + s_3 r^2 + s_4 r^4 \\ \text{where} \quad r^2 = x'^2 + y'^2  \\ u = f_x*x'' + c_x \\ v = f_y*y'' + c_y \end{array}\f]
+\f[\begin{array}{l}
+\vecthree{x}{y}{z} = R  \vecthree{X}{Y}{Z} + t \\
+x' = x/z \\
+y' = y/z \\
+x'' = x'  \frac{1 + k_1 r^2 + k_2 r^4 + k_3 r^6}{1 + k_4 r^2 + k_5 r^4 + k_6 r^6} + 2 p_1 x' y' + p_2(r^2 + 2 x'^2) + s_1 r^2 + s_2 r^4 \\
+y'' = y'  \frac{1 + k_1 r^2 + k_2 r^4 + k_3 r^6}{1 + k_4 r^2 + k_5 r^4 + k_6 r^6} + p_1 (r^2 + 2 y'^2) + 2 p_2 x' y' + s_3 r^2 + s_4 r^4 \\
+\text{where} \quad r^2 = x'^2 + y'^2  \\
+u = f_x*x'' + c_x \\
+v = f_y*y'' + c_y
+\end{array}\f]
 
 \f$k_1\f$, \f$k_2\f$, \f$k_3\f$, \f$k_4\f$, \f$k_5\f$, and \f$k_6\f$ are radial distortion coefficients. \f$p_1\f$ and \f$p_2\f$ are
 tangential distortion coefficients. \f$s_1\f$, \f$s_2\f$, \f$s_3\f$, and \f$s_4\f$, are the thin prism distortion
-coefficients. Higher-order coefficients are not considered in OpenCV. In the functions below the
-coefficients are passed or returned as
+coefficients. Higher-order coefficients are not considered in OpenCV.
 
-\f[(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f]
+In some cases the image sensor may be tilted in order to focus an oblique plane in front of the
+camera (Scheimpfug condition). This can be useful for particle image velocimetry (PIV) or
+triangulation with a laser fan. The tilt causes a perspective distortion of \f$x''\f$ and
+\f$y''\f$. This distortion can be modelled in the following way, see e.g. @cite Louhichi07.
+
+\f[\begin{array}{l}
+s\vecthree{x'''}{y'''}{1} =
+\vecthreethree{R_{33}(\tau_x, \tau_y)}{0}{-R_{13}(\tau_x, \tau_y)}
+{0}{R_{33}(\tau_x, \tau_y)}{-R_{23}(\tau_x, \tau_y)}
+{0}{0}{1} R(\tau_x, \tau_y) \vecthree{x''}{y''}{1}\\
+u = f_x*x''' + c_x \\
+v = f_y*y''' + c_y
+\end{array}\f]
+
+where the matrix \f$R(\tau_x, \tau_y)\f$ is defined by two rotations with angular parameter \f$\tau_x\f$
+and \f$\tau_y\f$, respectively,
+
+\f[
+R(\tau_x, \tau_y) =
+\vecthreethree{\cos(\tau_y)}{0}{-\sin(\tau_y)}{0}{1}{0}{\sin(\tau_y)}{0}{\cos(\tau_y)}
+\vecthreethree{1}{0}{0}{0}{\cos(\tau_x)}{\sin(\tau_x)}{0}{-\sin(\tau_x)}{\cos(\tau_x)} =
+\vecthreethree{\cos(\tau_y)}{\sin(\tau_y)\sin(\tau_x)}{-\sin(\tau_y)\cos(\tau_x)}
+{0}{\cos(\tau_x)}{\sin(\tau_x)}
+{\sin(\tau_y)}{-\cos(\tau_y)\sin(\tau_x)}{\cos(\tau_y)\cos(\tau_x)}.
+\f]
+
+In the functions below the coefficients are passed or returned as
+
+\f[(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f]
 
 vector. That is, if the vector contains four elements, it means that \f$k_3=0\f$ . The distortion
 coefficients do not depend on the scene viewed. Thus, they also belong to the intrinsic camera
@@ -221,6 +257,8 @@ enum { CALIB_USE_INTRINSIC_GUESS = 0x00001,
        CALIB_RATIONAL_MODEL      = 0x04000,
        CALIB_THIN_PRISM_MODEL    = 0x08000,
        CALIB_FIX_S1_S2_S3_S4     = 0x10000,
+       CALIB_TILTED_MODEL        = 0x20000,
+       CALIB_FIX_TAUX_TAUY       = 0x40000,
        // only for stereo
        CALIB_FIX_INTRINSIC       = 0x00100,
        CALIB_SAME_FOCAL_LENGTH   = 0x00200,
@@ -443,8 +481,8 @@ vector\<Point3f\> ), where N is the number of points in the view.
 @param tvec Translation vector.
 @param cameraMatrix Camera matrix \f$A = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{_1}\f$ .
 @param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f$ of 4, 5, 8 or 12 elements. If
-the vector is empty, the zero distortion coefficients are assumed.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
+4, 5, 8, 12 or 14 elements. If the vector is empty, the zero distortion coefficients are assumed.
 @param imagePoints Output array of image points, 2xN/Nx2 1-channel or 1xN/Nx1 2-channel, or
 vector\<Point2f\> .
 @param jacobian Optional output 2Nx(10+\<numDistCoeffs\>) jacobian matrix of derivatives of image
@@ -482,8 +520,9 @@ CV_EXPORTS_W void projectPoints( InputArray objectPoints,
 where N is the number of points. vector\<Point2f\> can be also passed here.
 @param cameraMatrix Input camera matrix \f$A = \vecthreethree{fx}{0}{cx}{0}{fy}{cy}{0}{0}{1}\f$ .
 @param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f$ of 4, 5, 8 or 12 elements. If
-the vector is NULL/empty, the zero distortion coefficients are assumed.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
+4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
+assumed.
 @param rvec Output rotation vector (see Rodrigues ) that, together with tvec , brings points from
 the model coordinate system to the camera coordinate system.
 @param tvec Output translation vector.
@@ -538,8 +577,9 @@ CV_EXPORTS_W bool solvePnP( InputArray objectPoints, InputArray imagePoints,
 where N is the number of points. vector\<Point2f\> can be also passed here.
 @param cameraMatrix Input camera matrix \f$A = \vecthreethree{fx}{0}{cx}{0}{fy}{cy}{0}{0}{1}\f$ .
 @param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f$ of 4, 5, 8 or 12 elements. If
-the vector is NULL/empty, the zero distortion coefficients are assumed.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
+4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
+assumed.
 @param rvec Output rotation vector (see Rodrigues ) that, together with tvec , brings points from
 the model coordinate system to the camera coordinate system.
 @param tvec Output translation vector.
@@ -718,7 +758,8 @@ together.
 and/or CV_CALIB_FIX_ASPECT_RATIO are specified, some or all of fx, fy, cx, cy must be
 initialized before calling the function.
 @param distCoeffs Output vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f$ of 4, 5, 8 or 12 elements.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
+4, 5, 8, 12 or 14 elements.
 @param rvecs Output vector of rotation vectors (see Rodrigues ) estimated for each pattern view
 (e.g. std::vector<cv::Mat>>). That is, each k-th rotation vector together with the corresponding
 k-th translation vector (see the next output parameter description) brings the calibration pattern
@@ -752,6 +793,13 @@ backward compatibility, this extra flag should be explicitly specified to make t
 calibration function use the thin prism model and return 12 coefficients. If the flag is not
 set, the function computes and returns only 5 distortion coefficients.
 -   **CALIB_FIX_S1_S2_S3_S4** The thin prism distortion coefficients are not changed during
+the optimization. If CV_CALIB_USE_INTRINSIC_GUESS is set, the coefficient from the
+supplied distCoeffs matrix is used. Otherwise, it is set to 0.
+-   **CALIB_TILTED_MODEL** Coefficients tauX and tauY are enabled. To provide the
+backward compatibility, this extra flag should be explicitly specified to make the
+calibration function use the tilted sensor model and return 14 coefficients. If the flag is not
+set, the function computes and returns only 5 distortion coefficients.
+-   **CALIB_FIX_TAUX_TAUY** The coefficients of the tilted sensor model are not changed during
 the optimization. If CV_CALIB_USE_INTRINSIC_GUESS is set, the coefficient from the
 supplied distCoeffs matrix is used. Otherwise, it is set to 0.
 @param criteria Termination criteria for the iterative optimization algorithm.
@@ -838,8 +886,8 @@ any of CV_CALIB_USE_INTRINSIC_GUESS , CV_CALIB_FIX_ASPECT_RATIO ,
 CV_CALIB_FIX_INTRINSIC , or CV_CALIB_FIX_FOCAL_LENGTH are specified, some or all of the
 matrix components must be initialized. See the flags description for details.
 @param distCoeffs1 Input/output vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f$ of 4, 5, 8 ot 12 elements. The
-output vector length depends on the flags.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
+4, 5, 8, 12 or 14 elements. The output vector length depends on the flags.
 @param cameraMatrix2 Input/output second camera matrix. The parameter is similar to cameraMatrix1
 @param distCoeffs2 Input/output lens distortion coefficients for the second camera. The parameter
 is similar to distCoeffs1 .
@@ -872,6 +920,13 @@ backward compatibility, this extra flag should be explicitly specified to make t
 calibration function use the thin prism model and return 12 coefficients. If the flag is not
 set, the function computes and returns only 5 distortion coefficients.
 -   **CALIB_FIX_S1_S2_S3_S4** The thin prism distortion coefficients are not changed during
+the optimization. If CV_CALIB_USE_INTRINSIC_GUESS is set, the coefficient from the
+supplied distCoeffs matrix is used. Otherwise, it is set to 0.
+-   **CALIB_TILTED_MODEL** Coefficients tauX and tauY are enabled. To provide the
+backward compatibility, this extra flag should be explicitly specified to make the
+calibration function use the tilted sensor model and return 14 coefficients. If the flag is not
+set, the function computes and returns only 5 distortion coefficients.
+-   **CALIB_FIX_TAUX_TAUY** The coefficients of the tilted sensor model are not changed during
 the optimization. If CV_CALIB_USE_INTRINSIC_GUESS is set, the coefficient from the
 supplied distCoeffs matrix is used. Otherwise, it is set to 0.
 @param criteria Termination criteria for the iterative optimization algorithm.
@@ -1057,8 +1112,9 @@ CV_EXPORTS_W float rectify3Collinear( InputArray cameraMatrix1, InputArray distC
 
 @param cameraMatrix Input camera matrix.
 @param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6],[s_1, s_2, s_3, s_4]])\f$ of 4, 5, 8 or 12 elements. If
-the vector is NULL/empty, the zero distortion coefficients are assumed.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
+4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
+assumed.
 @param imageSize Original image size.
 @param alpha Free scaling parameter between 0 (when all the pixels in the undistorted image are
 valid) and 1 (when all the source image pixels are retained in the undistorted image). See

--- a/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
+++ b/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
@@ -243,6 +243,8 @@ CVAPI(void) cvDrawChessboardCorners( CvArr* image, CvSize pattern_size,
 #define CV_CALIB_RATIONAL_MODEL 16384
 #define CV_CALIB_THIN_PRISM_MODEL 32768
 #define CV_CALIB_FIX_S1_S2_S3_S4  65536
+#define CV_CALIB_TILTED_MODEL  131072
+#define CV_CALIB_FIX_TAUX_TAUY  262144
 
 
 /* Finds intrinsic and extrinsic camera parameters

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -818,8 +818,8 @@ CV_IMPL void cvProjectPoints2( const CvMat* objectPoints,
                 }
                 dpdf_p += dpdf_step*2;
             }
-            for (size_t row = 0; row < 2; ++row)
-                for (size_t col = 0; col < 2; ++col)
+            for (int row = 0; row < 2; ++row)
+                for (int col = 0; col < 2; ++col)
                     dMatTilt(row,col) = matTilt(row,col)*vecTilt(2)
                       - matTilt(2,col)*vecTilt(row);
             double invProjSquare = (invProj*invProj);

--- a/modules/calib3d/test/test_cameracalibration_tilt.cpp
+++ b/modules/calib3d/test/test_cameracalibration_tilt.cpp
@@ -313,7 +313,7 @@ void cameraCalibrationTiltTest::numericalDerivative(
     std::vector<cv::Point2d> pix0, pix1;
     double invEps = .5/eps;
 
-    for (size_t col = 0; col < 10+NUM_DIST_COEFF_TILT; ++col)
+    for (int col = 0; col < 10+NUM_DIST_COEFF_TILT; ++col)
     {
         double save = *(param[col]);
         *(param[col]) = save + eps;
@@ -429,7 +429,7 @@ TEST_F(cameraCalibrationTiltTest, projectPoints)
         // remove object and imgage points out of range
         removeInvalidPoints(imagePoints, objectPoints);
 
-        int numPoints = imagePoints.size();
+        int numPoints = (int)imagePoints.size();
         int numParams = 10 + distortionCoeff.rows;
         cv::Mat jacobian(2*numPoints, numParams, CV_64FC1);
 
@@ -535,8 +535,8 @@ void show(const std::string& name, const INPUT in, const ESTIMATE est)
         << ", diff = " << est-in << ")\n";
 }
 
-template <typename INPUT, typename ESTIMATE>
-void showVec(const std::string& name, const INPUT& in, const ESTIMATE& est)
+template <typename INPUT>
+void showVec(const std::string& name, const INPUT& in, const cv::Mat& est)
 {
 
     for (size_t i = 0; i < in.channels; ++i)

--- a/modules/calib3d/test/test_cameracalibration_tilt.cpp
+++ b/modules/calib3d/test/test_cameracalibration_tilt.cpp
@@ -1,0 +1,696 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "test_precomp.hpp"
+#include <opencv2/ts/cuda_test.hpp>
+#include "opencv2/calib3d.hpp"
+
+#define NUM_DIST_COEFF_TILT 14
+
+/**
+Some conventions:
+- the first camera determines the world coordinate system
+- y points down, hence top means minimal y value (negative) and
+bottom means maximal y value (positive)
+- the field of view plane is tilted around x such that it
+intersects the xy-plane in a line with a large (positive)
+y-value
+- image sensor and object are both modelled in the halfspace
+z > 0
+
+
+**/
+class cameraCalibrationTiltTest : public ::testing::Test {
+
+protected:
+    cameraCalibrationTiltTest()
+        : m_toRadian(acos(-1.0)/180.0)
+        , m_toDegree(180.0/acos(-1.0))
+    {}
+    virtual void SetUp();
+
+protected:
+    static const cv::Size m_imageSize;
+    static const double m_pixelSize;
+    static const double m_circleConfusionPixel;
+    static const double m_lensFocalLength;
+    static const double m_lensFNumber;
+    static const double m_objectDistance;
+    static const double m_planeTiltDegree;
+    static const double m_pointTargetDist;
+    static const int m_pointTargetNum;
+
+    /** image distance coresponding to working distance */
+    double m_imageDistance;
+    /** image tilt angle corresponding to the tilt of the object plane */
+    double m_imageTiltDegree;
+    /** center of the field of view, near and far plane */
+    std::vector<cv::Vec3d> m_fovCenter;
+    /** normal of the field of view, near and far plane */
+    std::vector<cv::Vec3d> m_fovNormal;
+    /** points on a plane calibration target */
+    std::vector<cv::Point3d> m_pointTarget;
+    /** rotations for the calibration target */
+    std::vector<cv::Vec3d> m_pointTargetRvec;
+    /** translations for the calibration target */
+    std::vector<cv::Vec3d> m_pointTargetTvec;
+    /** camera matrix */
+    cv::Matx33d m_cameraMatrix;
+    /** distortion coefficients */
+    cv::Vec<double, NUM_DIST_COEFF_TILT> m_distortionCoeff;
+
+    /** random generator */
+    cv::RNG m_rng;
+    /** degree to radian conversion factor */
+    const double m_toRadian;
+    /** radian to degree conversion factor */
+    const double m_toDegree;
+
+    /**
+    computes for a given distance of an image or object point
+    the distance of the corresponding object or image point
+    */
+    double opticalMap(double dist) {
+        return m_lensFocalLength*dist/(dist - m_lensFocalLength);
+    }
+
+    /** magnification of the optical map */
+    double magnification(double dist) {
+        return m_lensFocalLength/(dist - m_lensFocalLength);
+    }
+
+    /**
+    Changes given distortion coefficients randomly by adding
+    a uniformly distributed random variable in [-max max]
+    \param coeff input
+    \param max limits for the random variables
+    */
+    void randomDistortionCoeff(
+        cv::Vec<double, NUM_DIST_COEFF_TILT>& coeff,
+        const cv::Vec<double, NUM_DIST_COEFF_TILT>& max)
+    {
+        for (size_t i = 0; i < coeff.rows; ++i)
+            coeff(i) += m_rng.uniform(-max(i), max(i));
+    }
+
+    /** numerical jacobian */
+    void numericalDerivative(
+        cv::Mat& jac,
+        double eps,
+        const std::vector<cv::Point3d>& obj,
+        const cv::Vec3d& rvec,
+        const cv::Vec3d& tvec,
+        const cv::Matx33d& camera,
+        const cv::Vec<double, NUM_DIST_COEFF_TILT>& distor);
+
+    /** remove points with projection outside the sensor array */
+    void removeInvalidPoints(
+        std::vector<cv::Point2d>& imagePoints,
+        std::vector<cv::Point3d>& objectPoints);
+
+    /** add uniform distribute noise in [-halfWidthNoise, halfWidthNoise]
+    to the image points and remove out of range points */
+    void addNoiseRemoveInvalidPoints(
+        std::vector<cv::Point2f>& imagePoints,
+        std::vector<cv::Point3f>& objectPoints,
+        std::vector<cv::Point2f>& noisyImagePoints,
+        double halfWidthNoise);
+};
+
+/** Number of Pixel of the sensor */
+const cv::Size cameraCalibrationTiltTest::m_imageSize(1600, 1200);
+/** Size of a pixel in mm */
+const double cameraCalibrationTiltTest::m_pixelSize(.005);
+/** Diameter of the circle of confusion */
+const double cameraCalibrationTiltTest::m_circleConfusionPixel(3);
+/** Focal length of the lens */
+const double cameraCalibrationTiltTest::m_lensFocalLength(16.4);
+/** F-Number */
+const double cameraCalibrationTiltTest::m_lensFNumber(8);
+/** Working distance */
+const double cameraCalibrationTiltTest::m_objectDistance(200);
+/** Angle between optical axis and object plane normal */
+const double cameraCalibrationTiltTest::m_planeTiltDegree(55);
+/** the calibration target are points on a square grid with this side length */
+const double cameraCalibrationTiltTest::m_pointTargetDist(5);
+/** the calibration target has (2*n + 1) x (2*n + 1) points */
+const int cameraCalibrationTiltTest::m_pointTargetNum(15);
+
+
+void cameraCalibrationTiltTest::SetUp()
+{
+    m_imageDistance = opticalMap(m_objectDistance);
+    m_imageTiltDegree = m_toDegree * atan2(
+        m_imageDistance * tan(m_toRadian * m_planeTiltDegree),
+        m_objectDistance);
+    // half sensor height
+    double tmp = .5 * (m_imageSize.height - 1) * m_pixelSize
+        * cos(m_toRadian * m_imageTiltDegree);
+    // y-Value of tilted sensor
+    double yImage[2] = {tmp, -tmp};
+    // change in z because of the tilt
+    tmp *= sin(m_toRadian * m_imageTiltDegree);
+    // z-values of the sensor lower and upper corner
+    double zImage[2] = {
+        m_imageDistance + tmp,
+        m_imageDistance - tmp};
+    // circle of confusion
+    double circleConfusion = m_circleConfusionPixel*m_pixelSize;
+    // aperture of the lense
+    double aperture = m_lensFocalLength/m_lensFNumber;
+    // near and far factor on the image side
+    double nearFarFactorImage[2] = {
+        aperture/(aperture - circleConfusion),
+        aperture/(aperture + circleConfusion)};
+    // on the object side - points that determin the field of
+    // view
+    std::vector<cv::Vec3d> fovBottomTop(6);
+    std::vector<cv::Vec3d>::iterator itFov = fovBottomTop.begin();
+    for (size_t iBottomTop = 0; iBottomTop < 2; ++iBottomTop)
+    {
+        // mapping sensor to field of view
+        *itFov = cv::Vec3d(0,yImage[iBottomTop],zImage[iBottomTop]);
+        *itFov *= magnification((*itFov)(2));
+        ++itFov;
+        for (size_t iNearFar = 0; iNearFar < 2; ++iNearFar, ++itFov)
+        {
+            // scaling to the near and far distance on the
+            // image side
+            *itFov = cv::Vec3d(0,yImage[iBottomTop],zImage[iBottomTop]) *
+                nearFarFactorImage[iNearFar];
+            // scaling to the object side
+            *itFov *= magnification((*itFov)(2));
+        }
+    }
+    m_fovCenter.resize(3);
+    m_fovNormal.resize(3);
+    for (size_t i = 0; i < 3; ++i)
+    {
+        m_fovCenter[i] = .5*(fovBottomTop[i] + fovBottomTop[i+3]);
+        m_fovNormal[i] = fovBottomTop[i+3] - fovBottomTop[i];
+        m_fovNormal[i] = cv::normalize(m_fovNormal[i]);
+        m_fovNormal[i] = cv::Vec3d(
+            m_fovNormal[i](0),
+            -m_fovNormal[i](2),
+            m_fovNormal[i](1));
+        // one target position in each plane
+        m_pointTargetTvec.push_back(m_fovCenter[i]);
+        cv::Vec3d rvec = cv::Vec3d(0,0,1).cross(m_fovNormal[i]);
+        rvec = cv::normalize(rvec);
+        rvec *= acos(m_fovNormal[i](2));
+        m_pointTargetRvec.push_back(rvec);
+    }
+    // calibration target
+    size_t num = 2*m_pointTargetNum + 1;
+    m_pointTarget.resize(num*num);
+    std::vector<cv::Point3d>::iterator itTarget = m_pointTarget.begin();
+    for (int iY = -m_pointTargetNum; iY <= m_pointTargetNum; ++iY)
+    {
+        for (int iX = -m_pointTargetNum; iX <= m_pointTargetNum; ++iX, ++itTarget)
+        {
+            *itTarget = cv::Point3d(iX, iY, 0) * m_pointTargetDist;
+        }
+    }
+    // oblique target positions
+    // approximate distance to the near and far plane
+    double dist = std::max(
+        std::abs(m_fovNormal[0].dot(m_fovCenter[0] - m_fovCenter[1])),
+        std::abs(m_fovNormal[0].dot(m_fovCenter[0] - m_fovCenter[2])));
+    // maximal angle such that target border "reaches" near and far plane
+    double maxAngle = atan2(dist, m_pointTargetNum*m_pointTargetDist);
+    std::vector<double> angle;
+    angle.push_back(-maxAngle);
+    angle.push_back(maxAngle);
+    cv::Matx33d baseMatrix;
+    cv::Rodrigues(m_pointTargetRvec.front(), baseMatrix);
+    for (double a : angle)
+    {
+        cv::Matx33d rmat;
+        for (size_t i = 0; i < 2; ++i)
+        {
+            cv::Vec3d rvec(0,0,0);
+            rvec(i) = a;
+            cv::Rodrigues(rvec, rmat);
+            rmat = baseMatrix*rmat;
+            cv::Rodrigues(rmat, rvec);
+            m_pointTargetTvec.push_back(m_fovCenter.front());
+            m_pointTargetRvec.push_back(rvec);
+        }
+    }
+    // camera matrix
+    double cx = .5 * (m_imageSize.width - 1);
+    double cy = .5 * (m_imageSize.height - 1);
+    double f = m_imageDistance/m_pixelSize;
+    m_cameraMatrix = cv::Matx33d(
+        f,0,cx,
+        0,f,cy,
+        0,0,1);
+    // distortion coefficients
+    m_distortionCoeff = cv::Vec<double, NUM_DIST_COEFF_TILT>::all(0);
+    // tauX
+    m_distortionCoeff(12) = -m_toRadian*m_imageTiltDegree;
+
+}
+
+void cameraCalibrationTiltTest::numericalDerivative(
+    cv::Mat& jac,
+    double eps,
+    const std::vector<cv::Point3d>& obj,
+    const cv::Vec3d& rvec,
+    const cv::Vec3d& tvec,
+    const cv::Matx33d& camera,
+    const cv::Vec<double, NUM_DIST_COEFF_TILT>& distor)
+{
+    cv::Vec3d r(rvec);
+    cv::Vec3d t(tvec);
+    cv::Matx33d cm(camera);
+    cv::Vec<double, NUM_DIST_COEFF_TILT> dc(distor);
+    double* param[10+NUM_DIST_COEFF_TILT] = {
+        &r(0), &r(1), &r(2),
+        &t(0), &t(1), &t(2),
+        &cm(0,0), &cm(1,1), &cm(0,2), &cm(1,2),
+        &dc(0), &dc(1), &dc(2), &dc(3), &dc(4), &dc(5), &dc(6),
+        &dc(7), &dc(8), &dc(9), &dc(10), &dc(11), &dc(12), &dc(13)};
+    std::vector<cv::Point2d> pix0, pix1;
+    double invEps = .5/eps;
+
+    for (size_t col = 0; col < 10+NUM_DIST_COEFF_TILT; ++col)
+    {
+        double save = *(param[col]);
+        *(param[col]) = save + eps;
+        cv::projectPoints(obj, r, t, cm, dc, pix0);
+        *(param[col]) = save - eps;
+        cv::projectPoints(obj, r, t, cm, dc, pix1);
+        *(param[col]) = save;
+
+        auto it0 = pix0.begin();
+        auto it1 = pix1.begin();
+        size_t row = 0;
+        for (;it0 != pix0.end(); ++it0, ++it1)
+        {
+            auto d = invEps*(*it0 - *it1);
+            jac.at<double>(row, col) = d.x;
+            ++row;
+            jac.at<double>(row, col) = d.y;
+            ++row;
+        }
+    }
+}
+
+void cameraCalibrationTiltTest::removeInvalidPoints(
+    std::vector<cv::Point2d>& imagePoints,
+    std::vector<cv::Point3d>& objectPoints)
+{
+    // remove object and imgage points out of range
+    auto itImg = imagePoints.begin();
+    auto itObj = objectPoints.begin();
+    while (itImg != imagePoints.end())
+    {
+        bool ok =
+            itImg->x >= 0 &&
+            itImg->x <= m_imageSize.width - 1.0 &&
+            itImg->y >= 0 &&
+            itImg->y <= m_imageSize.height - 1.0;
+        if (ok)
+        {
+            ++itImg;
+            ++itObj;
+        }
+        else
+        {
+            itImg = imagePoints.erase(itImg);
+            itObj = objectPoints.erase(itObj);
+        }
+    }
+}
+
+void cameraCalibrationTiltTest::addNoiseRemoveInvalidPoints(
+    std::vector<cv::Point2f>& imagePoints,
+    std::vector<cv::Point3f>& objectPoints,
+    std::vector<cv::Point2f>& noisyImagePoints,
+    double halfWidthNoise)
+{
+    auto itImg = imagePoints.begin();
+    auto itObj = objectPoints.begin();
+    noisyImagePoints.clear();
+    noisyImagePoints.reserve(imagePoints.size());
+    while (itImg != imagePoints.end())
+    {
+        cv::Point2f pix = *itImg + cv::Point2f(
+            m_rng.uniform(-halfWidthNoise, halfWidthNoise),
+            m_rng.uniform(-halfWidthNoise, halfWidthNoise));
+        bool ok =
+            pix.x >= 0 &&
+            pix.x <= m_imageSize.width - 1.0 &&
+            pix.y >= 0 &&
+            pix.y <= m_imageSize.height - 1.0;
+        if (ok)
+        {
+            noisyImagePoints.push_back(pix);
+            ++itImg;
+            ++itObj;
+        }
+        else
+        {
+            itImg = imagePoints.erase(itImg);
+            itObj = objectPoints.erase(itObj);
+        }
+    }
+}
+
+
+TEST_F(cameraCalibrationTiltTest, projectPoints)
+{
+    std::vector<cv::Point2d> imagePoints;
+    auto objectPoints = m_pointTarget;
+    auto rvec = m_pointTargetRvec.front();
+    auto tvec = m_pointTargetTvec.front();
+
+    cv::Vec<double, NUM_DIST_COEFF_TILT> coeffNoiseHalfWidth(
+        .1, .1, // k1 k2
+        .01, .01, // p1 p2
+        .001, .001, .001, .001, // k3 k4 k5 k6
+        .001, .001, .001, .001, // s1 s2 s3 s4
+        .01, .01); // tauX tauY
+    for (size_t numTest = 0; numTest < 10; ++numTest)
+    {
+        // create random distortion coefficients
+        auto distortionCoeff = m_distortionCoeff;
+        randomDistortionCoeff(distortionCoeff, coeffNoiseHalfWidth);
+
+        // projection
+        cv::projectPoints(
+            objectPoints,
+            rvec,
+            tvec,
+            m_cameraMatrix,
+            distortionCoeff,
+            imagePoints);
+
+        // remove object and imgage points out of range
+        removeInvalidPoints(imagePoints, objectPoints);
+
+        size_t numPoints = imagePoints.size();
+        size_t numParams = 10 + distortionCoeff.rows;
+        cv::Mat jacobian(2*numPoints, numParams, CV_64FC1);
+
+        // projection and jacobian
+        cv::projectPoints(
+            objectPoints,
+            rvec,
+            tvec,
+            m_cameraMatrix,
+            distortionCoeff,
+            imagePoints,
+            jacobian);
+
+        // numerical derivatives
+        cv::Mat numericJacobian(2*numPoints, numParams, CV_64FC1);
+        double eps = 1e-7;
+        numericalDerivative(
+            numericJacobian,
+            eps,
+            objectPoints,
+            rvec,
+            tvec,
+            m_cameraMatrix,
+            distortionCoeff);
+
+#if 0
+        for (size_t row = 0; row < 2; ++row)
+        {
+            std::cout << "------ Row = " << row << " ------\n";
+            for (size_t i = 0; i < 10+NUM_DIST_COEFF_TILT; ++i)
+            {
+                std::cout << i
+                    << "  jac = " << jacobian.at<double>(row,i)
+                    << "  num = " << numericJacobian.at<double>(row,i)
+                    << "  rel. diff = " << abs(numericJacobian.at<double>(row,i) - jacobian.at<double>(row,i))/abs(numericJacobian.at<double>(row,i))
+                    << "\n";
+            }
+        }
+#endif
+        // relative difference for large values (rvec and tvec)
+        cv::Mat check = abs(jacobian(cv::Range::all(), cv::Range(0,6)) - numericJacobian(cv::Range::all(), cv::Range(0,6)))/
+            (1 + abs(jacobian(cv::Range::all(), cv::Range(0,6))));
+        double minVal, maxVal;
+        cv::minMaxIdx(check, &minVal, &maxVal);
+        EXPECT_LE(maxVal, .01);
+        // absolute difference for distortion and camera matrix
+        EXPECT_MAT_NEAR(jacobian(cv::Range::all(), cv::Range(6,numParams)), numericJacobian(cv::Range::all(), cv::Range(6,numParams)), 1e-5);
+    }
+}
+
+TEST_F(cameraCalibrationTiltTest, undistortPoints)
+{
+    cv::Vec<double, NUM_DIST_COEFF_TILT> coeffNoiseHalfWidth(
+        .2, .1, // k1 k2
+        .01, .01, // p1 p2
+        .01, .01, .01, .01, // k3 k4 k5 k6
+        .001, .001, .001, .001, // s1 s2 s3 s4
+        .001, .001); // tauX tauY
+    double step = 99;
+    double toleranceBackProjection = 1e-5;
+
+    for (size_t numTest = 0; numTest < 10; ++numTest)
+    {
+        auto distortionCoeff = m_distortionCoeff;
+        randomDistortionCoeff(distortionCoeff, coeffNoiseHalfWidth);
+
+        // distorted points
+        std::vector<cv::Point2d> distorted;
+        for (double x = 0; x <= m_imageSize.width-1; x += step)
+            for (double y = 0; y <= m_imageSize.height-1; y += step)
+                distorted.push_back(cv::Point2d(x,y));
+        std::vector<cv::Point2d> normalizedUndistorted;
+
+        // undistort
+        cv::undistortPoints(distorted,
+            normalizedUndistorted,
+            m_cameraMatrix,
+            distortionCoeff);
+
+        // copy normalized points to 3D
+        std::vector<cv::Point3d> objectPoints;
+        for (auto& pnt : normalizedUndistorted)
+            objectPoints.push_back(cv::Point3d(pnt.x, pnt.y, 1));
+
+        // project
+        std::vector<cv::Point2d> imagePoints(objectPoints.size());
+        cv::projectPoints(objectPoints,
+            cv::Vec3d(0,0,0),
+            cv::Vec3d(0,0,0),
+            m_cameraMatrix,
+            distortionCoeff,
+            imagePoints);
+
+        EXPECT_MAT_NEAR(distorted, imagePoints, toleranceBackProjection);
+    }
+}
+
+template <typename INPUT, typename ESTIMATE>
+void show(const std::string& name, const INPUT in, const ESTIMATE est)
+{
+    std::cout << name << " = " << est << " (init = " << in
+        << ", diff = " << est-in << ")\n";
+}
+
+template <typename INPUT, typename ESTIMATE>
+void showVec(const std::string& name, const INPUT& in, const ESTIMATE& est)
+{
+
+    for (size_t i = 0; i < in.channels; ++i)
+    {
+        std::stringstream ss;
+        ss << name << "[" << i << "]";
+        show(ss.str(), in(i), est.at<double>(i));
+    }
+}
+
+/**
+For given camera matrix and distortion coefficients
+- project point target in different positions onto the sensor
+- add pixel noise
+- estimate camera modell with noisy measurements
+- compare result with initial model parameter
+
+Parameter are differently affected by the noise
+*/
+TEST_F(cameraCalibrationTiltTest, calibrateCamera)
+{
+    cv::Vec<double, NUM_DIST_COEFF_TILT> coeffNoiseHalfWidth(
+        .2, .1, // k1 k2
+        .01, .01, // p1 p2
+        0, 0, 0, 0, // k3 k4 k5 k6
+        .001, .001, .001, .001, // s1 s2 s3 s4
+        .001, .001); // tauX tauY
+    double pixelNoiseHalfWidth = .5;
+    std::vector<cv::Point3f> pointTarget;
+    pointTarget.reserve(m_pointTarget.size());
+    for (auto it = m_pointTarget.begin(); it != m_pointTarget.end(); ++it)
+        pointTarget.push_back(cv::Point3f(it->x, it->y, it->z));
+
+    for (size_t numTest = 0; numTest < 5; ++numTest)
+    {
+        // create random distortion coefficients
+        auto distortionCoeff = m_distortionCoeff;
+        randomDistortionCoeff(distortionCoeff, coeffNoiseHalfWidth);
+
+        // container for calibration data
+        std::vector<std::vector<cv::Point3f>> viewsObjectPoints;
+        std::vector<std::vector<cv::Point2f>> viewsImagePoints;
+        std::vector<std::vector<cv::Point2f>> viewsNoisyImagePoints;
+
+        // simulate calibration data with projectPoints
+        auto itRvec = m_pointTargetRvec.begin();
+        auto itTvec = m_pointTargetTvec.begin();
+        // loop over different views
+        for (;itRvec != m_pointTargetRvec.end(); ++ itRvec, ++itTvec)
+        {
+            std::vector<cv::Point3f> objectPoints(pointTarget);
+            std::vector<cv::Point2f> imagePoints;
+            std::vector<cv::Point2f> noisyImagePoints;
+            // project calibration target to sensor
+            cv::projectPoints(
+                objectPoints,
+                *itRvec,
+                *itTvec,
+                m_cameraMatrix,
+                distortionCoeff,
+                imagePoints);
+            // remove invisible points
+            addNoiseRemoveInvalidPoints(
+                imagePoints,
+                objectPoints,
+                noisyImagePoints,
+                pixelNoiseHalfWidth);
+            // add data for view
+            viewsNoisyImagePoints.push_back(noisyImagePoints);
+            viewsImagePoints.push_back(imagePoints);
+            viewsObjectPoints.push_back(objectPoints);
+        }
+
+        // Output
+        std::vector<cv::Mat> outRvecs, outTvecs;
+        cv::Mat outCameraMatrix(3, 3, CV_64F, cv::Scalar::all(1)), outDistCoeff;
+
+        // Stopping criteria
+        cv::TermCriteria stop(
+            cv::TermCriteria::COUNT+cv::TermCriteria::EPS,
+            50000,
+            1e-14);
+        // modell coice
+        int flag =
+            cv::CALIB_FIX_ASPECT_RATIO |
+            // cv::CALIB_RATIONAL_MODEL |
+            cv::CALIB_FIX_K3 |
+            // cv::CALIB_FIX_K6 |
+            cv::CALIB_THIN_PRISM_MODEL |
+            cv::CALIB_TILTED_MODEL;
+        // estimate
+        double backProjErr = cv::calibrateCamera(
+            viewsObjectPoints,
+            viewsNoisyImagePoints,
+            m_imageSize,
+            outCameraMatrix,
+            outDistCoeff,
+            outRvecs,
+            outTvecs,
+            flag,
+            stop);
+
+        EXPECT_LE(backProjErr, pixelNoiseHalfWidth);
+
+#if 0
+        std::cout << "------ estimate ------\n";
+        std::cout << "back projection error = " << backProjErr << "\n";
+        std::cout << "points per view = {" << viewsObjectPoints.front().size();
+        for (size_t i = 1; i < viewsObjectPoints.size(); ++i)
+            std::cout << ", " << viewsObjectPoints[i].size();
+        std::cout << "}\n";
+        show("fx", m_cameraMatrix(0,0), outCameraMatrix.at<double>(0,0));
+        show("fy", m_cameraMatrix(1,1), outCameraMatrix.at<double>(1,1));
+        show("cx", m_cameraMatrix(0,2), outCameraMatrix.at<double>(0,2));
+        show("cy", m_cameraMatrix(1,2), outCameraMatrix.at<double>(1,2));
+        showVec("distor", distortionCoeff, outDistCoeff);
+#endif
+        if (pixelNoiseHalfWidth > 0)
+        {
+            double tolRvec = pixelNoiseHalfWidth;
+            double tolTvec = m_objectDistance * tolRvec;
+            // back projection error
+            for (size_t i = 0; i < viewsNoisyImagePoints.size(); ++i)
+            {
+                double dRvec = norm(
+                    m_pointTargetRvec[i] -
+                    cv::Vec3d(
+                    outRvecs[i].at<double>(0),
+                    outRvecs[i].at<double>(1),
+                    outRvecs[i].at<double>(2)));
+                // std::cout << dRvec << "  " << tolRvec << "\n";
+                EXPECT_LE(dRvec,
+                    tolRvec);
+                double dTvec = norm(
+                    m_pointTargetTvec[i] -
+                    cv::Vec3d(
+                    outTvecs[i].at<double>(0),
+                    outTvecs[i].at<double>(1),
+                    outTvecs[i].at<double>(2)));
+                // std::cout << dTvec << "  " << tolTvec << "\n";
+                EXPECT_LE(dTvec,
+                    tolTvec);
+
+                std::vector<cv::Point2f> backProjection;
+                cv::projectPoints(
+                    viewsObjectPoints[i],
+                    outRvecs[i],
+                    outTvecs[i],
+                    outCameraMatrix,
+                    outDistCoeff,
+                    backProjection);
+                EXPECT_MAT_NEAR(backProjection, viewsNoisyImagePoints[i], 1.5*pixelNoiseHalfWidth);
+                EXPECT_MAT_NEAR(backProjection, viewsImagePoints[i], 1.5*pixelNoiseHalfWidth);
+            }
+        }
+        pixelNoiseHalfWidth *= .25;
+    }
+}

--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -117,6 +117,10 @@ public:
     Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3,
          _Tp v4, _Tp v5, _Tp v6, _Tp v7,
          _Tp v8, _Tp v9, _Tp v10, _Tp v11,
+         _Tp v12, _Tp v13); //!< 1x14, 2x7, 7x2 or 14x1 matrix
+    Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3,
+         _Tp v4, _Tp v5, _Tp v6, _Tp v7,
+         _Tp v8, _Tp v9, _Tp v10, _Tp v11,
          _Tp v12, _Tp v13, _Tp v14, _Tp v15); //!< 1x16, 4x4 or 16x1 matrix
     explicit Matx(const _Tp* vals); //!< initialize from a plain array
 
@@ -319,6 +323,7 @@ public:
     Vec(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7); //!< 8-element vector constructor
     Vec(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8); //!< 9-element vector constructor
     Vec(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8, _Tp v9); //!< 10-element vector constructor
+    Vec(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8, _Tp v9, _Tp v10, _Tp v11, _Tp v12, _Tp v13); //!< 14-element vector constructor
     explicit Vec(const _Tp* values);
 
     Vec(const Vec<_Tp, cn>& v);
@@ -579,6 +584,17 @@ Matx<_Tp,m,n>::Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp 
     val[4] = v4; val[5] = v5; val[6] = v6; val[7] = v7;
     val[8] = v8; val[9] = v9; val[10] = v10; val[11] = v11;
 }
+
+template<typename _Tp, int m, int n> inline
+Matx<_Tp,m,n>::Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8, _Tp v9, _Tp v10, _Tp v11, _Tp v12, _Tp v13)
+{
+    CV_StaticAssert(channels == 14, "Matx should have at least 14 elements.");
+    val[0] = v0; val[1] = v1; val[2] = v2; val[3] = v3;
+    val[4] = v4; val[5] = v5; val[6] = v6; val[7] = v7;
+    val[8] = v8; val[9] = v9; val[10] = v10; val[11] = v11;
+    val[12] = v12; val[13] = v13;
+}
+
 
 template<typename _Tp, int m, int n> inline
 Matx<_Tp,m,n>::Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8, _Tp v9, _Tp v10, _Tp v11, _Tp v12, _Tp v13, _Tp v14, _Tp v15)
@@ -920,6 +936,10 @@ Vec<_Tp, cn>::Vec(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7
 template<typename _Tp, int cn> inline
 Vec<_Tp, cn>::Vec(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8, _Tp v9)
     : Matx<_Tp, cn, 1>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9) {}
+
+template<typename _Tp, int cn> inline
+Vec<_Tp, cn>::Vec(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8, _Tp v9, _Tp v10, _Tp v11, _Tp v12, _Tp v13)
+    : Matx<_Tp, cn, 1>(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) {}
 
 template<typename _Tp, int cn> inline
 Vec<_Tp, cn>::Vec(const _Tp* values)

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2596,8 +2596,8 @@ the same.
 @param dst Output (corrected) image that has the same size and type as src .
 @param cameraMatrix Input camera matrix \f$A = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$ .
 @param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6]])\f$ of 4, 5, or 8 elements. If the vector is
-NULL/empty, the zero distortion coefficients are assumed.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6[, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$
+of 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are assumed.
 @param newCameraMatrix Camera matrix of the distorted image. By default, it is the same as
 cameraMatrix but you may additionally scale and shift the result by using a different matrix.
  */
@@ -2623,8 +2623,28 @@ The function actually builds the maps for the inverse mapping algorithm that is 
 is, for each pixel \f$(u, v)\f$ in the destination (corrected and rectified) image, the function
 computes the corresponding coordinates in the source image (that is, in the original image from
 camera). The following process is applied:
-\f[\begin{array}{l} x  \leftarrow (u - {c'}_x)/{f'}_x  \\ y  \leftarrow (v - {c'}_y)/{f'}_y  \\{[X\,Y\,W]} ^T  \leftarrow R^{-1}*[x \, y \, 1]^T  \\ x'  \leftarrow X/W  \\ y'  \leftarrow Y/W  \\ x"  \leftarrow x' (1 + k_1 r^2 + k_2 r^4 + k_3 r^6) + 2p_1 x' y' + p_2(r^2 + 2 x'^2)  \\ y"  \leftarrow y' (1 + k_1 r^2 + k_2 r^4 + k_3 r^6) + p_1 (r^2 + 2 y'^2) + 2 p_2 x' y'  \\ map_x(u,v)  \leftarrow x" f_x + c_x  \\ map_y(u,v)  \leftarrow y" f_y + c_y \end{array}\f]
-where \f$(k_1, k_2, p_1, p_2[, k_3])\f$ are the distortion coefficients.
+\f[
+\begin{array}{l}
+x  \leftarrow (u - {c'}_x)/{f'}_x  \\
+y  \leftarrow (v - {c'}_y)/{f'}_y  \\
+{[X\,Y\,W]} ^T  \leftarrow R^{-1}*[x \, y \, 1]^T  \\
+x'  \leftarrow X/W  \\
+y'  \leftarrow Y/W  \\
+r^2  \leftarrow x'^2 + y'^2 \\
+x''  \leftarrow x' \frac{1 + k_1 r^2 + k_2 r^4 + k_3 r^6}{1 + k_4 r^2 + k_5 r^4 + k_6 r^6}
++ 2p_1 x' y' + p_2(r^2 + 2 x'^2)  + s_1 r^2 + s_2 r^4\\
+y''  \leftarrow y' \frac{1 + k_1 r^2 + k_2 r^4 + k_3 r^6}{1 + k_4 r^2 + k_5 r^4 + k_6 r^6}
++ p_1 (r^2 + 2 y'^2) + 2 p_2 x' y' + s_3 r^2 + s_4 r^4 \\
+s\vecthree{x'''}{y'''}{1} =
+\vecthreethree{R_{33}(\tau_x, \tau_y)}{0}{-R_{13}((\tau_x, \tau_y)}
+{0}{R_{33}(\tau_x, \tau_y)}{-R_{23}(\tau_x, \tau_y)}
+{0}{0}{1} R(\tau_x, \tau_y) \vecthree{x''}{y''}{1}\\
+map_x(u,v)  \leftarrow x''' f_x + c_x  \\
+map_y(u,v)  \leftarrow y''' f_y + c_y
+\end{array}
+\f]
+where \f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6[, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$
+are the distortion coefficients.
 
 In case of a stereo camera, this function is called twice: once for each camera head, after
 stereoRectify, which in its turn is called after cv::stereoCalibrate. But if the stereo camera
@@ -2637,8 +2657,8 @@ where cameraMatrix can be chosen arbitrarily.
 
 @param cameraMatrix Input camera matrix \f$A=\vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$ .
 @param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6]])\f$ of 4, 5, or 8 elements. If the vector is
-NULL/empty, the zero distortion coefficients are assumed.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6[, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$
+of 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are assumed.
 @param R Optional rectification transformation in the object space (3x3 matrix). R1 or R2 ,
 computed by stereoRectify can be passed here. If the matrix is empty, the identity transformation
 is assumed. In cvInitUndistortMap R assumed to be an identity matrix.
@@ -2713,8 +2733,8 @@ The function can be used for both a stereo camera head or a monocular camera (wh
 transformation. If matrix P is identity or omitted, dst will contain normalized point coordinates.
 @param cameraMatrix Camera matrix \f$\vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$ .
 @param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6]])\f$ of 4, 5, or 8 elements. If the vector is
-NULL/empty, the zero distortion coefficients are assumed.
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6[, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$
+of 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are assumed.
 @param R Rectification transformation in the object space (3x3 matrix). R1 or R2 computed by
 cv::stereoRectify can be passed here. If the matrix is empty, the identity transformation is used.
 @param P New camera matrix (3x3) or new projection matrix (3x4). P1 or P2 computed by

--- a/modules/imgproc/include/opencv2/imgproc/detail/distortion_model.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/detail/distortion_model.hpp
@@ -1,0 +1,125 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef __OPENCV_IMGPROC_DETAIL_DISTORTION_MODEL_HPP__
+#define __OPENCV_IMGPROC_DETAIL_DISTORTION_MODEL_HPP__
+
+#include "precomp.hpp"
+
+//! @cond IGNORED
+
+namespace cv { namespace detail {
+/**
+Computes the matrix for the projection onto a tilted image sensor
+\param tauX angular parameter rotation around x-axis
+\param tauY angular parameter rotation around y-axis
+\param matTilt if not NULL returns the matrix
+\f[
+\vecthreethree{R_{33}(\tau_x, \tau_y)}{0}{-R_{13}((\tau_x, \tau_y)}
+{0}{R_{33}(\tau_x, \tau_y)}{-R_{23}(\tau_x, \tau_y)}
+{0}{0}{1} R(\tau_x, \tau_y)
+\f]
+where
+\f[
+R(\tau_x, \tau_y) =
+\vecthreethree{\cos(\tau_y)}{0}{-\sin(\tau_y)}{0}{1}{0}{\sin(\tau_y)}{0}{\cos(\tau_y)}
+\vecthreethree{1}{0}{0}{0}{\cos(\tau_x)}{\sin(\tau_x)}{0}{-\sin(\tau_x)}{\cos(\tau_x)} =
+\vecthreethree{\cos(\tau_y)}{\sin(\tau_y)\sin(\tau_x)}{-\sin(\tau_y)\cos(\tau_x)}
+{0}{\cos(\tau_x)}{\sin(\tau_x)}
+{\sin(\tau_y)}{-\cos(\tau_y)\sin(\tau_x)}{\cos(\tau_y)\cos(\tau_x)}.
+\f]
+\param dMatTiltdTauX if not NULL it returns the derivative of matTilt with
+respect to \f$\tau_x\f$.
+\param dMatTiltdTauY if not NULL it returns the derivative of matTilt with
+respect to \f$\tau_y\f$.
+\param invMatTilt if not NULL it returns the inverse of matTilt
+**/
+template <typename FLOAT>
+void computeTiltProjectionMatrix(FLOAT tauX,
+    FLOAT tauY,
+    Matx<FLOAT, 3, 3>* matTilt = 0,
+    Matx<FLOAT, 3, 3>* dMatTiltdTauX = 0,
+    Matx<FLOAT, 3, 3>* dMatTiltdTauY = 0,
+    Matx<FLOAT, 3, 3>* invMatTilt = 0)
+{
+    FLOAT cTauX = cos(tauX);
+    FLOAT sTauX = sin(tauX);
+    FLOAT cTauY = cos(tauY);
+    FLOAT sTauY = sin(tauY);
+    Matx<FLOAT, 3, 3> matRotX = Matx<FLOAT, 3, 3>(1,0,0,0,cTauX,sTauX,0,-sTauX,cTauX);
+    Matx<FLOAT, 3, 3> matRotY = Matx<FLOAT, 3, 3>(cTauY,0,-sTauY,0,1,0,sTauY,0,cTauY);
+    Matx<FLOAT, 3, 3> matRotXY = matRotY * matRotX;
+    Matx<FLOAT, 3, 3> matProjZ = Matx<FLOAT, 3, 3>(matRotXY(2,2),0,-matRotXY(0,2),0,matRotXY(2,2),-matRotXY(1,2),0,0,1);
+    if (matTilt)
+    {
+        // Matrix for trapezoidal distortion of tilted image sensor
+        *matTilt = matProjZ * matRotXY;
+    }
+    if (dMatTiltdTauX)
+    {
+        // Derivative with respect to tauX
+        Matx<FLOAT, 3, 3> dMatRotXYdTauX = matRotY * Matx<FLOAT, 3, 3>(0,0,0,0,-sTauX,cTauX,0,-cTauX,-sTauX);
+        Matx<FLOAT, 3, 3> dMatProjZdTauX = Matx<FLOAT, 3, 3>(dMatRotXYdTauX(2,2),0,-dMatRotXYdTauX(0,2),
+          0,dMatRotXYdTauX(2,2),-dMatRotXYdTauX(1,2),0,0,0);
+        *dMatTiltdTauX = (matProjZ * dMatRotXYdTauX) + (dMatProjZdTauX * matRotXY);
+    }
+    if (dMatTiltdTauY)
+    {
+        // Derivative with respect to tauY
+        Matx<FLOAT, 3, 3> dMatRotXYdTauY = Matx<FLOAT, 3, 3>(-sTauY,0,-cTauY,0,0,0,cTauY,0,-sTauY) * matRotX;
+        Matx<FLOAT, 3, 3> dMatProjZdTauY = Matx<FLOAT, 3, 3>(dMatRotXYdTauY(2,2),0,-dMatRotXYdTauY(0,2),
+          0,dMatRotXYdTauY(2,2),-dMatRotXYdTauY(1,2),0,0,0);
+        *dMatTiltdTauY = (matProjZ * dMatRotXYdTauY) + (dMatProjZdTauY * matRotXY);
+    }
+    if (invMatTilt)
+    {
+        FLOAT inv = 1./matRotXY(2,2);
+        Matx<FLOAT, 3, 3> invMatProjZ = Matx<FLOAT, 3, 3>(inv,0,inv*matRotXY(0,2),0,inv,inv*matRotXY(1,2),0,0,1);
+        *invMatTilt = matRotXY.t()*invMatProjZ;
+    }
+}
+}} // namespace detail, cv
+
+
+//! @endcond
+
+#endif // __OPENCV_IMGPROC_DETAIL_DISTORTION_MODEL_HPP__

--- a/modules/imgproc/include/opencv2/imgproc/detail/distortion_model.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/detail/distortion_model.hpp
@@ -43,8 +43,6 @@
 #ifndef __OPENCV_IMGPROC_DETAIL_DISTORTION_MODEL_HPP__
 #define __OPENCV_IMGPROC_DETAIL_DISTORTION_MODEL_HPP__
 
-#include "precomp.hpp"
-
 //! @cond IGNORED
 
 namespace cv { namespace detail {


### PR DESCRIPTION
#### Motivation
The current camera model assumes that the optical axis of the lens is perpendicular on the image sensor. Consequently, it is perpendicular on the plane of focus of such a camera.

There are situations, where it is usefull that the plane of focus is oblique, e.g. laser triangulation or particle image velocimetry. Using the Scheimpflug principle, one can tilt the image plane such that image, lens and focus plane intersect in a common line.

For a pinhole model a tilted image sensor yields a principal point far from the center of the sensor. It is the point of the image plane, which is closest (euklidian distance) to the center of projection. Yet, it does not represent a point close to the optical axis of the lens suitable e.g. for modeling radial distortion. That is why for such a situation we propose an extension of the current camera distortion model.  

#### Extended Model
The idea is that there is a virtual image plane (z = 1) perpendicular to th optical axis. The current model with distortion maps object points onto this image plane. In a next step a projection depending on two rotation parameter maps points from the virtual image plane to a tilted one. Finally, using the camera matrix one obtains pixel values. 

#### Changes
There are two more distortion parameters. Model changes affect the mapping from 3D to pixel (projectPoints) and its Jacobian (necessary for calibrateCamera, etc.) and the inverse map (undistortPoints). There are test for these three functionalities.