### PR TITLE
[2.4] remove some functions that have no implementation

### DIFF
--- a/modules/features2d/include/opencv2/features2d/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d/features2d.hpp
@@ -423,8 +423,6 @@ public:
            float patternScale = 22.0f,
            int nOctaves = 4,
            const vector<int>& selectedPairs = vector<int>());
-    FREAK( const FREAK& rhs );
-    FREAK& operator=( const FREAK& );
 
     virtual ~FREAK();
 

--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -79,7 +79,6 @@ CVAPI(void) cvDisplayStatusBar(const char* name, const char* text, int delayms C
 CVAPI(void) cvSaveWindowParameters(const char* name);
 CVAPI(void) cvLoadWindowParameters(const char* name);
 CVAPI(int) cvStartLoop(int (*pt2Func)(int argc, char *argv[]), int argc, char* argv[]);
-CVAPI(void) cvStopLoop( void );
 
 typedef void (CV_CDECL *CvButtonCallback)(int state, void* userdata);
 enum {CV_PUSH_BUTTON = 0, CV_CHECKBOX = 1, CV_RADIOBOX = 2};

--- a/modules/objdetect/include/opencv2/objdetect/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/objdetect.hpp
@@ -887,11 +887,6 @@ protected:
 };
 
 /**
- * \brief Debug function to colormap a quantized image for viewing.
- */
-void colormap(const Mat& quantized, Mat& dst);
-
-/**
  * \brief Represents a successful template match.
  */
 struct CV_EXPORTS Match


### PR DESCRIPTION
These functions are only declared in the header files, but do not have implementations in any c(pp) files.