### PR TITLE
[ML] wrong class labels in createConcentricSpheresTestSet

### DIFF
--- a/modules/ml/src/testset.cpp
+++ b/modules/ml/src/testset.cpp
@@ -104,7 +104,7 @@ void createConcentricSpheresTestSet( int num_samples, int num_features, int num_
         max_dst = std::max( max_dst, dis[i].d );
 
         for( ; i < num_samples && dis[i].d <= max_dst; ++i )
-            responses.at<int>(i) = cur_class;
+            responses.at<int>(dis[i].i) = cur_class;
     }
 }
 


### PR DESCRIPTION
I fixed the assignment of class labels by using the corresponding indices from the sorted vector of index/distance pairs.

Here is an example to see the problem (tested in OpenCV 3.1.0):

``` cpp
#include "opencv2/core.hpp"
#include "opencv2/imgproc.hpp"
#include "opencv2/highgui.hpp"
#include "opencv2/ml.hpp"
using namespace cv;

int main()
{
    // generate 2D data with 3-classes
    Mat X, Y;
    ml::createConcentricSpheresTestSet(1000, 2, 3, X, Y);

    // plot data color-coded by class label
    Mat img(400, 400, CV_8UC3, Scalar::all(255));
    for (int i=0; i<Y.total(); i++) {
        // map [-4,4] to [0,400]
        Point pt(cvRound(img.cols*(X.at<float>(i,0)+4.0)/8.0),
                 cvRound(img.rows*(X.at<float>(i,1)+4.0)/8.0));
        Scalar clr = Scalar::all(0);
        clr[Y.at<int>(i)] = 255;
        circle(img, pt, 2, clr, FILLED);
    }
    namedWindow("points2D", WINDOW_AUTOSIZE);
    imshow("points2D", img);
    waitKey(0);

    return 0;
}
```

The data before and after the fix:
![img](https://cloud.githubusercontent.com/assets/83908/12313027/d2ec1248-ba6c-11e5-8594-b009fc12f3df.png)

