### PR TITLE
findHomography sets output mask to all zeros in case of no inlier

### DIFF
--- a/modules/calib3d/src/fundam.cpp
+++ b/modules/calib3d/src/fundam.cpp
@@ -411,7 +411,13 @@ cv::Mat cv::findHomography( InputArray _points1, InputArray _points2,
             tempMask.copyTo(_mask);
     }
     else
+    {
         H.release();
+        if(_mask.needed() ) {
+            tempMask = Mat::zeros(npoints >= 0 ? npoints : 0, 1, CV_8U);
+            tempMask.copyTo(_mask);
+        }
+    }
 
     return H;
 }


### PR DESCRIPTION
Fixing #5551:
 > if we pass an empty mask and afterwards want to check for each provided point if it was an inlier, we get an index-out-of-bounds exception.

Replacing #5560 