### PR TITLE
fixed  enclosing circle always larger than 1.0

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -43,8 +43,7 @@
 namespace cv
 {
 
-
-// inner product 
+// inner product
 static float innerProduct(Point2f &v1, Point2f &v2)
 {
     return v1.x * v2.y - v1.y * v2.x;
@@ -58,7 +57,7 @@ static void findCircle3pts(Point2f *pts, Point2f &center, float &radius)
 
     if (innerProduct(v1, v2) == 0.0f)
     {
-        // v1, v2 colineation, can not determine a unique circle 
+        // v1, v2 colineation, can not determine a unique circle
         // find the longtest distance as diameter line
         float d1 = (float)norm(pts[0] - pts[1]);
         float d2 = (float)norm(pts[0] - pts[2]);


### PR DESCRIPTION
issue #5745 

1. Delete the range limiting (radius > 1.0) code for circle radius.
2. change to EMO Welzl's method which computing enclosing circle in expected O(n) time.
3. add EPS = 1.0e-5 to float variable radius to avoid round-off error in computing (such as sqrt function).

> Welzl, Emo. Smallest enclosing disks (balls and ellipsoids). Springer Berlin Heidelberg, 1991.