### PR TITLE
fix OpenCV_CONFIG_PATH get null value after CMake 2.8.11

### DIFF
--- a/cmake/OpenCVConfig.cmake
+++ b/cmake/OpenCVConfig.cmake
@@ -109,7 +109,12 @@ if(NOT OpenCV_FIND_QUIETLY)
   message(STATUS "OpenCV STATIC: ${OpenCV_STATIC}")
 endif()
 
-get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH CACHE)
+if(CMAKE_VERSION VERSION_LESS "2.8.12")
+  get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH CACHE)
+else()
+  get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY CACHE)
+endif()
+
 if(OpenCV_RUNTIME AND OpenCV_ARCH)
   if(OpenCV_STATIC AND EXISTS "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib/OpenCVConfig.cmake")
     if(OpenCV_CUDA AND EXISTS "${OpenCV_CONFIG_PATH}/gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib/OpenCVConfig.cmake")

--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -110,7 +110,11 @@ set(OpenCV_SHARED @BUILD_SHARED_LIBS@)
 set(OpenCV_USE_MANGLED_PATHS @OpenCV_USE_MANGLED_PATHS_CONFIGCMAKE@)
 
 # Extract the directory where *this* file has been installed (determined at cmake run-time)
-get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH CACHE)
+if(CMAKE_VERSION VERSION_LESS "2.8.12")
+  get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH CACHE)
+else()
+  get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY CACHE)
+endif()
 
 if(NOT WIN32 OR ANDROID)
   if(ANDROID)


### PR DESCRIPTION
resolves OpenCV_CONFIG_PATH get null value after CMake 2.8.11

### What does this PR change?
get_filename_component(<VAR> <FileName> PATH [CACHE]) is deprecated
after CMake 2.8.11

It should be replace by
get_filename_component(<VAR> <FileName> DIRECTORY [CACHE])