### PR TITLE
resolve finding concurrent python2 and python3 installation on windows after #6000

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -26,7 +26,7 @@ function(find_python preferred_version min_version library_env include_dir_env
          libs_found libs_version_string libraries library debug_libraries
          debug_library include_path include_dir include_dir2 packages_path
          numpy_include_dirs numpy_version)
-if(NOT ${found})
+if(NOT ${found} OR WIN32)
   ocv_check_environment_variables(${executable})
   if(${executable})
     set(PYTHON_EXECUTABLE "${${executable}}")


### PR DESCRIPTION
After #6000 i cannot setup my machine to use both python2 and python3 concurrently anymore.
Since the problem of #6000 was only detected on Ubuntu i would like to force finding both python versions on windows machines since there was not such a problem.

@alalek please look over this