### PR TITLE
fix header problem(can't find cstdint) on OSX platform

### DIFF
--- a/modules/hal/include/opencv2/hal/defs.h
+++ b/modules/hal/include/opencv2/hal/defs.h
@@ -270,7 +270,7 @@
 */
 
 #if !defined _MSC_VER && !defined __BORLANDC__
-#  if defined __cplusplus && __cplusplus >= 201103L
+#  if defined __cplusplus && __cplusplus >= 201103L && !defined __APPLE__
 #    include <cstdint>
      typedef std::uint32_t uint;
 #  else


### PR DESCRIPTION
I encounter a problem when compile some node addon on its 4.1.2 version. The compiler will throw a "cstdint" header not found error. This won't show up when doing the normal compilation. And it seems only happened on Mac OS platform, for the `cstdint` header usually locate in `/usr/include/c++/4.x.x/tr1 ` folder but still depends. So I just changed the macro and force it using `stdint.h` on OSX platform.