### PR TITLE
MacOSX / QTKit capture: trying to fix invalid timer call

### DIFF
--- a/modules/highgui/src/cap_qtkit.mm
+++ b/modules/highgui/src/cap_qtkit.mm
@@ -95,6 +95,8 @@ didDropVideoFrameWithSampleBuffer:(QTSampleBuffer *)sampleBuffer
 - (int)updateImage;
 - (IplImage*)getOutput;
 
+- (void)doFireTimer:(NSTimer *)timer;
+
 @end
 
 /*****************************************************************************
@@ -623,6 +625,11 @@ didDropVideoFrameWithSampleBuffer:(QTSampleBuffer *)sampleBuffer
     CVBufferRelease(pixels);
 
     return 1;
+}
+
+- (void)doFireTimer:(NSTimer *)timer {
+    (void)timer;
+    // dummy
 }
 
 @end


### PR DESCRIPTION
The same as #6051, which solved #5874, but this one is for old branch 2.4. Works for me. Since many developers are still working on 2.x so might be useful.