### PR TITLE
throws StsBadArg on wrong image type (related to #6149)

### DIFF
--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -145,8 +145,7 @@ namespace colormap
         // Applies the colormap on a given image.
         //
         // This function expects BGR-aligned data of type CV_8UC1 or
-        // CV_8UC3. If the wrong image type is given, the original image
-        // will be returned.
+        // CV_8UC3.
         //
         // Throws an error for wrong-aligned lookup table, which must be
         // of size 256 in the latest OpenCV release (2.3.1).
@@ -499,11 +498,8 @@ namespace colormap
             CV_Error(Error::StsAssert, "cv::LUT only supports tables of size 256.");
         Mat src = _src.getMat();
         // Return original matrix if wrong type is given (is fail loud better here?)
-        if(src.type() != CV_8UC1 && src.type() != CV_8UC3)
-        {
-            src.copyTo(_dst);
-            return;
-        }
+        if(src.type() != CV_8UC1  &&  src.type() != CV_8UC3)
+            CV_Error(Error::StsBadArg, "cv::ColorMap only supports source images of type CV_8UC1 or CV_8UC3");
         // Turn into a BGR matrix into its grayscale representation.
         if(src.type() == CV_8UC3)
             cvtColor(src.clone(), src, COLOR_BGR2GRAY);

--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -144,8 +144,7 @@ namespace colormap
 
         // Applies the colormap on a given image.
         //
-        // This function expects BGR-aligned data of type CV_8UC1 or
-        // CV_8UC3.
+        // This function expects BGR-aligned data of type CV_8UC1 or CV_8UC3.
         //
         // Throws an error for wrong-aligned lookup table, which must be
         // of size 256 in the latest OpenCV release (2.3.1).
@@ -497,7 +496,6 @@ namespace colormap
         if(_lut.total() != 256)
             CV_Error(Error::StsAssert, "cv::LUT only supports tables of size 256.");
         Mat src = _src.getMat();
-        // Return original matrix if wrong type is given (is fail loud better here?)
         if(src.type() != CV_8UC1  &&  src.type() != CV_8UC3)
             CV_Error(Error::StsBadArg, "cv::ColorMap only supports source images of type CV_8UC1 or CV_8UC3");
         // Turn into a BGR matrix into its grayscale representation.


### PR DESCRIPTION
https://github.com/Itseez/opencv/pull/6150
	alalek commented a day ago
	| If the wrong image type is given, the original image will be returned.
	I'm not sure that we should allow user to shoot the leg. I believe
	exception should be thrown in case of wrong types.