### PR TITLE
Fixed parser for img1_filename and img2_filename.

### DIFF
--- a/samples/cpp/stereo_match.cpp
+++ b/samples/cpp/stereo_match.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
     Ptr<StereoBM> bm = StereoBM::create(16,9);
     Ptr<StereoSGBM> sgbm = StereoSGBM::create(0,16,3);
     cv::CommandLineParser parser(argc, argv,
-        "{help h||}{algorithm||}{max-disparity|0|}{blocksize|0|}{no-display||}{scale|1|}{i||}{e||}{o||}{p||}");
+        "{@arg1||}{@arg2||}{help h||}{algorithm||}{max-disparity|0|}{blocksize|0|}{no-display||}{scale|1|}{i||}{e||}{o||}{p||}");
     if(parser.has("help"))
     {
         print_help();


### PR DESCRIPTION
Without fixes after 68 line (`img1_filename = parser.get<std::string>(0);`) OpenCV Error:
```
./stereo_matching im0.png im1.png --max-disparity=16 --blocksize=17

OpenCV Error: Bad argument (undeclared position 0 requested) in getByIndex, file /home/entodi/opencv/modules/core/src/command_line_parser.cpp, line 169
terminate called after throwing an instance of 'cv::Exception'
  what():  /home/entodi/opencv/modules/core/src/command_line_parser.cpp:169: error: (-5) undeclared position 0 requested in function getByIndex
```