### PR TITLE
do not open libOpenCL.so if HAVE_OPENCL is not set

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -684,10 +684,10 @@ typedef struct _cl_buffer_region {
 
 #define CL_CALLBACK CV_STDCALL
 
-static volatile bool g_haveOpenCL = false;
 
 #ifdef HAVE_OPENCL
 static const char* oclFuncToCheck = "clEnqueueReadBufferRect";
+static volatile bool g_haveOpenCL = false;
 #endif
 
 #if defined(__APPLE__) && defined(HAVE_OPENCL)

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -685,9 +685,12 @@ typedef struct _cl_buffer_region {
 #define CL_CALLBACK CV_STDCALL
 
 static volatile bool g_haveOpenCL = false;
-static const char* oclFuncToCheck = "clEnqueueReadBufferRect";
 
-#if defined(__APPLE__)
+#ifdef HAVE_OPENCL
+static const char* oclFuncToCheck = "clEnqueueReadBufferRect";
+#endif
+
+#if defined(__APPLE__) && defined(HAVE_OPENCL)
 #include <dlfcn.h>
 
 static void* initOpenCLAndLoad(const char* funcname)
@@ -716,7 +719,7 @@ static void* initOpenCLAndLoad(const char* funcname)
     return funcname && handle ? dlsym(handle, funcname) : 0;
 }
 
-#elif defined WIN32 || defined _WIN32
+#elif (defined WIN32 || defined _WIN32) && defined(HAVE_OPENCL)
 
 #ifndef _WIN32_WINNT           // This is needed for the declaration of TryEnterCriticalSection in winbase.h with Visual Studio 2005 (and older?)
   #define _WIN32_WINNT 0x0400  // http://msdn.microsoft.com/en-us/library/ms686857(VS.85).aspx
@@ -751,7 +754,7 @@ static void* initOpenCLAndLoad(const char* funcname)
     return funcname ? (void*)GetProcAddress(handle, funcname) : 0;
 }
 
-#elif defined(__linux)
+#elif defined(__linux) && defined(HAVE_OPENCL)
 
 #include <dlfcn.h>
 #include <stdio.h>


### PR DESCRIPTION
When building opencv3 with `-DWITH_OPENCL=OFF`, *libOpenCL.so* is still loaded at runtime. If cuda is available on the host, calling some opencv functions would implicitly initialize cuda context. So a cuda-enabled program may be broken in the following way: it first calls opencv functions (without knowing it would create cuda context), and then forks some child processes and invokes cuda functions in the child processes, and then observes strange undefined behavior ( see http://stackoverflow.com/questions/22950047/cuda-initialization-error-after-fork for the reason).

I actually encountered this problem and my program hangs randomly after running for some time ( phenomenon: *nvidia-smi* reports 0% GPU usage, *cuda-gdb* reports no kernel running, but `cudaStreamQuery` or `cudaEventQuery` always reports `cudaErrorNotReady` ). It took me a long and tough time to find this out. In fact I checked that *cv2.cpython-34m.so* is not linked with cuda libraries, but did not expected it opens *libOpenCL.so* by `dlopen` dynamically.