### PR TITLE
CMake: turn off precompiled headers in case of opencv_world builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ OCV_OPTION(INSTALL_TESTS            "Install accuracy and performance test binar
 
 # OpenCV build options
 # ===================================================
-OCV_OPTION(ENABLE_PRECOMPILED_HEADERS "Use precompiled headers"                                  ON IF (NOT IOS AND NOT CMAKE_CROSSCOMPILING AND NOT ((HAVE_CUDA OR WITH_CUDA) AND BUILD_opencv_world)) )
+OCV_OPTION(ENABLE_PRECOMPILED_HEADERS "Use precompiled headers"                                  ON IF (NOT IOS AND NOT CMAKE_CROSSCOMPILING) )
 OCV_OPTION(ENABLE_SOLUTION_FOLDERS    "Solution folder in Visual Studio or in other IDEs"        (MSVC_IDE OR CMAKE_GENERATOR MATCHES Xcode) )
 OCV_OPTION(ENABLE_PROFILING           "Enable profiling in the GCC compiler (Add flags: -g -pg)" OFF  IF CMAKE_COMPILER_IS_GNUCXX )
 OCV_OPTION(ENABLE_COVERAGE            "Enable coverage collection with  GCov"                    OFF  IF CMAKE_COMPILER_IS_GNUCXX )

--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -14,6 +14,7 @@ function(include_one_module m)
 endfunction()
 
 if(NOT OPENCV_INITIAL_PASS)
+  set(ENABLE_PRECOMPILED_HEADERS OFF CACHE INTERNAL "" FORCE)
   project(opencv_world)
 
   message(STATUS "Processing WORLD modules...")


### PR DESCRIPTION
Precompiled headers were "fixed" during CUDA+world fix, so just disable them now for all opencv_world builds.