### PR TITLE
Do not modify input parameter in MergeDebevec

### DIFF
--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -79,9 +79,11 @@ public:
             response = linearResponse(channels);
             response.at<Vec3f>(0) = response.at<Vec3f>(1);
         }
-        log(response, response);
-        CV_Assert(response.rows == LDR_SIZE && response.cols == 1 &&
-                  response.channels() == channels);
+
+        Mat log_response;
+        log(response, log_response);
+        CV_Assert(log_response.rows == LDR_SIZE && log_response.cols == 1 &&
+                  log_response.channels() == channels);
 
         Mat exp_values(times);
         log(exp_values, exp_values);
@@ -103,7 +105,7 @@ public:
             w /= channels;
 
             Mat response_img;
-            LUT(images[i], response, response_img);
+            LUT(images[i], log_response, response_img);
             split(response_img, splitted);
             for(int c = 0; c < channels; c++) {
                 result_split[c] += w.mul(splitted[c] - exp_values.at<float>((int)i));


### PR DESCRIPTION
`MergeDebevec::process()` takes camera response function as an optional input parameter. Despite being clearly marked as input, this matrix is overwritten during processing.

This commit adds a temporary matrix to store the log response and avoid modification of the input.