### PR TITLE
Update train_HOG.cpp

### DIFF
--- a/samples/cpp/train_HOG.cpp
+++ b/samples/cpp/train_HOG.cpp
@@ -78,7 +78,7 @@ void load_images( const string & prefix, vector< Mat > & img_lst )
 	vector<String> files;
 	glob(prefix, files);
 
-	for (int i = 0; i < files.size(); ++i) {
+	for (int i = 0; i < (int)files.size(); ++i) {
 
 		img = imread(files.at(i)); // load the image
 		if (img.empty()) // invalid image, just skip it.

--- a/samples/cpp/train_HOG.cpp
+++ b/samples/cpp/train_HOG.cpp
@@ -74,21 +74,21 @@ void convert_to_ml(const std::vector< cv::Mat > & train_samples, cv::Mat& trainD
 
 void load_images( const string & prefix, vector< Mat > & img_lst )
 {
-	Mat img;
-	vector<String> files;
-	glob(prefix, files);
+    Mat img;
+    vector<String> files;
+    glob(prefix, files);
 
-	for (int i = 0; i < (int)files.size(); ++i) {
+    for (int i = 0; i < (int)files.size(); ++i) {
 
-		img = imread(files.at(i)); // load the image
-		if (img.empty()) // invalid image, just skip it.
-			continue;
+        img = imread(files.at(i)); // load the image
+        if (img.empty()) // invalid image, just skip it.
+            continue;
 #ifdef _DEBUG
-		imshow("image", img);
-		waitKey(10);
+        imshow("image", img);
+        waitKey(10);
 #endif
-		img_lst.push_back(img.clone());
-	}
+        img_lst.push_back(img.clone());
+    }
 }
 
 void sample_neg( const vector< Mat > & full_neg_lst, vector< Mat > & neg_lst, const Size & size )

--- a/samples/cpp/train_HOG.cpp
+++ b/samples/cpp/train_HOG.cpp
@@ -87,7 +87,7 @@ void load_images( const string & prefix, vector< Mat > & img_lst )
 		imshow("image", img);
 		waitKey(10);
 #endif
-		image_list.push_back(img.clone());
+		img_lst.push_back(img.clone());
 	}
 }
 


### PR DESCRIPTION
Instead of dealing with **pos.lst** and **neg.lst** files, now it is possible to give only *prefix* as parameter to **load_images** function (and also vector of matrices).

(With the help of [cv::glob](http://docs.opencv.org/3.1.0/db/de0/group__core__utils.html#gaf91b7f383218e2d3f760939140942297&gsc.tab=0))