### PR TITLE
Adds supports for the majority of features2d to the Java wrappers

### DIFF
--- a/modules/features2d/misc/java/filelist
+++ b/modules/features2d/misc/java/filelist
@@ -1,1 +1,2 @@
 misc/java/src/cpp/features2d_manual.hpp
+include/opencv2/features2d.hpp

--- a/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
+++ b/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
@@ -408,17 +408,6 @@ enum
                                   // orientation will be drawn.
 };
 
-// Draw keypoints.
-CV_EXPORTS_W void drawKeypoints( const Mat& image, const std::vector<KeyPoint>& keypoints, Mat& outImage,
-                               const Scalar& color=Scalar::all(-1), int flags=0 );
-
-// Draws matches of keypints from two images on output image.
-CV_EXPORTS_W void drawMatches( const Mat& img1, const std::vector<KeyPoint>& keypoints1,
-                             const Mat& img2, const std::vector<KeyPoint>& keypoints2,
-                             const std::vector<DMatch>& matches1to2, Mat& outImg,
-                             const Scalar& matchColor=Scalar::all(-1), const Scalar& singlePointColor=Scalar::all(-1),
-                             const std::vector<char>& matchesMask=std::vector<char>(), int flags=0 );
-
 CV_EXPORTS_AS(drawMatches2) void drawMatches( const Mat& img1, const std::vector<KeyPoint>& keypoints1,
                              const Mat& img2, const std::vector<KeyPoint>& keypoints2,
                              const std::vector<std::vector<DMatch> >& matches1to2, Mat& outImg,

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -13,6 +13,8 @@ else:
 class_ignore_list = (
     #core
     "FileNode", "FileStorage", "KDTree", "KeyPoint", "DMatch",
+    #features2d
+    "SimpleBlobDetector", "FlannBasedMatcher", "DescriptorMatcher"
 )
 
 const_ignore_list = (


### PR DESCRIPTION
### Adds supports for the majority of features2d to the Java wrappers.

The primary reason for this change is to expose MSER detectRegions to the Java wrappers, but as a bonus we get support for almost the entire feature2d module.

* Adds the main features2d header to the parse list for the generator.
* Removes the manual definition of drawKeypoints and drawMatches since these are now included in the main header.
* Updates the generator to ignore SimpleBlobDetector, FlannBasedMatcher and DescriptorMatcher as these cause conflicts with the generator. This is okay since these were not previously included in the distribution anyway, so no harm is done.