### PR TITLE
Fixing variable importance in rtrees.cpp

### DIFF
--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -217,6 +217,7 @@ public:
                     else
                     {
                         int ival = cvRound(val);
+						//Voting scheme to combine OOB errors of each tree
                         int* votes = &oobvotes[j*nclasses];
                         votes[ival]++;
                         int best_class = 0;
@@ -239,7 +240,7 @@ public:
 
                     for( vi_ = 0; vi_ < nvars; vi_++ )
                     {
-                        vi = vidx ? vidx[vi_] : vi_; //no clue what this should achieve. Just use vi_?
+                        vi = vidx ? vidx[vi_] : vi_; //Ensure that only the user specified predictors are used for training
                         double ncorrect_responses_permuted = 0;
 
                         for( i = 0; i < n_oob; i++ )

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -257,11 +257,10 @@ public:
                                 val = (val - w->ord_responses[w->sidx[j]])/max_response;
                                 ncorrect_responses_permuted += exp( -val*val );
                             }
-                            else 
+                            else
                             {
                                 ncorrect_responses_permuted += cvRound(val) == w->cat_responses[w->sidx[j]];
                             }
-                                
                         }
                         varImportance[vi] += (float)(ncorrect_responses - ncorrect_responses_permuted);
                     }

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -239,7 +239,7 @@ public:
                     for (i = n_oob - 1; i > 0; --i)  //Randomly shuffle indices so we can permute features
                     {
                         int r_i = rng.uniform(0, i + 1);
-                        std::swap(oobperm[r_i], oobperm[r_i]);
+                        std::swap(oobperm[i], oobperm[r_i]);
                     }
 
                     for( vi_ = 0; vi_ < nvars; vi_++ )

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -217,7 +217,7 @@ public:
                     else
                     {
                         int ival = cvRound(val);
-						//Voting scheme to combine OOB errors of each tree
+                        //Voting scheme to combine OOB errors of each tree
                         int* votes = &oobvotes[j*nclasses];
                         votes[ival]++;
                         int best_class = 0;
@@ -236,7 +236,7 @@ public:
                     oobperm.resize(n_oob);
                     for( i = 0; i < n_oob; i++ )
                         oobperm[i] = oobidx[i];
-					std::random_shuffle(oobperm.begin(), oobperm.end()); //Randomly shuffle indices so we can permute features
+                    std::random_shuffle(oobperm.begin(), oobperm.end()); //Randomly shuffle indices so we can permute features
 
                     for( vi_ = 0; vi_ < nvars; vi_++ )
                     {
@@ -248,8 +248,8 @@ public:
                             j = oobidx[i];
                             int vj = oobperm[i];
                             sample0 = Mat( nallvars, 1, CV_32F, psamples + sstep0*w->sidx[j], sstep1*sizeof(psamples[0]) );
-							Mat sample_clone = sample0.clone(); //create a copy so we don't mess up the original data
-							sample_clone.at<float>(vi) = psamples[sstep0*w->sidx[vj] + sstep1*vi];
+                            Mat sample_clone = sample0.clone(); //create a copy so we don't mess up the original data
+                            sample_clone.at<float>(vi) = psamples[sstep0*w->sidx[vj] + sstep1*vi];
 
                             double val = predictTrees(Range(treeidx, treeidx+1), sample_clone, predictFlags);
                             if( !_isClassifier )
@@ -257,10 +257,10 @@ public:
                                 val = (val - w->ord_responses[w->sidx[j]])/max_response;
                                 ncorrect_responses_permuted += exp( -val*val );
                             }
-							else 
-							{
-								ncorrect_responses_permuted += cvRound(val) == w->cat_responses[w->sidx[j]];
-							}
+                            else 
+                            {
+                                ncorrect_responses_permuted += cvRound(val) == w->cat_responses[w->sidx[j]];
+                            }
                                 
                         }
                         varImportance[vi] += (float)(ncorrect_responses - ncorrect_responses_permuted);

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -187,7 +187,7 @@ public:
                 oobidx.clear();
                 for( i = 0; i < n; i++ )
                 {
-                    if( !oobmask[i] )
+                    if( oobmask[i] )
                         oobidx.push_back(i);
                 }
                 int n_oob = (int)oobidx.size();
@@ -235,6 +235,7 @@ public:
                     oobperm.resize(n_oob);
                     for( i = 0; i < n_oob; i++ )
                         oobperm[i] = oobidx[i];
