### PR TITLE
Continue on fixing bug #5623

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -2440,13 +2440,13 @@ int cv::solveCubic( InputArray _coeffs, OutputArray _roots )
         {
             if(R >= 0)
             {
-                x0 = pow(R/4, 1./3) - a1/3;
-                x1 = -pow(2*R, 1./3) - a1/3;
+                x0 = -2*pow(R, 1./3) - a1/3;
+                x1 = pow(R, 1./3) - a1/3;
             }
             else
             {
-                x0 = -pow(-R/4, 1./3) - a1/3;
-                x1 = pow(-2*R, 1./3) - a1/3;
+                x0 = 2*pow(-R, 1./3) - a1/3;
+                x1 = -pow(-R, 1./3) - a1/3;
             }
             x2 = 0;
             n = x0 == x1 ? 1 : 2;


### PR DESCRIPTION
My previous solution just solve the case x^3 = 0 giving "nan" roots. I need to fix some signs to give the right solutions for every cases. For example, The current version will not solve the equation x^3 - x^2 = 0 correctly.