### PR TITLE
fix for CXX move semantics for cv::Ptr, cv::Mat, cv::UMat

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1165,6 +1165,9 @@ Mat::Mat(Mat&& m)
 inline
 Mat& Mat::operator = (Mat&& m)
 {
+    if (this == &m)
+      return *this;
+
     release();
     flags = m.flags; dims = m.dims; rows = m.rows; cols = m.cols; data = m.data;
     datastart = m.datastart; dataend = m.dataend; datalimit = m.datalimit; allocator = m.allocator;
@@ -3599,6 +3602,8 @@ UMat::UMat(UMat&& m)
 inline
 UMat& UMat::operator = (UMat&& m)
 {
+    if (this == &m)
+      return *this;
     release();
     flags = m.flags; dims = m.dims; rows = m.rows; cols = m.cols;
     allocator = m.allocator; usageFlags = m.usageFlags;

--- a/modules/core/include/opencv2/core/ptr.inl.hpp
+++ b/modules/core/include/opencv2/core/ptr.inl.hpp
@@ -264,6 +264,9 @@ Ptr<T>::Ptr(Ptr&& o) : owner(o.owner), stored(o.stored)
 template<typename T>
 Ptr<T>& Ptr<T>::operator = (Ptr<T>&& o)
 {
+    if (this == &o)
+        return *this;
+
     release();
     owner = o.owner;
     stored = o.stored;


### PR DESCRIPTION
resolves #6258

### What does this PR change?
Adds additional check for self-assigment for rvalue-reference assignment operator for Ptr, Mat, UMat. This fixes releasing self when performing actions such as
`ptr = std::move(ptr);`
`mat = std::move(mat);`

This becomes an issue, for example, when std::stable_sort of std::vector<cv::Ptr> is called.