### PR TITLE
cap_gst: inspect sink instead of videoconvert to find out properties

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -847,7 +847,7 @@ bool CvCapture_GStreamer::open( int type, const char* filename )
             duration = -1;
         }
 
-        GstPad* pad = gst_element_get_static_pad(color, "src");
+        GstPad* pad = gst_element_get_static_pad(sink, "sink");
 #if GST_VERSION_MAJOR == 0
         GstCaps* buffer_caps = gst_pad_get_caps(pad);
 #else


### PR DESCRIPTION
videoconvert might not be present on a manual pipeline, but appsink must
be.

without this change you get warnings like
```
(python3:10829): GStreamer-CRITICAL **: gst_element_get_static_pad: assertion 'GST_IS_ELEMENT (element)' failed

(python3:10829): GStreamer-CRITICAL **: gst_pad_get_current_caps: assertion 'GST_IS_PAD (pad)' failed

(python3:10829): GStreamer-CRITICAL **: gst_caps_get_structure: assertion 'GST_IS_CAPS (caps)' failed

(python3:10829): GStreamer-CRITICAL **: gst_structure_get_int: assertion 'structure != NULL' failed

(python3:10829): GStreamer-CRITICAL **: gst_structure_get_int: assertion 'structure != NULL' failed

(python3:10829): GStreamer-CRITICAL **: gst_structure_get_fraction: assertion 'structure != NULL' failed
```

when using:
```python
cv2.VideoCapture("v4l2src ! appsink")
```