### PR TITLE
Add support for YUV 4:2:0 NV12 frame format in VFW camera capture

### DIFF
--- a/modules/videoio/src/cap_vfw.cpp
+++ b/modules/videoio/src/cap_vfw.cpp
@@ -43,6 +43,8 @@
 
 #include <vfw.h>
 
+#include <cstdio>
+
 #ifdef __GNUC__
 #define WM_CAP_FIRSTA              (WM_USER)
 #define capSendMessage(hwnd,m,w,l) (IsWindow(hwnd)?SendMessage(hwnd,m,w,l):0)
@@ -498,8 +500,17 @@ IplImage* CvCaptureCAM_VFW::retrieveFrame(int)
         frame = cvCreateImage( cvSize( vfmt0.biWidth, vfmt0.biHeight ), 8, 3 );
     }
 
-    if( vfmt0.biCompression != BI_RGB ||
-        vfmt0.biBitCount != 24 )
+    if ( vfmt0.biCompression == MAKEFOURCC('N','V','1','2') )
+    {
+        // Frame is in YUV 4:2:0 NV12 format, convert to BGR color space
+        // See https://msdn.microsoft.com/en-us/library/windows/desktop/dd206750(v=vs.85).aspx#nv12)
+        IplImage src;
+        cvInitImageHeader( &src, cvSize( vfmt0.biWidth, vfmt0.biHeight * 3 / 2 ), IPL_DEPTH_8U, 1, IPL_ORIGIN_BL, 4 );
+        cvSetData( &src, hdr->lpData, src.widthStep );
+        cvCvtColor( &src, frame, CV_YUV2BGR_NV12 );
+    }
+    else if( vfmt0.biCompression != BI_RGB ||
+             vfmt0.biBitCount != 24 )
     {
         BITMAPINFOHEADER vfmt1 = icvBitmapHeader( vfmt0.biWidth, vfmt0.biHeight, 24 );
 

--- a/modules/videoio/src/cap_vfw.cpp
+++ b/modules/videoio/src/cap_vfw.cpp
@@ -43,8 +43,6 @@
 
 #include <vfw.h>
 
-#include <cstdio>
-
 #ifdef __GNUC__
 #define WM_CAP_FIRSTA              (WM_USER)
 #define capSendMessage(hwnd,m,w,l) (IsWindow(hwnd)?SendMessage(hwnd,m,w,l):0)


### PR DESCRIPTION
This pull request resolves #6061, it checks if the video frame format is YUV 4:2:0 NV12 and converts the frame to the BGR color space before returning the frame. Tested on my Surface 4 using the front and rear camera.