### PR TITLE
Added ability to disable lighting in the viz-module.

### DIFF
--- a/modules/viz/include/opencv2/viz/widgets.hpp
+++ b/modules/viz/include/opencv2/viz/widgets.hpp
@@ -67,7 +67,8 @@ namespace cv
             REPRESENTATION,
             IMMEDIATE_RENDERING,
             SHADING,
-            AMBIENT
+            AMBIENT,
+            LIGHTING
         };
 
         enum RepresentationValues

--- a/modules/viz/src/widget.cpp
+++ b/modules/viz/src/widget.cpp
@@ -115,6 +115,14 @@ void cv::viz::Widget::setRenderingProperty(int property, double value)
         case LINE_WIDTH:          actor->GetProperty()->SetLineWidth(float(value)); break;
         case IMMEDIATE_RENDERING: actor->GetMapper()->SetImmediateModeRendering(int(value)); break;
         case AMBIENT:             actor->GetProperty()->SetAmbient(float(value)); break;
+        case LIGHTING:
+        {
+            if (value == 0)
+                actor->GetProperty()->LightingOff();
+            else
+                actor->GetProperty()->LightingOn();
+            break;
+        }
         case FONT_SIZE:
         {
             vtkTextActor* text_actor = vtkTextActor::SafeDownCast(actor);


### PR DESCRIPTION
When I reconstructed the 3D scene I want to show it as viz::WMesh with an initial value of lighting. For this I disable lighting and shadows:
cv::viz::Viz3d viz_3d_window("3D");
viz_3d_window.setRenderingProperty("mesh", cv::viz::LIGHTING, 0);

Most of the examples show the 3D reconstruction using the point cloud, but using  the mesh one part of it creates a shadow on other parts of it if lighting ON.
Using a 3D mesh with disabled lighting gives the most realistic picture of the reconstructed 3D scene.