### PR TITLE
Fix for 32s and 8u copy with mask and IPP9.0.1

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -206,14 +206,18 @@ static void copyMask##suffix(const uchar* src, size_t sstep, const uchar* mask, 
 }
 #endif
 
-
+#if IPP_VERSION_X100 == 901 // bug in IPP 9.0.1
+DEF_COPY_MASK(32sC3, Vec3i)
+DEF_COPY_MASK(8uC3, Vec3b)
+#else
+DEF_COPY_MASK_F(8uC3, Vec3b, 8u_C3MR, Ipp8u)
+DEF_COPY_MASK_F(32sC3, Vec3i, 32s_C3MR, Ipp32s)
+#endif
 DEF_COPY_MASK(8u, uchar)
 DEF_COPY_MASK(16u, ushort)
-DEF_COPY_MASK_F(8uC3, Vec3b, 8u_C3MR, Ipp8u)
 DEF_COPY_MASK_F(32s, int, 32s_C1MR, Ipp32s)
 DEF_COPY_MASK_F(16uC3, Vec3s, 16u_C3MR, Ipp16u)
 DEF_COPY_MASK(32sC2, Vec2i)
-DEF_COPY_MASK_F(32sC3, Vec3i, 32s_C3MR, Ipp32s)
 DEF_COPY_MASK_F(32sC4, Vec4i, 32s_C4MR, Ipp32s)
 DEF_COPY_MASK(32sC6, Vec6i)
 DEF_COPY_MASK(32sC8, Vec8i)


### PR DESCRIPTION
IPP 9.0.1 has optimization bugs in functions ippiCopy_32s_C3MR and ippiCopy_8u_C3MR. These functions calls were disabled.