### PR TITLE
Backport of setRNGSeed implementation and python test randomness fix

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -2593,6 +2593,9 @@ CV_EXPORTS_W double kmeans( InputArray data, int K, CV_OUT InputOutputArray best
 //! returns the thread-local Random number generator
 CV_EXPORTS RNG& theRNG();
 
+//! sets state of the thread-local Random number generator
+CV_EXPORTS_W void setRNGSeed(int seed);
+
 //! returns the next unifomly-distributed random number of the specified type
 template<typename _Tp> static inline _Tp randu() { return (_Tp)theRNG(); }
 

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -806,6 +806,11 @@ RNG& theRNG()
 
 }
 
+void cv::setRNGSeed(int seed)
+{
+    theRNG() = RNG(static_cast<uint64>(seed));
+}
+
 void cv::randu(InputOutputArray dst, InputArray low, InputArray high)
 {
     theRNG().fill(dst, RNG::UNIFORM, low, high);

--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -42,6 +42,7 @@ class NewOpenCVTests(unittest.TestCase):
         return self.image_cache[filename]
 
     def setUp(self):
+        cv2.setRNGSeed(10)
         self.image_cache = {}
 
     def hashimg(self, im):


### PR DESCRIPTION
### What does this PR change?
Some python binding tests use random values(i.e. use RANSAC) so we have to reset random seed to ensure test stability.


