### PR TITLE
Implemented support for CV_8UC3 in cuda::HOG

### DIFF
--- a/modules/cudaobjdetect/src/cuda/hog.cu
+++ b/modules/cudaobjdetect/src/cuda/hog.cu
@@ -925,6 +925,7 @@ namespace cv { namespace cuda { namespace device
         // Resize
 
         texture<uchar4, 2, cudaReadModeNormalizedFloat> resize8UC4_tex;
+        texture<uchar3, 2, cudaReadModeNormalizedFloat> resize8UC3_tex;
         texture<uchar,  2, cudaReadModeNormalizedFloat> resize8UC1_tex;
 
         __global__ void resize_for_hog_kernel(float sx, float sy, PtrStepSz<uchar> dst, int colOfs)
@@ -934,6 +935,18 @@ namespace cv { namespace cuda { namespace device
 
             if (x < dst.cols && y < dst.rows)
                 dst.ptr(y)[x] = tex2D(resize8UC1_tex, x * sx + colOfs, y * sy) * 255;
+        }
+        
+        __global__ void resize_for_hog_kernel(float sx, float sy, PtrStepSz<uchar3> dst, int colOfs)
+        {
+            unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+            unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+            if (x < dst.cols && y < dst.rows)
+            {
+                float3 val = tex2D(resize8UC3_tex, x * sx + colOfs, y * sy);
+                dst.ptr(y)[x] = make_uchar3(val.x * 255, val.y * 255, val.z * 255);
+            }
         }
 
         __global__ void resize_for_hog_kernel(float sx, float sy, PtrStepSz<uchar4> dst, int colOfs)
@@ -981,6 +994,7 @@ namespace cv { namespace cuda { namespace device
         }
 
         void resize_8UC1(const PtrStepSzb& src, PtrStepSzb dst) { resize_for_hog<uchar> (src, dst, resize8UC1_tex); }
+        void resize_8UC3(const PtrStepSzb& src, PtrStepSzb dst) { resize_for_hog<uchar3> (src, dst, resize8UC3_tex); }
         void resize_8UC4(const PtrStepSzb& src, PtrStepSzb dst) { resize_for_hog<uchar4>(src, dst, resize8UC4_tex); }
     } // namespace hog
 }}} // namespace cv { namespace cuda { namespace cudev

--- a/modules/cudaobjdetect/src/hog.cpp
+++ b/modules/cudaobjdetect/src/hog.cpp
@@ -100,6 +100,7 @@ namespace cv { namespace cuda { namespace device
                                     float angle_scale, cv::cuda::PtrStepSzf grad, cv::cuda::PtrStepSzb qangle, bool correct_gamma);
 
         void resize_8UC1(const cv::cuda::PtrStepSzb& src, cv::cuda::PtrStepSzb dst);
+        void resize_8UC3(const cv::cuda::PtrStepSzb& src, cv::cuda::PtrStepSzb dst);
         void resize_8UC4(const cv::cuda::PtrStepSzb& src, cv::cuda::PtrStepSzb dst);
     }
 }}}
@@ -302,7 +303,7 @@ namespace
     {
         const GpuMat img = _img.getGpuMat();
 
-        CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC4 );
+        CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC3 || img.type() == CV_8UC4 );
         CV_Assert( win_stride_.width % block_stride_.width == 0 && win_stride_.height % block_stride_.height == 0 );
 
         hits.clear();
@@ -383,7 +384,7 @@ namespace
     {
         const GpuMat img = _img.getGpuMat();
 
-        CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC4 );
+        CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC3 || img.type() == CV_8UC4 );
         CV_Assert( confidences == NULL || group_threshold_ == 0 );
 
         std::vector<double> level_scale;
@@ -428,6 +429,7 @@ namespace
                 switch (img.type())
                 {
                     case CV_8UC1: hog::resize_8UC1(img, smaller_img); break;
+                    case CV_8UC3: hog::resize_8UC3(img, smaller_img); break;
                     case CV_8UC4: hog::resize_8UC4(img, smaller_img); break;
                 }
             }

--- a/modules/cudaobjdetect/src/hog.cpp
+++ b/modules/cudaobjdetect/src/hog.cpp
@@ -96,6 +96,8 @@ namespace cv { namespace cuda { namespace device
                                     float angle_scale, cv::cuda::PtrStepSzf grad, cv::cuda::PtrStepSzb qangle, bool correct_gamma);
         void compute_gradients_8UC4(int nbins, int height, int width, const cv::cuda::PtrStepSzb& img,
                                     float angle_scale, cv::cuda::PtrStepSzf grad, cv::cuda::PtrStepSzb qangle, bool correct_gamma);
+        void compute_gradients_8UC3(int nbins, int height, int width, const cv::cuda::PtrStepSzb& img,
+                                    float angle_scale, cv::cuda::PtrStepSzf grad, cv::cuda::PtrStepSzb qangle, bool correct_gamma);
 
         void resize_8UC1(const cv::cuda::PtrStepSzb& src, cv::cuda::PtrStepSzb dst);
         void resize_8UC4(const cv::cuda::PtrStepSzb& src, cv::cuda::PtrStepSzb dst);
@@ -456,7 +458,7 @@ namespace
     {
         const GpuMat img = _img.getGpuMat();
 
-        CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC4 );
+        CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC3 || img.type() == CV_8UC4 );
         CV_Assert( win_stride_.width % block_stride_.width == 0 && win_stride_.height % block_stride_.height == 0 );
         CV_Assert( !stream );
 
@@ -545,6 +547,9 @@ namespace
         {
             case CV_8UC1:
                 hog::compute_gradients_8UC1(nbins_, img.rows, img.cols, img, angleScale, grad, qangle, gamma_correction_);
+                break;
+            case CV_8UC3:
+                hog::compute_gradients_8UC3(nbins_, img.rows, img.cols, img, angleScale, grad, qangle, gamma_correction_);
                 break;
             case CV_8UC4:
                 hog::compute_gradients_8UC4(nbins_, img.rows, img.cols, img, angleScale, grad, qangle, gamma_correction_);


### PR DESCRIPTION
Added functions and kernels in order to support CV_8UC3 input image in cuda::HOG module.
Functions and kernels for 8UC3 are simply the "downgrade" of the case 8UC4 already implemented.