### PR TITLE
fixed to use NVCUVID in 'gpu' module on 2.4 branch.

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -35,7 +35,18 @@ if(CUDA_FOUND)
 
   if(WITH_NVCUVID)
     find_cuda_helper_libs(nvcuvid)
-    set(HAVE_NVCUVID 1)
+
+    if(WIN32)
+      find_cuda_helper_libs(nvcuvenc)
+    endif()
+
+    if(CUDA_nvcuvid_LIBRARY)
+      set(HAVE_NVCUVID 1)
+    endif()
+
+    if(CUDA_nvcuvenc_LIBRARY)
+      set(HAVE_NVCUVENC 1)
+    endif()
   endif()
 
   message(STATUS "CUDA detected: " ${CUDA_VERSION})

--- a/cmake/templates/cvconfig.h.in
+++ b/cmake/templates/cvconfig.h.in
@@ -109,6 +109,9 @@
 /* NVidia Video Decoding API*/
 #cmakedefine HAVE_NVCUVID
 
+/* NVidia Video Encoding API*/
+#cmakedefine HAVE_NVCUVENC
+
 /* OpenCL Support */
 #cmakedefine HAVE_OPENCL
 #cmakedefine HAVE_OPENCL_STATIC

--- a/modules/gpu/CMakeLists.txt
+++ b/modules/gpu/CMakeLists.txt
@@ -54,11 +54,14 @@ if(HAVE_CUDA)
   endif()
 
   if(WITH_NVCUVID)
-    set(cuda_link_libs ${cuda_link_libs} ${CUDA_CUDA_LIBRARY} ${CUDA_nvcuvid_LIBRARY})
+    if(HAVE_NVCUVID)
+      set(cuda_link_libs ${cuda_link_libs} ${CUDA_CUDA_LIBRARY} ${CUDA_nvcuvid_LIBRARY})
+    endif()
 
     if(WIN32)
-      find_cuda_helper_libs(nvcuvenc)
-      set(cuda_link_libs ${cuda_link_libs} ${CUDA_nvcuvenc_LIBRARY})
+      if(HAVE_NVCUVENC)
+        set(cuda_link_libs ${cuda_link_libs} ${CUDA_nvcuvenc_LIBRARY})
+      endif()
     endif()
 
     if(WITH_FFMPEG)

--- a/modules/gpu/src/precomp.hpp
+++ b/modules/gpu/src/precomp.hpp
@@ -98,7 +98,9 @@
         #include <nvcuvid.h>
 
         #ifdef WIN32
-            #include <NVEncoderAPI.h>
+            #ifdef HAVE_NVCUVENC
+                #include <NVEncoderAPI.h>
+            #endif
         #endif
     #endif
 

--- a/modules/gpu/src/video_writer.cpp
+++ b/modules/gpu/src/video_writer.cpp
@@ -42,7 +42,7 @@
 
 #include "precomp.hpp"
 
-#if !defined(HAVE_CUDA) || defined(CUDA_DISABLER) || !defined(HAVE_NVCUVID) || !defined(WIN32)
+#if !defined(HAVE_CUDA) || defined(CUDA_DISABLER) || !defined(HAVE_NVCUVENC) || !defined(WIN32)
 
 class cv::gpu::VideoWriter_GPU::Impl
 {


### PR DESCRIPTION
I resolved [Issues #4858](https://github.com/Itseez/opencv/issues/4858).
And, this change is same as the [Pull requests #6036](https://github.com/Itseez/opencv/pull/6036).
I appied to '2.4' branch.