### PR TITLE
add cascade classifier info - total number of unique features passed …

### DIFF
--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -191,6 +191,7 @@ bool CvCascadeClassifier::train( const string _cascadeDirName,
     cascadeParams.printAttrs();
     stageParams->printAttrs();
     featureParams->printAttrs();
+    cout << "Number of unique features given windowSize [" << _cascadeParams.winSize.width << "," << _cascadeParams.winSize.height << "] : " << featureEvaluator->getNumFeatures() << "" << endl;
 
     int startNumStages = (int)stageClassifiers.size();
     if ( startNumStages > 1 )


### PR DESCRIPTION
### What does this PR change?
It adds extra info during the training of a boosted cascade of weak classifiers, identifying the number of unique features calculated and evaluated on the given window size during the boosting process.

Ported back to 2.4 from https://github.com/Itseez/opencv/pull/6286