### PR TITLE
calculate innTilted only for Haar::ALL mode

### DIFF
--- a/apps/traincascade/haarfeatures.cpp
+++ b/apps/traincascade/haarfeatures.cpp
@@ -101,12 +101,13 @@ void CvHaarEvaluator::setImage(const Mat& img, uchar clsLabel, int idx)
     CvFeatureEvaluator::setImage( img, clsLabel, idx);
     Mat innSum(winSize.height + 1, winSize.width + 1, sum.type(), sum.ptr<int>((int)idx));
     Mat innSqSum;
-    if (((const CvHaarFeatureParams*)featureParams)->mode == CvHaarFeatureParams::ALL) {
-	Mat innTilted(winSize.height + 1, winSize.width + 1, tilted.type(), tilted.ptr<int>((int)idx));
-	integral(img, innSum, innSqSum, innTilted);
+    if (((const CvHaarFeatureParams*)featureParams)->mode == CvHaarFeatureParams::ALL)
+    {
+        Mat innTilted(winSize.height + 1, winSize.width + 1, tilted.type(), tilted.ptr<int>((int)idx));
+        integral(img, innSum, innSqSum, innTilted);
     }
     else
-    	integral(img, innSum, innSqSum);
+        integral(img, innSum, innSqSum);
     normfactor.ptr<float>(0)[idx] = calcNormFactor( innSum, innSqSum );
 }
 

--- a/apps/traincascade/haarfeatures.cpp
+++ b/apps/traincascade/haarfeatures.cpp
@@ -100,9 +100,13 @@ void CvHaarEvaluator::setImage(const Mat& img, uchar clsLabel, int idx)
     CV_DbgAssert( !sum.empty() && !tilted.empty() && !normfactor.empty() );
     CvFeatureEvaluator::setImage( img, clsLabel, idx);
     Mat innSum(winSize.height + 1, winSize.width + 1, sum.type(), sum.ptr<int>((int)idx));
-    Mat innTilted(winSize.height + 1, winSize.width + 1, tilted.type(), tilted.ptr<int>((int)idx));
     Mat innSqSum;
-    integral(img, innSum, innSqSum, innTilted);
+    if (((const CvHaarFeatureParams*)featureParams)->mode == CvHaarFeatureParams::ALL) {
+		Mat innTilted(winSize.height + 1, winSize.width + 1, tilted.type(), tilted.ptr<int>((int)idx));
+		integral(img, innSum, innSqSum, innTilted);
+	}
+	else
+		integral(img, innSum, innSqSum);
     normfactor.ptr<float>(0)[idx] = calcNormFactor( innSum, innSqSum );
 }
 

--- a/apps/traincascade/haarfeatures.cpp
+++ b/apps/traincascade/haarfeatures.cpp
@@ -102,11 +102,11 @@ void CvHaarEvaluator::setImage(const Mat& img, uchar clsLabel, int idx)
     Mat innSum(winSize.height + 1, winSize.width + 1, sum.type(), sum.ptr<int>((int)idx));
     Mat innSqSum;
     if (((const CvHaarFeatureParams*)featureParams)->mode == CvHaarFeatureParams::ALL) {
-		Mat innTilted(winSize.height + 1, winSize.width + 1, tilted.type(), tilted.ptr<int>((int)idx));
-		integral(img, innSum, innSqSum, innTilted);
-	}
-	else
-		integral(img, innSum, innSqSum);
+	Mat innTilted(winSize.height + 1, winSize.width + 1, tilted.type(), tilted.ptr<int>((int)idx));
+	integral(img, innSum, innSqSum, innTilted);
+    }
+    else
+    	integral(img, innSum, innSqSum);
     normfactor.ptr<float>(0)[idx] = calcNormFactor( innSum, innSqSum );
 }
 


### PR DESCRIPTION
major time consuming part for training app is in function fillPassedSamples for negatives, 
this change make setImage faster, in my test data, the total time for setImage decrease from 9177666 to 5839263,
should help for Haar feature and non Haar::ALL mode which is commonly used