### PR TITLE
Fix incompatibility with some C++11 implementations

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -363,7 +363,7 @@ CV_EXPORTS void parallel_for_(const Range& range, const ParallelLoopBody& body, 
 template<typename _Tp, typename Functor> inline
 void Mat::forEach_impl(const Functor& operation) {
     if (false) {
-        operation(*reinterpret_cast<_Tp*>(0), reinterpret_cast<int*>(NULL));
+        operation(*reinterpret_cast<_Tp*>(0), reinterpret_cast<int*>(0));
         // If your compiler fail in this line.
         // Please check that your functor signature is
         //     (_Tp&, const int*)   <- multidimential


### PR DESCRIPTION
I've ran into this issue with `reinterpret_cast` while trying to compile OpenCV 3.1.0 on FreeBSD. The proposed change fixes this by no longer using `NULL`.

Background:
Since C++11, the null pointer constant `NULL` may be defined as either `0` or `nullptr` (see [cppreference.com:NULL](http://en.cppreference.com/w/cpp/types/NULL)). It seems on most systems (like Mac OS X and Linux) it is still defined as `0` when using `-std=c++11`. However, this is not the case on my FreeBSD system (10.2-RELEASE), where it being defined as `nullptr` causes `reinterpret_cast` to be rejected (see item 9 on [cppreference.com:reinterpret_cast](http://en.cppreference.com/w/cpp/language/reinterpret_cast)):

```
./include/opencv2/core/utility.hpp:362:47: error: reinterpret_cast from 'nullptr_t' to 'int *' is not allowed
        operation(*reinterpret_cast<_Tp*>(0), reinterpret_cast<int*>(NULL));
                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```