### PR TITLE
fixed compilation warning

### DIFF
--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -317,6 +317,7 @@ enum {
 #define ARM_ROUND(_value, _asm_string) \
     int res; \
     float temp; \
+    (void)temp; \
     asm(_asm_string : [res] "=r" (res), [temp] "=w" (temp) : [value] "w" (_value)); \
     return res;
 // 2. version for double


### PR DESCRIPTION
```
/hdd/usr/opencv/include/opencv2/core/types_c.h(351): warning: variable "temp" was set but never used
/hdd/usr/opencv/include/opencv2/core/types_c.h(351): warning: variable "temp" was set but never used
/hdd/usr/opencv/include/opencv2/core/types_c.h(351): warning: variable "temp" was set but never used
/hdd/usr/opencv/include/opencv2/core/types_c.h(351): warning: variable "temp" was set but never used
/hdd/usr/opencv/include/opencv2/core/types_c.h(351): warning: variable "temp" was set but never used
/hdd/usr/opencv/include/opencv2/core/types_c.h(351): warning: variable "temp" was set but never used
```