### PR TITLE
Fix missing format field when writing DTrees-based StatModel to file

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1225,6 +1225,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
         << "minDisparity" << params.minDisparity
         << "numDisparities" << params.numDisparities

--- a/modules/calib3d/src/stereosgbm.cpp
+++ b/modules/calib3d/src/stereosgbm.cpp
@@ -1512,6 +1512,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
         << "minDisparity" << params.minDisparity
         << "numDisparities" << params.numDisparities

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -3059,6 +3059,9 @@ public:
     /** Returns the algorithm string identifier.
      This string is used as top level xml/yml node tag when the object is saved to a file or string. */
     CV_WRAP virtual String getDefaultName() const;
+
+protected:
+    void writeFormat(FileStorage& fs) const;
 };
 
 struct Param {

--- a/modules/core/src/algorithm.cpp
+++ b/modules/core/src/algorithm.cpp
@@ -57,7 +57,6 @@ void Algorithm::save(const String& filename) const
 {
     FileStorage fs(filename, FileStorage::WRITE);
     fs << getDefaultName() << "{";
-    fs << "format" << (int)3;
     write(fs);
     fs << "}";
 }
@@ -65,6 +64,11 @@ void Algorithm::save(const String& filename) const
 String Algorithm::getDefaultName() const
 {
     return String("my_object");
+}
+
+void Algorithm::writeFormat(FileStorage& fs) const
+{
+    fs << "format" << (int)3;
 }
 
 }

