### PR TITLE
Removed older libraries pointing to 2.4 in eclipse tutorial docs

### DIFF
--- a/doc/tutorials/introduction/linux_eclipse/linux_eclipse.markdown
+++ b/doc/tutorials/introduction/linux_eclipse/linux_eclipse.markdown
@@ -112,7 +112,7 @@ Making a project
             @endcode
             My output (in case you want to check) was:
             @code{.bash}
-            -L/usr/local/lib -lopencv_core -lopencv_imgproc -lopencv_highgui -lopencv_ml -lopencv_video -lopencv_features2d -lopencv_calib3d -lopencv_objdetect -lopencv_contrib -lopencv_legacy -lopencv_flann
+            -L/usr/local/lib -lopencv_core -lopencv_imgproc -lopencv_highgui -lopencv_ml -lopencv_video -lopencv_features2d -lopencv_calib3d -lopencv_objdetect -lopencv_videoio -lopencv_imgcodecs -lopencv_flann
             @endcode
             Now you are done. Click **OK**
 


### PR DESCRIPTION

The following PR resolves documentation error in  issue 5002 
### Changes :
 Added   : -lopencv_videoio -lopencv_imgcodecs 
Removed : -lopencv_legacy -lopencv_contrib 