### PR TITLE
Fix FreeBSD compatibility

### DIFF
--- a/modules/imgcodecs/src/rgbe.cpp
+++ b/modules/imgcodecs/src/rgbe.cpp
@@ -43,9 +43,7 @@
 #include "precomp.hpp"
 #include "rgbe.hpp"
 #include <math.h>
-#if !defined(__APPLE__)
-#include <malloc.h>
-#endif
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 


### PR DESCRIPTION
The header `<malloc.h>` is deprecated / non-standard. Instead, `<stdlib.h>` should be used, which is defined by C99 and later.

On FreeBSD, using `<malloc.h>` generates an error:

```
In file included from ./modules/imgcodecs/src/rgbe.cpp:50:
/usr/include/malloc.h:3:2: error: "<malloc.h> has been replaced by <stdlib.h>"
#error "<malloc.h> has been replaced by <stdlib.h>"
 ^
```

This PR fixes the issue for FreeBSD specifically (since it currently generates an error), but it could also be fixed for all systems by removing the `#ifdef` altogether, since on `__APPLE__`, `<stdlib.h>` is also available. The entire include block would then become:

```
#include "precomp.hpp"
#include "rgbe.hpp"
#include <math.h>
#include <stdlib.h>
#include <string.h>
#include <ctype.h>
```

However, this should be properly tested on all platforms first, which is why I first propose this FreeBSD-only fix.