### PR TITLE
fix solveCubic() on version 3.0.0

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -44,6 +44,7 @@
 #include "precomp.hpp"
 #include "opencl_kernels_core.hpp"
 #include <limits>
+#include <iostream>
 
 namespace cv
 {
@@ -1992,10 +1993,10 @@ int cv::solveCubic( InputArray _coeffs, OutputArray _roots )
         double Qcubed = Q * Q * Q;
         double d = Qcubed - R * R;
 
-        if( d >= 0 )
+        if( d > 0 )
         {
-            double theta = acos(R / std::sqrt(Qcubed));
-            double sqrtQ = std::sqrt(Q);
+            double theta = acos(R / sqrt(Qcubed));
+            double sqrtQ = sqrt(Q);
             double t0 = -2 * sqrtQ;
             double t1 = theta * (1./3);
             double t2 = a1 * (1./3);
@@ -2004,11 +2005,27 @@ int cv::solveCubic( InputArray _coeffs, OutputArray _roots )
             x2 = t0 * cos(t1 + (4.*CV_PI/3)) - t2;
             n = 3;
         }
+        else if( d == 0 )
+        {
+            if(R >= 0)
+            {
+                x0 = -2*pow(R, 1./3) - a1/3;
+                x1 = pow(R, 1./3) - a1/3;
+            }
+            else
+            {
+                x0 = 2*pow(-R, 1./3) - a1/3;
+                x1 = -pow(-R, 1./3) - a1/3;
+            }
+            x2 = 0;
+            n = x0 == x1 ? 1 : 2;
+            x1 = x0 == x1 ? 0 : x1;
+        }
         else
         {
             double e;
-            d = std::sqrt(-d);
-            e = std::pow(d + fabs(R), 0.333333333333);
+            d = sqrt(-d);
+            e = pow(d + fabs(R), 1./3);
             if( R > 0 )
                 e = -e;
             x0 = (e + Q / e) - a1 * (1./3);

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -2330,6 +2330,17 @@ void Core_SolvePolyTest::run( int )
             pass = pass && div < err_eps;
         }
 
+        //test x^3 = 0
+        cv::Mat coeffs_5623(4, 1, CV_64FC1);
+        cv::Mat r_5623(3, 1, CV_64FC2);
+        coeffs_5623.at<double>(0) = 1;
+        coeffs_5623.at<double>(1) = 0;
+        coeffs_5623.at<double>(2) = 0;
+        coeffs_5623.at<double>(3) = 0;
+        double prec_5623 = cv::solveCubic(coeffs_5623, r_5623);
+        pass = pass && r_5623.at<double>(0) == 0 && r_5623.at<double>(1) == 0 && r_5623.at<double>(2) == 0;
+        pass = pass && prec_5623 == 1;
+
         if (!pass)
         {
             ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);


### PR DESCRIPTION
Delta = 0 must be process separately. It should not be added to case when delta > 0.