### PR TITLE
remove support of Video4Linux1 API/ fix memory leaks for V4L2 path

### DIFF
--- a/modules/videoio/CMakeLists.txt
+++ b/modules/videoio/CMakeLists.txt
@@ -101,7 +101,7 @@ endif(HAVE_UNICAP)
 
 if(HAVE_LIBV4L)
   list(APPEND videoio_srcs ${CMAKE_CURRENT_LIST_DIR}/src/cap_libv4l.cpp)
-elseif(HAVE_CAMV4L OR HAVE_CAMV4L2 OR HAVE_VIDEOIO)
+elseif(HAVE_CAMV4L2 OR HAVE_VIDEOIO)
   list(APPEND videoio_srcs ${CMAKE_CURRENT_LIST_DIR}/src/cap_v4l.cpp)
 endif()
 

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1066,60 +1066,17 @@ yuv411p_to_rgb24(int width, int height,
 }
 
 /* convert from 4:2:2 YUYV interlaced to RGB24 */
-/* based on ccvt_yuyv_bgr32() from camstream */
-#define SAT(c) \
-        if (c & (~255)) { if (c < 0) c = 0; else c = 255; }
-
 static void
 yuyv_to_rgb24(int width, int height, unsigned char* src, unsigned char* dst) {
     cvtColor(Mat(height, width, CV_8UC2, src), Mat(height, width, CV_8UC3, dst),
              COLOR_YUV2BGR_YUYV);
 }
 
-static void
+static inline void
 uyvy_to_rgb24 (int width, int height, unsigned char *src, unsigned char *dst)
 {
-   unsigned char *s;
-   unsigned char *d;
-   int l, c;
-   int r, g, b, cr, cg, cb, y1, y2;
-
-   l = height;
-   s = src;
-   d = dst;
-   while (l--) {
-      c = width >> 1;
-      while (c--) {
-         cb = ((*s - 128) * 454) >> 8;
-         cg = (*s++ - 128) * 88;
-         y1 = *s++;
-         cr = ((*s - 128) * 359) >> 8;
-         cg = (cg + (*s++ - 128) * 183) >> 8;
-         y2 = *s++;
-
-         r = y1 + cr;
-         b = y1 + cb;
-         g = y1 - cg;
-         SAT(r);
-         SAT(g);
-         SAT(b);
-
-     *d++ = b;
-     *d++ = g;
-     *d++ = r;
-
-         r = y2 + cr;
-         b = y2 + cb;
-         g = y2 - cg;
-         SAT(r);
-         SAT(g);
-         SAT(b);
-
-     *d++ = b;
-     *d++ = g;
-     *d++ = r;
-      }
-   }
+    cvtColor(Mat(height, width, CV_8UC2, src), Mat(height, width, CV_8UC3, dst),
+             COLOR_YUV2BGR_UYVY);
 }
 #ifdef HAVE_JPEG
 

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -558,6 +558,9 @@ static int v4l2_num_channels(__u32 palette) {
     case V4L2_PIX_FMT_YUYV:
     case V4L2_PIX_FMT_UYVY:
         return 2;
+    case V4L2_PIX_FMT_BGR24:
+    case V4L2_PIX_FMT_RGB24:
+        return 3;
     default:
         return 0;
     }
@@ -1366,16 +1369,10 @@ static void sgbrg2rgb24(long int WIDTH, long int HEIGHT, unsigned char *src, uns
     }
 }
 
-static void
+static inline void
 rgb24_to_rgb24 (int width, int height, unsigned char *src, unsigned char *dst)
 {
-  const int size = width * height;
-  for(int i = 0; i < size; ++i, src += 3, dst += 3)
-  {
-    *(dst + 0) = *(src + 2);
-    *(dst + 1) = *(src + 1);
-    *(dst + 2) = *(src + 0);
-  }
+    cvtColor(Mat(height, width, CV_8UC3, src), Mat(height, width, CV_8UC3, dst), COLOR_RGB2BGR);
 }
 
 #define CLAMP(x)        ((x)<0?0:((x)>255)?255:(x))

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1583,7 +1583,7 @@ static double icvGetPropertyCAM_V4L (const CvCaptureCAM_V4L* capture,
       case CV_CAP_PROP_MODE:
           return capture->palette;
       case CV_CAP_PROP_FORMAT:
-          return CV_8UC3;
+          return CV_MAKETYPE(CV_8U, capture->frame.nChannels);
       case CV_CAP_PROP_CONVERT_RGB:
           return capture->convert_rgb;
       }


### PR DESCRIPTION
the last kernel that allowed compiling this code was 2.6.37 which was
released almost 5 Years ago. So probably it does not get much testing
any more. Furthermore even back then one was better off using the V4L2
API.

The only change touching currently used code is the removal of the
global V4L2_SUPPORT variable.

fixes #5594