### PR TITLE
Error message for wrong kernel size was insufficient.

### DIFF
--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -607,7 +607,7 @@ void cv::Canny( InputArray _src, OutputArray _dst,
     }
 
     if ((aperture_size & 1) == 0 || (aperture_size != -1 && (aperture_size < 3 || aperture_size > 7)))
-        CV_Error(CV_StsBadFlag, "Aperture size should be odd");
+        CV_Error(CV_StsBadFlag, "Aperture size should be odd between 3 and 7");
 
     if (low_thresh > high_thresh)
         std::swap(low_thresh, high_thresh);


### PR DESCRIPTION
### What does this PR change?
Modified error message.

When setting a wrong kernel size, the error message only tells the user that it
must be odd, however the conditions for rejection include values > 7 which must
be communicated. Without that, the message would be incorrect and confusing if
the user is unaware that only values 3, 5, 7 are accepted.