### PR TITLE
kalman.py was broken totally

### DIFF
--- a/samples/python/kalman.py
+++ b/samples/python/kalman.py
@@ -19,7 +19,7 @@ if PY3:
     long = int
 
 import cv2
-from math import cos, sin
+from math import cos, sin, sqrt
 import numpy as np
 
 if __name__ == "__main__":
@@ -81,12 +81,12 @@ if __name__ == "__main__":
 
             kalman.correct(measurement)
 
-            process_noise = kalman.processNoiseCov * np.random.randn(2, 1)
+            process_noise = sqrt(kalman.processNoiseCov[0,0]) * np.random.randn(2, 1)
             state = np.dot(kalman.transitionMatrix, state) + process_noise
 
             cv2.imshow("Kalman", img)
 
-            code = cv2.waitKey(100) % 0x100
+            code = cv2.waitKey(100)
             if code != -1:
                 break
 

--- a/samples/python/kalman.py
+++ b/samples/python/kalman.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
    Tracking of rotating point.
    Rotation speed is constant.
@@ -90,7 +90,7 @@ if __name__ == "__main__":
             if code != -1:
                 break
 
-        if code in [27, ord('q'), ord('Q')]:
+        if (code % 0x100) in [27, ord('q'), ord('Q')]:
             break
 
     cv2.destroyWindow("Kalman")


### PR DESCRIPTION
The python example of kalman filter (kalman.py) was broken totally.

Following condition is True on each iteration(-1 % 0x100 is 255). This were resetting point position on each cycle, not on key press as intended
```
code = cv2.waitKey(100) % 0x100
if code != -1:
   break
```

Previous small bug were masking serious bug with matrix operation on matrices of incorrect size.
As the result on 2nd iteration of internal cycle program has **crashed**.

I have fixed it too, matrix operation was taken from examples/cpp/kalman.cpp where it looks like
```
randn( processNoise, Scalar(0), Scalar::all(sqrt(KF.processNoiseCov.at<float>(0, 0))));
```
which is something totally different from previous code here.

Example behave as it should now, i.e. point moving by circle trajectory as in C++ example.