### PR TITLE
Fix KAZE/AKAZE descriptors to use angle instead radians.

### DIFF
--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -191,7 +191,7 @@ public:
 
     for (int i = range.start; i < range.end; i++)
     {
-        float ratio = (float)fastpow(2, evolution[i].octave);
+      float ratio = (float)fastpow(2, evolution[i].octave);
       int sigma_size_ = fRound(evolution[i].esigma * options_.derivative_factor / ratio);
 
       compute_scharr_derivatives(evolution[i].Lsmooth, evolution[i].Lx, 1, 0, sigma_size_);
@@ -1000,7 +1000,7 @@ void MSURF_Descriptor_64_Invoker::Get_MSURF_Descriptor_64(const KeyPoint& kpt, f
   // Get the information from the keypoint
   ratio = (float)(1 << kpt.octave);
   scale = fRound(0.5f*kpt.size / ratio);
-  angle = kpt.angle;
+  angle = (kpt.angle * static_cast<float>(CV_PI)) / 180.f;
   level = kpt.class_id;
   yf = kpt.pt.y / ratio;
   xf = kpt.pt.x / ratio;
@@ -1406,8 +1406,9 @@ void MLDB_Full_Descriptor_Invoker::Get_MLDB_Full_Descriptor(const KeyPoint& kpt,
   float scale = (float)fRound(0.5f*kpt.size / ratio);
   float xf = kpt.pt.x / ratio;
   float yf = kpt.pt.y / ratio;
-  float co = cos(kpt.angle);
-  float si = sin(kpt.angle);
+  float angle = (kpt.angle * static_cast<float>(CV_PI)) / 180.f;
+  float co = cos(angle);
+  float si = sin(angle);
   int pattern_size = options_->descriptor_pattern_size;
 
   int dpos = 0;
@@ -1441,7 +1442,7 @@ void MLDB_Descriptor_Subset_Invoker::Get_MLDB_Descriptor_Subset(const KeyPoint& 
   // Get the information from the keypoint
   float ratio = (float)(1 << kpt.octave);
   int scale = fRound(0.5f*kpt.size / ratio);
-  float angle = kpt.angle;
+  float angle = (kpt.angle * static_cast<float>(CV_PI)) / 180.f;
   int level = kpt.class_id;
   float yf = kpt.pt.y / ratio;
   float xf = kpt.pt.x / ratio;

--- a/modules/features2d/src/kaze/KAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/KAZEFeatures.cpp
@@ -512,7 +512,7 @@ public:
         for (int i = range.start; i < range.end; i++)
         {
             kpts[i].angle = 0.0;
-                        if (options_.upright)
+            if (options_.upright)
             {
                 kpts[i].angle = 0.0;
                                 if (options_.extended)
@@ -805,7 +805,7 @@ void KAZE_Descriptor_Invoker::Get_KAZE_Descriptor_64(const KeyPoint &kpt, float 
     yf = kpt.pt.y;
     xf = kpt.pt.x;
     scale = fRound(kpt.size / 2.0f);
-    angle = kpt.angle;
+    angle = (kpt.angle * static_cast<float>(CV_PI)) / 180.f;
     level = kpt.class_id;
     co = cos(angle);
     si = sin(angle);
@@ -1088,7 +1088,7 @@ void KAZE_Descriptor_Invoker::Get_KAZE_Descriptor_128(const KeyPoint &kpt, float
     yf = kpt.pt.y;
     xf = kpt.pt.x;
     scale = fRound(kpt.size / 2.0f);
-    angle = kpt.angle;
+    angle = (kpt.angle * static_cast<float>(CV_PI)) / 180.f;
     level = kpt.class_id;
     co = cos(angle);
     si = sin(angle);


### PR DESCRIPTION
* This PR completes the work done at #5735 .

Without this patch descriptor does not work at all, produces zero matches on real SfM scene. Within #5735 done by @Astero92 keypoint detection produces angle in degree 0->360 (as opencv's convention) but description part still expects radians. Thus descriptor part must convert back degree to radians. This PR fix the descriptor part at all.