### PR TITLE
Hdr.mergemertens.fixalgo

### DIFF
--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -694,7 +694,7 @@ public:
 @param exposure_weight well-exposedness measure weight
  */
 CV_EXPORTS_W Ptr<MergeMertens>
-createMergeMertens(float contrast_weight = 1.0f, float saturation_weight = 1.0f, float exposure_weight = 0.0f);
+createMergeMertens(float contrast_weight = 1.0f, float saturation_weight = 1.0f, float exposure_weight = 1.0f);
 
 /** @brief The resulting HDR image is calculated as weighted average of the exposures considering exposure
 values and camera response.

--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -694,7 +694,7 @@ public:
 @param exposure_weight well-exposedness measure weight
  */
 CV_EXPORTS_W Ptr<MergeMertens>
-createMergeMertens(float contrast_weight = 1.0f, float saturation_weight = 1.0f, float exposure_weight = 1.0f);
+createMergeMertens(float contrast_weight = 1.0f, float saturation_weight = 1.0f, float exposure_weight = 0.0f);
 
 /** @brief The resulting HDR image is calculated as weighted average of the exposures considering exposure
 values and camera response.

--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -194,10 +194,11 @@ public:
 
             wellexp = Mat::ones(size, CV_32F);
             for(int c = 0; c < channels; c++) {
-                Mat exp = splitted[c] - 0.5f;
-                pow(exp, 2.0f, exp);
-                exp = -exp / 0.08f;
-                wellexp = wellexp.mul(exp);
+                Mat expo = splitted[c] - 0.5f;
+                pow(expo, 2.0f, expo);
+                expo = -expo / 0.08f;
+                exp(expo, expo);
+                wellexp = wellexp.mul(expo);
             }
 
             pow(contrast, wcon, contrast);


### PR DESCRIPTION
Fix for #5807: 
> In the MergeMertensImpl::process method, the implementation of the formula to compute the well-exposedness map is false and is missing a call to cv::exp to get a gaussian curve.
