### PR TITLE
Fix AGAST keypoint declared size.

### DIFF
--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -793,7 +793,7 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto homogeneous;
             success_structured:
@@ -810,7 +810,7 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto structured;
         }
@@ -3237,7 +3237,7 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto homogeneous;
           success_structured:
@@ -3254,7 +3254,7 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto structured;
         }
@@ -5319,7 +5319,7 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto homogeneous;
           success_structured:
@@ -5336,7 +5336,7 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto structured;
         }
@@ -7440,7 +7440,7 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
         }
     }
@@ -7892,7 +7892,7 @@ static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto homogeneous;
             success_structured:
@@ -7909,7 +7909,7 @@ static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                     keypoints.reserve(nExpectedCorners);
                 }
             }
-            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 1.0f));
+            keypoints.push_back(KeyPoint(Point2f((float)x, (float)y), 7.0f));
             total++;
             goto structured;
         }


### PR DESCRIPTION

 This tiny PR fixes the declared size of AGAST detected keypoint. It should be always 7.0f according to original paper. The value 7.0f is the same like in case of FAST (see fast.cpp).

Impact:

 * It may be trivial when AGAST is used against some OpenCV descriptor, since some descriptors looks for the pattern size / octave.