+					std::random_shuffle(oobperm.begin(), oobperm.end());
 
                     for( vi_ = 0; vi_ < nvars; vi_++ )
                     {
@@ -254,7 +255,7 @@ public:
                             sample0 = Mat( nallvars, 1, CV_32F, psamples + sstep0*w->sidx[j], sstep1*sizeof(psamples[0]) );
                             for( k = 0; k < nallvars; k++ )
                                 sample.at<float>(k) = sample0.at<float>(k);
-                            sample.at<float>(vi) = psamples[sstep0*w->sidx[vj] + sstep1*vi];
+							sample.at<float>(vi) = psamples[sstep0*w->sidx[vj] + sstep1*vi];
 
                             double val = predictTrees(Range(treeidx, treeidx+1), sample, predictFlags);
                             if( !_isClassifier )

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -236,7 +236,11 @@ public:
                     oobperm.resize(n_oob);
                     for( i = 0; i < n_oob; i++ )
                         oobperm[i] = oobidx[i];
-                    std::random_shuffle(oobperm.begin(), oobperm.end()); //Randomly shuffle indices so we can permute features
+                    for (i = n_oob - 1; i > 0; --i)  //Randomly shuffle indices so we can permute features
+                    {
+                        int r_i = rng.uniform(0, i + 1);
+                        std::swap(oobperm[r_i], oobperm[r_i]);
+                    }
 
                     for( vi_ = 0; vi_ < nvars; vi_++ )
                     {

--- a/samples/cpp/tree_engine.cpp
+++ b/samples/cpp/tree_engine.cpp
@@ -110,15 +110,15 @@ int main(int argc, char** argv)
     rtrees->setActiveVarCount(0);
     rtrees->setTermCriteria(TermCriteria(TermCriteria::MAX_ITER, 100, 0));
     train_and_print_errs(rtrees, data);
-	cv::Mat ref_labels = data->getClassLabels();
-	cv::Mat test_data = data->getTestSampleIdx();
-	cv::Mat predict_labels;
-	rtrees->predict(data->getSamples(), predict_labels);
+    cv::Mat ref_labels = data->getClassLabels();
+    cv::Mat test_data = data->getTestSampleIdx();
+    cv::Mat predict_labels;
+    rtrees->predict(data->getSamples(), predict_labels);
 
-	cv::Mat variable_importance = rtrees->getVarImportance();
-	std::cout << "Estimated variable importance" << std::endl;
-	for (int i = 0; i < variable_importance.rows; i++) {
-		std::cout << "Variable " << i << ": " << variable_importance.at<float>(i, 0) << std::endl;
-	}
+    cv::Mat variable_importance = rtrees->getVarImportance();
+    std::cout << "Estimated variable importance" << std::endl;
+    for (int i = 0; i < variable_importance.rows; i++) {
+	    std::cout << "Variable " << i << ": " << variable_importance.at<float>(i, 0) << std::endl;
+    }
     return 0; 
 }

--- a/samples/cpp/tree_engine.cpp
+++ b/samples/cpp/tree_engine.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv)
     }
 
     data->setTrainTestSplitRatio(train_test_split_ratio);
-	std::cout << "Test/Train: " << data->getNTestSamples() << "/" << data->getNTrainSamples();
+    std::cout << "Test/Train: " << data->getNTestSamples() << "/" << data->getNTrainSamples();
 
     printf("======DTREE=====\n");
     Ptr<DTrees> dtree = DTrees::create();
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
     cv::Mat variable_importance = rtrees->getVarImportance();
     std::cout << "Estimated variable importance" << std::endl;
     for (int i = 0; i < variable_importance.rows; i++) {
-	    std::cout << "Variable " << i << ": " << variable_importance.at<float>(i, 0) << std::endl;
+        std::cout << "Variable " << i << ": " << variable_importance.at<float>(i, 0) << std::endl;
     }
-    return 0; 
+    return 0;
 }

--- a/samples/cpp/tree_engine.cpp
+++ b/samples/cpp/tree_engine.cpp
@@ -101,25 +101,24 @@ int main(int argc, char** argv)
     printf("======RTREES=====\n");
     Ptr<RTrees> rtrees = RTrees::create();
     rtrees->setMaxDepth(10);
-    //rtrees->setMinSampleCount(1);
-	rtrees->setActiveVarCount(2);
+    rtrees->setMinSampleCount(2);
     rtrees->setRegressionAccuracy(0);
     rtrees->setUseSurrogates(false);
     rtrees->setMaxCategories(16);
     rtrees->setPriors(Mat());
     rtrees->setCalculateVarImportance(true);
     rtrees->setActiveVarCount(0);
-    rtrees->setTermCriteria(TermCriteria(TermCriteria::MAX_ITER, 10, 0));
+    rtrees->setTermCriteria(TermCriteria(TermCriteria::MAX_ITER, 100, 0));
     train_and_print_errs(rtrees, data);
-	std::cout << rtrees->isClassifier() << std::endl;
 	cv::Mat ref_labels = data->getClassLabels();
 	cv::Mat test_data = data->getTestSampleIdx();
 	cv::Mat predict_labels;
 	rtrees->predict(data->getSamples(), predict_labels);
 
 	cv::Mat variable_importance = rtrees->getVarImportance();
+	std::cout << "Estimated variable importance" << std::endl;
 	for (int i = 0; i < variable_importance.rows; i++) {
-		std::cout << variable_importance.at<float>(i, 0) << std::endl;
+		std::cout << "Variable " << i << ": " << variable_importance.at<float>(i, 0) << std::endl;
 	}
     return 0; 
 }


### PR DESCRIPTION
Variable importance for random forests was not working properly. It would always return a uniform distribution.

There were several issues:
 - Part of the data was being overwritten
 - The predictor values were not permuted (hence the uniform distribution)
 - The wrong entries were used for OOB. For OOB estimation the in bag samples were used

The issues are fixed and the example is now also printing out the estimated variable importance