--- a/modules/cudaimgproc/src/canny.cpp
+++ b/modules/cudaimgproc/src/canny.cpp
@@ -93,6 +93,7 @@ namespace
 
         void write(FileStorage& fs) const
         {
+            writeFormat(fs);
             fs << "name" << "Canny_CUDA"
             << "low_thresh" << low_thresh_
             << "high_thresh" << high_thresh_

--- a/modules/cudaimgproc/src/hough_circles.cpp
+++ b/modules/cudaimgproc/src/hough_circles.cpp
@@ -99,6 +99,7 @@ namespace
 
         void write(FileStorage& fs) const
         {
+            writeFormat(fs);
             fs << "name" << "HoughCirclesDetector_CUDA"
             << "dp" << dp_
             << "minDist" << minDist_

--- a/modules/cudaimgproc/src/hough_lines.cpp
+++ b/modules/cudaimgproc/src/hough_lines.cpp
@@ -95,6 +95,7 @@ namespace
 
         void write(FileStorage& fs) const
         {
+            writeFormat(fs);
             fs << "name" << "HoughLinesDetector_CUDA"
             << "rho" << rho_
             << "theta" << theta_

--- a/modules/cudaimgproc/src/hough_segments.cpp
+++ b/modules/cudaimgproc/src/hough_segments.cpp
@@ -98,6 +98,7 @@ namespace
 
         void write(FileStorage& fs) const
         {
+            writeFormat(fs);
             fs << "name" << "PHoughLinesDetector_CUDA"
             << "rho" << rho_
             << "theta" << theta_

--- a/modules/features2d/src/akaze.cpp
+++ b/modules/features2d/src/akaze.cpp
@@ -217,6 +217,7 @@ namespace cv
 
         void write(FileStorage& fs) const
         {
+            writeFormat(fs);
             fs << "descriptor" << descriptor;
             fs << "descriptor_channels" << descriptor_channels;
             fs << "descriptor_size" << descriptor_size;

--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -184,6 +184,7 @@ void SimpleBlobDetectorImpl::read( const cv::FileNode& fn )
 
 void SimpleBlobDetectorImpl::write( cv::FileStorage& fs ) const
 {
+    writeFormat(fs);
     params.write(fs);
 }
 

--- a/modules/features2d/src/kaze.cpp
+++ b/modules/features2d/src/kaze.cpp
@@ -159,6 +159,7 @@ namespace cv
 
         void write(FileStorage& fs) const
         {
+            writeFormat(fs);
             fs << "extended" << (int)extended;
             fs << "upright" << (int)upright;
             fs << "threshold" << threshold;

--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -1179,6 +1179,7 @@ void FlannBasedMatcher::read( const FileNode& fn)
 
 void FlannBasedMatcher::write( FileStorage& fs) const
 {
+     writeFormat(fs);
      fs << "indexParams" << "[";
 
      if (indexParams)

--- a/modules/ml/src/ann_mlp.cpp
+++ b/modules/ml/src/ann_mlp.cpp
@@ -1151,6 +1151,7 @@ public:
             return;
         int i, l_count = layer_count();
 
+        writeFormat(fs);
         fs << "layer_sizes" << layer_sizes;
 
         write_params( fs );

--- a/modules/ml/src/boost.cpp
+++ b/modules/ml/src/boost.cpp
@@ -387,6 +387,7 @@ public:
         if( roots.empty() )
             CV_Error( CV_StsBadArg, "RTrees have not been trained" );
 
+        writeFormat(fs);
         writeParams(fs);
 
         int k, ntrees = (int)roots.size();

--- a/modules/ml/src/em.cpp
+++ b/modules/ml/src/em.cpp
@@ -770,6 +770,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "training_params" << "{";
         write_params(fs);
         fs << "}";

--- a/modules/ml/src/knearest.cpp
+++ b/modules/ml/src/knearest.cpp
@@ -466,6 +466,7 @@ public:
 
     void write( FileStorage& fs ) const
     {
+        writeFormat(fs);
         impl->write(fs);
     }
 

--- a/modules/ml/src/lr.cpp
+++ b/modules/ml/src/lr.cpp
@@ -547,6 +547,7 @@ void LogisticRegressionImpl::write(FileStorage& fs) const
     {
         CV_Error(CV_StsBadArg,"file can't open. Check file path");
     }
+    writeFormat(fs);
     string desc = "Logisitic Regression Classifier";
     fs<<"classifier"<<desc.c_str();
     fs<<"alpha"<<this->params.alpha;

--- a/modules/ml/src/nbayes.cpp
+++ b/modules/ml/src/nbayes.cpp
@@ -342,6 +342,7 @@ public:
     {
         int nclasses = (int)cls_labels.total(), i;
 
+        writeFormat(fs);
         fs << "var_count" << (var_idx.empty() ? nallvars : (int)var_idx.total());
         fs << "var_all" << nallvars;
 

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -296,6 +296,7 @@ public:
         if( roots.empty() )
             CV_Error( CV_StsBadArg, "RTrees have not been trained" );
 
+        writeFormat(fs);
         writeParams(fs);
 
         fs << "oob_error" << oobError;

--- a/modules/ml/src/svm.cpp
+++ b/modules/ml/src/svm.cpp
@@ -2037,6 +2037,7 @@ public:
         if( !isTrained() )
             CV_Error( CV_StsParseError, "SVM model data is invalid, check sv_count, var_* and class_count tags" );
 
+        writeFormat(fs);
         write_params( fs );
 
         fs << "var_count" << var_count;

--- a/modules/ml/src/svmsgd.cpp
+++ b/modules/ml/src/svmsgd.cpp
@@ -364,6 +364,7 @@ void SVMSGDImpl::write(FileStorage& fs) const
     if( !isTrained() )
         CV_Error( CV_StsParseError, "SVMSGD model data is invalid, it hasn't been trained" );
 
+    writeFormat(fs);
     writeParams( fs );
 
     fs << "weights" << weights_;

--- a/modules/ml/src/tree.cpp
+++ b/modules/ml/src/tree.cpp
@@ -1681,6 +1681,7 @@ void DTreesImpl::writeTree( FileStorage& fs, int root ) const
 
 void DTreesImpl::write( FileStorage& fs ) const
 {
+    writeFormat(fs);
     writeParams(fs);
     writeTree(fs, roots[0]);
 }

--- a/modules/photo/src/align.cpp
+++ b/modules/photo/src/align.cpp
@@ -184,6 +184,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "max_bits" << max_bits
            << "exclude_range" << exclude_range

--- a/modules/photo/src/calibrate.cpp
+++ b/modules/photo/src/calibrate.cpp
@@ -141,6 +141,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "samples" << samples
            << "lambda" << lambda
@@ -250,6 +251,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "max_iter" << max_iter
            << "threshold" << threshold;

--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -265,6 +265,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "contrast_weight" << wcon
            << "saturation_weight" << wsat

--- a/modules/photo/src/tonemap.cpp
+++ b/modules/photo/src/tonemap.cpp
@@ -83,6 +83,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "gamma" << gamma;
     }
@@ -161,6 +162,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "gamma" << gamma
            << "bias" << bias
@@ -242,6 +244,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "gamma" << gamma
            << "contrast" << contrast
@@ -339,6 +342,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "gamma" << gamma
            << "intensity" << intensity
@@ -446,6 +450,7 @@ public:
 
     void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name
            << "gamma" << gamma
            << "scale" << scale

--- a/modules/shape/src/aff_trans.cpp
+++ b/modules/shape/src/aff_trans.cpp
@@ -79,6 +79,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "affine_type" << int(fullAffine);
     }

--- a/modules/shape/src/haus_dis.cpp
+++ b/modules/shape/src/haus_dis.cpp
@@ -77,6 +77,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "distance" << distanceFlag
            << "rank" << rankProportion;

--- a/modules/shape/src/hist_cost.cpp
+++ b/modules/shape/src/hist_cost.cpp
@@ -99,6 +99,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "flag" << flag
            << "dummies" << nDummies
@@ -224,6 +225,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "flag" << flag
            << "dummies" << nDummies
@@ -350,6 +352,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "dummies" << nDummies
            << "default" << defaultCost;
@@ -466,6 +469,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "dummies" << nDummies
            << "default" << defaultCost;

--- a/modules/shape/src/sc_dis.cpp
+++ b/modules/shape/src/sc_dis.cpp
@@ -137,6 +137,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "nRads" << nRadialBins
            << "nAngs" << nAngularBins

--- a/modules/shape/src/tps_trans.cpp
+++ b/modules/shape/src/tps_trans.cpp
@@ -81,6 +81,7 @@ public:
     //! write/read
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
            << "regularization" << regularizationParameter;
     }

--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -183,6 +183,7 @@ public:
 
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
         << "history" << history
         << "nsamples" << nN

--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -286,6 +286,7 @@ public:
 
     virtual void write(FileStorage& fs) const
     {
+        writeFormat(fs);
         fs << "name" << name_
         << "history" << history
         << "nmixtures" << nmixtures


### PR DESCRIPTION
resolves #6294

### What does this PR change?

Make output from StatModel::save() and StatModel()::write for DTrees-based StatModel's such as RTrees and Boost the same. This is accomplished by moving the write of the "format" field from Algorithm::save() to DTreesImpl::writeParams(). This appears to be safe as the format field is only used by DTreesImpl and not by any other Algorithm-derived objects.

This is the easiest way to fix the issue but it does mean that other Algorithm-derived objects would no longer add the format field when saving to file.