### PR TITLE
features2d agast: clear in/out keypoints container

### DIFF
--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -7961,6 +7961,7 @@ public:
             cvtColor( _image, ogray, COLOR_BGR2GRAY );
             gray = ogray;
         }
+        keypoints.clear();
         AGAST( gray, keypoints, threshold, nonmaxSuppression, type );
         KeyPointsFilter::runByPixelsMask( keypoints, mask );
     }


### PR DESCRIPTION
#5863

```
check_regression=*agast*
```