### PR TITLE
gcc6: fix misleading indentation warning

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -1043,7 +1043,7 @@ icvRemoveQuadFromGroup(CvCBQuad **quads, int count, CvCBQuad *q0)
                         q0->count--;
                         break;
                     }
-                    break;
+                break;
             }
         }
     }

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -1349,27 +1349,27 @@ bool CV_StereoCalibrationTest::checkPandROI( int test_case_idx, const Mat& M, co
             return false;
         }
 
-        // step 2. check that all the points inside ROI belong to the original source image
-        Mat temp(imgsize, CV_8U), utemp, map1, map2;
-        temp = Scalar::all(1);
-        initUndistortRectifyMap(M, D, R, P, imgsize, CV_16SC2, map1, map2);
-        remap(temp, utemp, map1, map2, INTER_LINEAR);
+    // step 2. check that all the points inside ROI belong to the original source image
+    Mat temp(imgsize, CV_8U), utemp, map1, map2;
+    temp = Scalar::all(1);
+    initUndistortRectifyMap(M, D, R, P, imgsize, CV_16SC2, map1, map2);
+    remap(temp, utemp, map1, map2, INTER_LINEAR);
 
-        if(roi.x < 0 || roi.y < 0 || roi.x + roi.width > imgsize.width || roi.y + roi.height > imgsize.height)
-        {
+    if(roi.x < 0 || roi.y < 0 || roi.x + roi.width > imgsize.width || roi.y + roi.height > imgsize.height)
+    {
             ts->printf(cvtest::TS::LOG, "Test #%d. The ROI=(%d, %d, %d, %d) is outside of the imge rectangle\n",
-                test_case_idx, roi.x, roi.y, roi.width, roi.height);
+                            test_case_idx, roi.x, roi.y, roi.width, roi.height);
             return false;
-        }
-        double s = sum(utemp(roi))[0];
-        if( s > roi.area() || roi.area() - s > roi.area()*(1-eps) )
-        {
+    }
+    double s = sum(utemp(roi))[0];
+    if( s > roi.area() || roi.area() - s > roi.area()*(1-eps) )
+    {
             ts->printf(cvtest::TS::LOG, "Test #%d. The ratio of black pixels inside the valid ROI (~%g%%) is too large\n",
-                test_case_idx, s*100./roi.area());
+                            test_case_idx, s*100./roi.area());
             return false;
-        }
+    }
 
-        return true;
+    return true;
 }
 
 void CV_StereoCalibrationTest::run( int )

--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -8097,19 +8097,19 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
                     && (kpts[lastRowCorner_ind].pt.y == lastRow) )
                     lastRowCorner_ind++;
 
-                    if( (kpts[lastRowCorner_ind].pt.x == currCorner->pt.x)
-                     && (lastRowCorner_ind != curr_idx) )
-                    {
-                        size_t w = lastRowCorner_ind;
-                        // find the maximum in this block
-                        while(nmsFlags[w] != -1)
-                            w = nmsFlags[w];
+                if( (kpts[lastRowCorner_ind].pt.x == currCorner->pt.x)
+                 && (lastRowCorner_ind != curr_idx) )
+                {
+                    size_t w = lastRowCorner_ind;
+                    // find the maximum in this block
+                    while(nmsFlags[w] != -1)
+                        w = nmsFlags[w];
 
-                        if(kpts[curr_idx].response < kpts[w].response)
-                            nmsFlags[curr_idx] = (int)w;
-                        else
-                            nmsFlags[w] = (int)curr_idx;
-                    }
+                    if(kpts[curr_idx].response < kpts[w].response)
+                        nmsFlags[curr_idx] = (int)w;
+                    else
+                        nmsFlags[w] = (int)curr_idx;
+                }
             }
 
             // check left

--- a/modules/flann/include/opencv2/flann/any.h
+++ b/modules/flann/include/opencv2/flann/any.h
@@ -79,7 +79,8 @@ struct big_any_policy : typed_base_any_policy<T>
 {
     virtual void static_delete(void** x)
     {
-        if (* x) delete (* reinterpret_cast<T**>(x)); *x = NULL;
+        if (* x) delete (* reinterpret_cast<T**>(x));
+        *x = NULL;
     }
     virtual void copy_from_value(void const* src, void** dest)
     {

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1772,7 +1772,8 @@ cmpUlpsFlt_(const int* src1, const int* src2, size_t total, int imaxdiff, size_t
     for( i = 0; i < total; i++ )
     {
         int a = src1[i], b = src2[i];
-        if( a < 0 ) a ^= C; if( b < 0 ) b ^= C;
+        if( a < 0 ) a ^= C;
+        if( b < 0 ) b ^= C;
         int diff = std::abs(a - b);
         if( realmaxdiff < diff )
         {
@@ -1794,7 +1795,8 @@ cmpUlpsFlt_(const int64* src1, const int64* src2, size_t total, int imaxdiff, si
     for( i = 0; i < total; i++ )
     {
         int64 a = src1[i], b = src2[i];
-        if( a < 0 ) a ^= C; if( b < 0 ) b ^= C;
+        if( a < 0 ) a ^= C;
+        if( b < 0 ) b ^= C;
         double diff = fabs((double)a - (double)b);
         if( realmaxdiff < diff )
         {

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -82,7 +82,7 @@ bool CV_ECC_BaseTest::isMapCorrect(const Mat& map)
             tr = tr & (!cvIsNaN(mapVal) && (fabs(mapVal) < 1e9));
         }
 
-        return tr;
+    return tr;
 }
 
 double CV_ECC_BaseTest::computeRMS(const Mat& mat1, const Mat& mat2){

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -371,8 +371,8 @@ static void icvInitCapture_V4L() {
     }
     if (deviceHandle != -1)
       close(deviceHandle);
-      /* Set up to test the next /dev/video source in line */
-      CameraNumber++;
+    /* Set up to test the next /dev/video source in line */
+    CameraNumber++;
    } /* End while */
 
 }; /* End icvInitCapture_V4L */


### PR DESCRIPTION
cosmetic changes to fix misleading indentation warnings

http://developerblog.redhat.com/2016/02/26/gcc-6-wmisleading-indentation-vs-goto-fail/