### PR TITLE
Remove gittip link in 2.4.12.x-prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ### OpenCV: Open Source Computer Vision Library
 
-[![Gittip](http://img.shields.io/gittip/OpenCV.png)](https://www.gittip.com/OpenCV/)
-
 #### Resources
 
 * Homepage: <http://opencv.org>


### PR DESCRIPTION
This project is dead from the 1st September last year