### PR TITLE
Fix the OpenCV's random access iterator according to std::distance: d(x,y) = -d(y,x)

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -2474,7 +2474,7 @@ ptrdiff_t operator - (const MatConstIterator& b, const MatConstIterator& a)
     if( a.m != b.m )
         return ((size_t)(-1) >> 1);
     if( a.sliceEnd == b.sliceEnd )
-        return (b.ptr - a.ptr)/b.elemSize;
+        return (b.ptr - a.ptr)/static_cast<ptrdiff_t>(b.elemSize);
 
     return b.lpos() - a.lpos();
 }


### PR DESCRIPTION
Unfortunately, cv::Mat does not accept the std::distance axiom for the random-access iterators: std::distance(x, y) == -std::distance(y, x).

Please find the minimal not-working example below:

```
#include <opencv2/core.hpp>
#include <vector>

#include <cstdlib>
#include <cassert>

int main(int argc, char** argv)
{
    std::vector<int> v(10u);
    std::ptrdiff_t d1 = std::distance(v.cbegin(), v.cend()); // 10
    std::ptrdiff_t d2 = std::distance(v.cend(), v.cbegin()); // -10
    assert(("d(v,w) != -d(w,v)", d1 == -d2)); // successfully passed

    cv::Mat1i m(1u, 10u);
    d1 = std::distance(m.begin(), m.end()); // 10
    d2 = std::distance(m.end(), m.begin()); // positive overflow here!
    assert(("d(v,w) != -d(w,v)", d1 == -d2)); // failed here!

    return EXIT_SUCCESS;
}
```

This commit fixes that bug.
