### PR TITLE
Add function setRNGSeed and seed setup in python tests

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -2170,6 +2170,14 @@ is much faster to use this function to retrieve the generator and then use RNG::
 */
 CV_EXPORTS RNG& theRNG();
 
+/** @brief Sets state of default random number generator.
+
+The function sets state of default random number generator to custom value.
+@param new state for default random number generator
+@sa RNG, randu, randn
+*/
+CV_EXPORTS_W void setRNGSeed(int seed);
+
 /** @brief Generates a single uniformly-distributed random number or an array of random numbers.
 
 Non-template variant of the function fills the matrix dst with uniformly-distributed

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -2173,7 +2173,7 @@ CV_EXPORTS RNG& theRNG();
 /** @brief Sets state of default random number generator.
 
 The function sets state of default random number generator to custom value.
-@param new state for default random number generator
+@param seed new state for default random number generator
 @sa RNG, randu, randn
 */
 CV_EXPORTS_W void setRNGSeed(int seed);

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -734,6 +734,12 @@ cv::RNG& cv::theRNG()
     return getCoreTlsData().get()->rng;
 }
 
+void cv::setRNGSeed(int seed)
+{
+    getCoreTlsData().get()->rng.state = static_cast<uint64>(seed);
+}
+
+
 void cv::randu(InputOutputArray dst, InputArray low, InputArray high)
 {
     theRNG().fill(dst, RNG::UNIFORM, low, high);

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -736,7 +736,7 @@ cv::RNG& cv::theRNG()
 
 void cv::setRNGSeed(int seed)
 {
-    getCoreTlsData().get()->rng.state = static_cast<uint64>(seed);
+    theRNG() = RNG(static_cast<uint64>(seed));
 }
 
 

--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -42,6 +42,7 @@ class NewOpenCVTests(unittest.TestCase):
         return self.image_cache[filename]
 
     def setUp(self):
+        cv2.setRNGSeed(10)
         self.image_cache = {}
 
     def hashimg(self, im):


### PR DESCRIPTION
### What does this PR change?
Add function for initialization of default RNG object.
Python tests updated: now setRNGSeed sets seed on every test start.