### PR TITLE
revert PR 5362

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -998,7 +998,7 @@ public:
                     {
                         if( result == 1 )
                             result = -(int)classifier->data.stages.size();
-                        if( -result >= 0 ) // TODO: Add variable to define a specific last accepted Stage - ABI_COMPATIBILITY problem with new/changed virtual functions - PR #5362
+                        if( classifier->data.stages.size() + result == 0 )
                         {
                             mtx->lock();
                             rectangles->push_back(Rect(cvRound(x*scalingFactor),


### PR DESCRIPTION
PR https://github.com/Itseez/opencv/pull/5362 tries to fix issues with the cascade classifier interface, but by doing so it broke down the extended functionality using the stage scores and weights. Therefore this needs to be reverted and better investigated before suggesting another fix.

@Dikay900 here you go!
@alalek or @vpisarev I suggest to merge this rather fast, so that problems around this issue can all be closed for now.

Related issue: https://github.com/Itseez/opencv/issues/6022
Related Q&A question and tests performed: http://answers.opencv.org/question/84605/detectmultiscale-fails-when-weights-are-requested