### PR TITLE
Fix run.py test detection issues for debug VS configurations

### DIFF
--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     parser.add_argument("--list", action="store_true", default=False, help="List available tests (executables)")
     parser.add_argument("--list_short", action="store_true", default=False, help="List available tests (aliases)")
     parser.add_argument("--list_short_main", action="store_true", default=False, help="List available tests (main repository, aliases)")
-    parser.add_argument("--configuration", metavar="CFG", default="", help="Visual Studio: force Debug or Release configuration")
+    parser.add_argument("--configuration", metavar="CFG", default=None, help="Force Debug or Release configuration (for Visual Studio and Java tests build)")
     parser.add_argument("-n", "--dry_run", action="store_true", help="Do not run the tests")
     parser.add_argument("-v", "--verbose", action="store_true", default=False, help="Print more debug information")
 
@@ -95,12 +95,12 @@ if __name__ == "__main__":
         try:
             if not os.path.isdir(path):
                 raise Err("Not a directory (should contain CMakeCache.txt ot test executables)")
-            cache = CMakeCache()
+            cache = CMakeCache(args.configuration)
             fname = os.path.join(path, "CMakeCache.txt")
 
             if os.path.isfile(fname):
                 log.debug("Reading cmake cache file: %s", fname)
-                cache.read(path, fname, args.configuration)
+                cache.read(path, fname)
             else:
                 log.debug("Assuming folder contains tests: %s", path)
                 cache.setDummy(path)

--- a/modules/ts/misc/run_suite.py
+++ b/modules/ts/misc/run_suite.py
@@ -66,7 +66,9 @@ class TestSuite(object):
         res.append(fname) # filename (opencv_test_core.exe)
         for s in getCuts(fname, self.nameprefix):
             res.append(s)
-            res.append(re.sub(r"d$", '', s)) # MSVC debug config, remove 'd' suffix
+            if self.cache.build_type == "Debug":
+                res.append(re.sub(r"d$", '', s)) # MSVC debug config, remove 'd' suffix
+        log.debug("Aliases: %s", set(res))
         return set(res)
 
     def getTest(self, name):
@@ -104,10 +106,7 @@ class TestSuite(object):
         args = args[:]
         exe = os.path.abspath(path)
         if path == "java":
-            cfg = self.cache.build_type
-            if self.options.configuration:
-                cfg = self.options.configuration
-            cmd = [self.cache.ant_executable, "-Dopencv.build.type=%s" % cfg, "buildAndTest"]
+            cmd = [self.cache.ant_executable, "-Dopencv.build.type=%s" % self.cache.build_type, "buildAndTest"]
             ret = execute(cmd, cwd = self.cache.java_test_binary_dir + "/.build")
             return None, ret
         else:

--- a/modules/ts/misc/run_suite.py
+++ b/modules/ts/misc/run_suite.py
@@ -48,22 +48,25 @@ class TestSuite(object):
         return sorted(self.getAliases(fname), key = len)[0]
 
     def getAliases(self, fname):
+        def getCuts(fname, prefix):
+            # filename w/o extension (opencv_test_core)
+            noext = re.sub(r"\.(exe|apk)$", '', fname)
+            # filename w/o prefix (core.exe)
+            nopref = fname
+            if fname.startswith(prefix):
+                nopref = fname[len(prefix):]
+            # filename w/o prefix and extension (core)
+            noprefext = noext
+            if noext.startswith(prefix):
+                noprefext = noext[len(prefix):]
+            return noext, nopref, noprefext
         # input is full path ('/home/.../bin/opencv_test_core') or 'java'
         res = [fname]
         fname = os.path.basename(fname)
         res.append(fname) # filename (opencv_test_core.exe)
-        noext = re.sub(r"\.(exe|apk)$", '', fname)
-        res.append(noext) # filename w/o extension (opencv_test_core)
-        nopref = None
-        if fname.startswith(self.nameprefix):
-            nopref = fname[len(self.nameprefix):]
-            res.append(nopref) # filename w/o prefix (core)
-        if noext.startswith(self.nameprefix):
-            res.append(noext[len(self.nameprefix):])
-        if self.options.configuration == "Debug":
-            res.append(re.sub(r"d$", '', noext))  # MSVC debug config, remove 'd' suffix
-            if nopref:
-                res.append(re.sub(r"d$", '', nopref))  # MSVC debug config, remove 'd' suffix
+        for s in getCuts(fname, self.nameprefix):
+            res.append(s)
+            res.append(re.sub(r"d$", '', s)) # MSVC debug config, remove 'd' suffix
         return set(res)
 
     def getTest(self, name):

