### PR TITLE
Fixing for bug #5551 to return empty mask in case of no inliers.

### DIFF
--- a/modules/calib3d/src/fundam.cpp
+++ b/modules/calib3d/src/fundam.cpp
@@ -405,14 +405,14 @@ cv::Mat cv::findHomography( InputArray _points1, InputArray _points2,
         }
     }
 
-    if( result )
+    //Copy empty to mask even if H is empty.
+    if ( _mask.needed() )
+    	tempMask.copyTo(_mask);
+    if ( !result )
     {
-        if( _mask.needed() )
-            tempMask.copyTo(_mask);
+    	H.release();
+	_mask.clear();
     }
-    else
-        H.release();
-
     return H;
 }
 


### PR DESCRIPTION
Removing all the inliers if finding fundamental matrix fails.