### PR TITLE
Now handling the `rpath` on Mac OS X properly

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -824,6 +824,10 @@ macro(_ocv_create_module)
     set_target_properties(${the_module} PROPERTIES FOLDER "modules")
   endif()
 
+  if(NOT CMAKE_MACOSX_RPATH)
+    set_target_properties(${the_module} PROPERTIES INSTALL_NAME_DIR lib)
+  endif()
+
   set_target_properties(${the_module} PROPERTIES
     OUTPUT_NAME "${the_module}${OPENCV_DLLVERSION}"
     DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
@@ -833,7 +837,6 @@ macro(_ocv_create_module)
     COMPILE_PDB_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH}
     LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH}
     RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}
-    INSTALL_NAME_DIR lib
   )
 
   # For dynamic link numbering convenions


### PR DESCRIPTION
Adding `-DCMAKE_MACOSX_RPATH=ON` to the cmake configuration line allows to use the `rpath` on Mac OS  X.