--- a/modules/ts/misc/run_suite.py
+++ b/modules/ts/misc/run_suite.py
@@ -66,7 +66,7 @@ class TestSuite(object):
         res.append(fname) # filename (opencv_test_core.exe)
         for s in getCuts(fname, self.nameprefix):
             res.append(s)
-            if self.cache.build_type == "Debug":
+            if self.cache.build_type == "Debug" and "Visual Studio" in self.cache.cmake_generator:
                 res.append(re.sub(r"d$", '', s)) # MSVC debug config, remove 'd' suffix
         log.debug("Aliases: %s", set(res))
         return set(res)

--- a/modules/ts/misc/run_utils.py
+++ b/modules/ts/misc/run_utils.py
@@ -174,17 +174,19 @@ parse_patterns = (
 )
 
 class CMakeCache:
-    def __init__(self):
+    def __init__(self, cfg = None):
         self.setDefaultAttrs()
         self.cmake_home_vcver = None
         self.opencv_home_vcver = None
         self.featuresSIMD = None
         self.main_modules = []
+        if cfg:
+            self.build_type = cfg
 
     def setDummy(self, path):
         self.tests_dir = os.path.normpath(path)
 
-    def read(self, path, fname, cfg):
+    def read(self, path, fname):
         rx = re.compile(r'^opencv_(\w+)_SOURCE_DIR:STATIC=(.*)$')
         module_paths = {} # name -> path
         with open(fname, "rt") as cachefile:
@@ -213,10 +215,7 @@ class CMakeCache:
 
         # fix VS test binary path (add Debug or Release)
         if "Visual Studio" in self.cmake_generator:
-            if cfg:
-                self.tests_dir = os.path.join(self.tests_dir, cfg)
-            else:
-                self.tests_dir = os.path.join(self.tests_dir, self.build_type)
+            self.tests_dir = os.path.join(self.tests_dir, self.build_type)
 
         self.cmake_home_vcver = readGitVersion(self.git_executable, self.cmake_home)
         if self.opencv_home == self.cmake_home:

--- a/modules/ts/misc/run_utils.py
+++ b/modules/ts/misc/run_utils.py
@@ -152,7 +152,7 @@ parse_patterns = (
     {'name': "opencv_home",              'default': None,       'pattern': re.compile(r"^OpenCV_SOURCE_DIR:STATIC=(.+)$")},
     {'name': "opencv_build",             'default': None,       'pattern': re.compile(r"^OpenCV_BINARY_DIR:STATIC=(.+)$")},
     {'name': "tests_dir",                'default': None,       'pattern': re.compile(r"^EXECUTABLE_OUTPUT_PATH:PATH=(.+)$")},
-    {'name': "build_type",               'default': "Release",  'pattern': re.compile(r"^CMAKE_BUILD_TYPE:STRING=(.*)$")},
+    {'name': "build_type",               'default': "Release",  'pattern': re.compile(r"^CMAKE_BUILD_TYPE:\w+=(.*)$")},
     {'name': "git_executable",           'default': None,       'pattern': re.compile(r"^GIT_EXECUTABLE:FILEPATH=(.*)$")},
     {'name': "cxx_flags",                'default': "",         'pattern': re.compile(r"^CMAKE_CXX_FLAGS:STRING=(.*)$")},
     {'name': "cxx_flags_debug",          'default': "",         'pattern': re.compile(r"^CMAKE_CXX_FLAGS_DEBUG:STRING=(.*)$")},
@@ -214,7 +214,7 @@ class CMakeCache:
         # fix VS test binary path (add Debug or Release)
         if "Visual Studio" in self.cmake_generator:
             if cfg:
-                self.tests_dir = os.path.join(self.tests_dir, self.options.configuration)
+                self.tests_dir = os.path.join(self.tests_dir, cfg)
             else:
                 self.tests_dir = os.path.join(self.tests_dir, self.build_type)
 


### PR DESCRIPTION
Could not find CMAKE_BUILD_TYPE in CMakeCache, also added more aliases for debug executables (with `d` suffix).