### PR TITLE
Fixed pnpTask: don't copy inliers vector in case it's empty.

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -197,7 +197,7 @@ namespace cv
             }
 
             resultsMutex.lock();
-            if ( (localInliers.size() > inliers.size()) || (localInliers.size() == inliers.size() && curIndex > bestIndex))
+            if ( (localInliers.size() > inliers.size()) || (localInliers.size() == inliers.size() && inliers.size() > 0 && curIndex > bestIndex))
             {
                 inliers.clear();
                 inliers.resize(localInliers.size());


### PR DESCRIPTION
To fix Visual Studio assertion in debug mode on this line:
`memcpy(&inliers[0], &localInliers[0], sizeof(int) * localInliers.size());`