### PR TITLE
fix compilation with qt

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -664,7 +664,7 @@ CV_IMPL void cvSetTrackbarMax(const char* name_bar, const char* window_name, int
         QPointer<CvTrackbar> t = icvFindTrackBarByName(name_bar, window_name);
         if (t)
         {
-            int minval = t->slider->getMinimum();
+            int minval = t->slider->minimum();
             maxval = (maxval>minval)?maxval:minval;
             t->slider->setMaximum(maxval);
         }
@@ -679,7 +679,7 @@ CV_IMPL void cvSetTrackbarMin(const char* name_bar, const char* window_name, int
         QPointer<CvTrackbar> t = icvFindTrackBarByName(name_bar, window_name);
         if (t)
         {
-            int maxval = t->slider->getMaximum();
+            int maxval = t->slider->maximum();
             minval = (maxval<minval)?maxval:minval;
             t->slider->setMinimum(minval);
         }


### PR DESCRIPTION
QSlider does not have getMinimum/Maximum getters. Probably was not
compile tested.

Fixup of #5495