### PR TITLE
add TestData::getTestSamples()

### DIFF
--- a/modules/ml/include/opencv2/ml.hpp
+++ b/modules/ml/include/opencv2/ml.hpp
@@ -223,7 +223,12 @@ public:
      */
     CV_WRAP virtual void setTrainTestSplitRatio(double ratio, bool shuffle=true) = 0;
     CV_WRAP virtual void shuffleTrainTest() = 0;
-    CV_WRAP virtual Mat getTestSamples() const = 0;
+
+    CV_WRAP Mat getTestSamples() const {
+        Mat idx = getTestSampleIdx();
+        Mat samples = getSamples();
+        return idx.empty() ? Mat() : getSubVector(samples, idx);
+    }
 
     CV_WRAP static Mat getSubVector(const Mat& vec, const Mat& idx);
 

--- a/modules/ml/include/opencv2/ml.hpp
+++ b/modules/ml/include/opencv2/ml.hpp
@@ -181,6 +181,7 @@ public:
     TrainData::getClassLabels.
      */
     CV_WRAP virtual Mat getTrainNormCatResponses() const = 0;
+    CV_WRAP virtual Mat getTestSamples() const = 0;
     CV_WRAP virtual Mat getTestResponses() const = 0;
     CV_WRAP virtual Mat getTestNormCatResponses() const = 0;
     CV_WRAP virtual Mat getResponses() const = 0;

--- a/modules/ml/include/opencv2/ml.hpp
+++ b/modules/ml/include/opencv2/ml.hpp
@@ -181,7 +181,6 @@ public:
     TrainData::getClassLabels.
      */
     CV_WRAP virtual Mat getTrainNormCatResponses() const = 0;
-    CV_WRAP virtual Mat getTestSamples() const = 0;
     CV_WRAP virtual Mat getTestResponses() const = 0;
     CV_WRAP virtual Mat getTestNormCatResponses() const = 0;
     CV_WRAP virtual Mat getResponses() const = 0;
@@ -224,6 +223,7 @@ public:
      */
     CV_WRAP virtual void setTrainTestSplitRatio(double ratio, bool shuffle=true) = 0;
     CV_WRAP virtual void shuffleTrainTest() = 0;
+    CV_WRAP virtual Mat getTestSamples() const = 0;
 
     CV_WRAP static Mat getSubVector(const Mat& vec, const Mat& idx);
 

--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -185,11 +185,6 @@ public:
         Mat idx = getTestSampleIdx();
         return idx.empty() ? Mat() : getSubVector(responses, idx);
     }
-    Mat getTestSamples() const
-    {
-        Mat idx = getTestSampleIdx();
-        return idx.empty() ? Mat() : getSubVector(samples, idx);
-    }
     Mat getTestNormCatResponses() const
     {
         Mat idx = getTestSampleIdx();

--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -185,6 +185,11 @@ public:
         Mat idx = getTestSampleIdx();
         return idx.empty() ? Mat() : getSubVector(responses, idx);
     }
+    Mat getTestSamples() const
+    {
+        Mat idx = getTestSampleIdx();
+        return idx.empty() ? Mat() : getSubVector(samples, idx);
+    }
     Mat getTestNormCatResponses() const
     {
         Mat idx = getTestSampleIdx();


### PR DESCRIPTION
Documentation for cv::ml::TrainData::setTrainTestSplitRatio explicitly states "Please, note that for each of TrainData::getTrain* there is corresponding TrainData::getTest*, so that the test subset can be retrieved and processed as well."

For some reason getTestSamples() was missing.