### PR TITLE
Added filename check to the ExifReader

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -267,13 +267,16 @@ int JpegDecoder::getOrientation()
 {
     int orientation = JPEG_ORIENTATION_TL;
 
-    ExifReader reader( m_filename );
-    if( reader.parse() )
+    if (m_filename.size() > 0)
     {
-        ExifEntry_t entry = reader.getTag( ORIENTATION );
-        if (entry.tag != INVALID_TAG)
+        ExifReader reader( m_filename );
+        if( reader.parse() )
         {
-            orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
+            ExifEntry_t entry = reader.getTag( ORIENTATION );
+            if (entry.tag != INVALID_TAG)
+            {
+                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
+            }
         }
     }
 

--- a/modules/imgcodecs/src/jpeg_exif.cpp
+++ b/modules/imgcodecs/src/jpeg_exif.cpp
@@ -128,6 +128,11 @@ std::map<int, ExifEntry_t > ExifReader::getExif()
 
     size_t count;
 
+    if (m_filename.size() == 0)
+    {
+        return m_exif;
+    }
+
     FILE* f = fopen( m_filename.c_str(), "rb" );
 
     if( !f )


### PR DESCRIPTION
When called from `imdecode`, ExifReader does not work, but make unnecessary call to `fopen`. This pull request adds checks fixing this behaviour.

Related issue: #6120.