### PR TITLE
suppress cmake policy 0020 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ if(WINRT)
   endif()
 endif()
 
+if(POLICY CMP0020)
+  cmake_policy(SET CMP0020 OLD)
+endif()
+
 if(POLICY CMP0022)
   cmake_policy(SET CMP0022 OLD)
 endif()


### PR DESCRIPTION
resolves #6260

Suppress cmake policy 0020 warning while generating make files. It happened when WITH_QT checked.