### PR TITLE
fix cmake OpenBSD linker libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,7 +490,7 @@ if(UNIX)
     CHECK_INCLUDE_FILE(pthread.h HAVE_LIBPTHREAD)
     if(ANDROID)
       set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} dl m log)
-    elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|NetBSD|DragonFly")
+    elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|NetBSD|DragonFly|OpenBSD")
       set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} m pthread)
     elseif(EMSCRIPTEN)
       # no need to link to system libs with emscripten


### PR DESCRIPTION
OpenBSD needs m and pthread like Net- and FreeBSD.