### PR TITLE
Add link to (external) Java tutorials

### DIFF
--- a/doc/root.markdown.in
+++ b/doc/root.markdown.in
@@ -4,6 +4,7 @@ OpenCV modules {#mainpage}
 - @ref intro
 - @ref tutorial_root
 - @ref tutorial_py_root
+- <a href="http://opencv-java-tutorials.readthedocs.org/" class="el">OpenCV-Java Tutorials</a> (external)
 @CMAKE_DOXYGEN_TUTORIAL_CONTRIB_ROOT@
 - @ref faq
 - @ref citelist


### PR DESCRIPTION
As briefly discussed via mail with @kirill-kornyakov, I would like to add a link to some OpenCV-Java (desktop) tutorials in the OpenCV 3.0 documentation, since few information about the usage of OpenCV with Java desktop are present in the current documentation.

The final goal will be to completely integrate such tutorials in the official documentation (one tutorial at time), after their complete update to OpenCV 3.0 (currently in process).
Moreover, if this pull request will be accepted, I hope to get other contributions to refine the tutorials. Such contributions would be useful for enhancing the tutorials' quality, before proposing a "real" merge into the OpenCV documentation.