### PR TITLE
cuda box filter for CV_32FC1

### DIFF
--- a/modules/cudafilters/include/opencv2/cudafilters.hpp
+++ b/modules/cudafilters/include/opencv2/cudafilters.hpp
@@ -89,7 +89,7 @@ public:
 
 /** @brief Creates a normalized 2D box filter.
 
-@param srcType Input image type. Only CV_8UC1 and CV_8UC4 are supported for now.
+@param srcType Input image type. Only CV_8UC1, CV_8UC4 and CV_32FC1 are supported for now.
 @param dstType Output image type. Only the same type as src is supported for now.
 @param ksize Kernel size.
 @param anchor Anchor point. The default value Point(-1, -1) means that the anchor is at the kernel

--- a/modules/cudafilters/perf/perf_filters.cpp
+++ b/modules/cudafilters/perf/perf_filters.cpp
@@ -53,7 +53,7 @@ DEF_PARAM_TEST(Sz_Type_KernelSz, cv::Size, MatType, int);
 
 PERF_TEST_P(Sz_Type_KernelSz, Blur,
             Combine(CUDA_TYPICAL_MAT_SIZES,
-                    Values(CV_8UC1, CV_8UC4),
+                    Values(CV_8UC1, CV_8UC4, CV_32FC1),
                     Values(3, 5, 7)))
 {
     declare.time(20.0);

--- a/modules/cudafilters/src/filtering.cpp
+++ b/modules/cudafilters/src/filtering.cpp
@@ -103,13 +103,14 @@ namespace
         void apply(InputArray src, OutputArray dst, Stream& stream = Stream::Null());
 
     private:
-        typedef NppStatus (*nppFilterBox_t)(const Npp8u* pSrc, Npp32s nSrcStep, Npp8u* pDst, Npp32s nDstStep,
+        typedef NppStatus (*nppFilterBox8U_t)(const Npp8u* pSrc, Npp32s nSrcStep, Npp8u* pDst, Npp32s nDstStep,
+                                            NppiSize oSizeROI, NppiSize oMaskSize, NppiPoint oAnchor);
+        typedef NppStatus (*nppFilterBox32F_t)(const Npp32f* pSrc, Npp32s nSrcStep, Npp32f* pDst, Npp32s nDstStep,
                                             NppiSize oSizeROI, NppiSize oMaskSize, NppiPoint oAnchor);
 
         Size ksize_;
         Point anchor_;
         int type_;
-        nppFilterBox_t func_;
         int borderMode_;
         Scalar borderVal_;
         GpuMat srcBorder_;
@@ -118,14 +119,10 @@ namespace
     NPPBoxFilter::NPPBoxFilter(int srcType, int dstType, Size ksize, Point anchor, int borderMode, Scalar borderVal) :
         ksize_(ksize), anchor_(anchor), type_(srcType), borderMode_(borderMode), borderVal_(borderVal)
     {
-        static const nppFilterBox_t funcs[] = {0, nppiFilterBox_8u_C1R, 0, 0, nppiFilterBox_8u_C4R};
-
-        CV_Assert( srcType == CV_8UC1 || srcType == CV_8UC4 );
+        CV_Assert( srcType == CV_8UC1 || srcType == CV_8UC4 || srcType == CV_32FC1);
         CV_Assert( dstType == srcType );
 
         normalizeAnchor(anchor_, ksize);
-
-        func_ = funcs[CV_MAT_CN(srcType)];
     }
 
     void NPPBoxFilter::apply(InputArray _src, OutputArray _dst, Stream& _stream)
@@ -155,10 +152,30 @@ namespace
         oAnchor.x = anchor_.x;
         oAnchor.y = anchor_.y;
 
-        nppSafeCall( func_(srcRoi.ptr<Npp8u>(), static_cast<int>(srcRoi.step),
-                           dst.ptr<Npp8u>(), static_cast<int>(dst.step),
-                           oSizeROI, oMaskSize, oAnchor) );
+       const int depth = CV_MAT_DEPTH(type_);
+       const int cn = CV_MAT_CN(type_);
 
+       switch (depth)
+       {
+        case CV_8U:
+        {
+            static const nppFilterBox8U_t funcs8U[] = { 0, nppiFilterBox_8u_C1R, 0, 0, nppiFilterBox_8u_C4R };
+            const nppFilterBox8U_t func8U = funcs8U[cn];
+            nppSafeCall(func8U(srcRoi.ptr<Npp8u>(), static_cast<int>(srcRoi.step),
+                dst.ptr<Npp8u>(), static_cast<int>(dst.step),
+                oSizeROI, oMaskSize, oAnchor));
+        }
+            break;
+        case CV_32F:
+        {
+            static const nppFilterBox32F_t funcs32F[] = { 0, nppiFilterBox_32f_C1R, 0, 0, 0 };
+            const nppFilterBox32F_t func32F = funcs32F[cn];
+            nppSafeCall(func32F(srcRoi.ptr<Npp32f>(), static_cast<int>(srcRoi.step),
+                dst.ptr<Npp32f>(), static_cast<int>(dst.step),
+                oSizeROI, oMaskSize, oAnchor));
+        }
+            break;
+        }
         if (stream == 0)
             cudaSafeCall( cudaDeviceSynchronize() );
     }

--- a/modules/cudafilters/src/filtering.cpp
+++ b/modules/cudafilters/src/filtering.cpp
@@ -152,11 +152,11 @@ namespace
         oAnchor.x = anchor_.x;
         oAnchor.y = anchor_.y;
 
-       const int depth = CV_MAT_DEPTH(type_);
-       const int cn = CV_MAT_CN(type_);
+        const int depth = CV_MAT_DEPTH(type_);
+        const int cn = CV_MAT_CN(type_);
 
-       switch (depth)
-       {
+        switch (depth)
+        {
         case CV_8U:
         {
             static const nppFilterBox8U_t funcs8U[] = { 0, nppiFilterBox_8u_C1R, 0, 0, nppiFilterBox_8u_C4R };

--- a/modules/cudafilters/test/test_filters.cpp
+++ b/modules/cudafilters/test/test_filters.cpp
@@ -113,7 +113,7 @@ CUDA_TEST_P(Blur, Accuracy)
 INSTANTIATE_TEST_CASE_P(CUDA_Filters, Blur, testing::Combine(
     ALL_DEVICES,
     DIFFERENT_SIZES,
-    testing::Values(MatType(CV_8UC1), MatType(CV_8UC4)),
+    testing::Values(MatType(CV_8UC1), MatType(CV_8UC4), MatType(CV_32FC1)),
     testing::Values(KSize(cv::Size(3, 3)), KSize(cv::Size(5, 5)), KSize(cv::Size(7, 7))),
     testing::Values(Anchor(cv::Point(-1, -1)), Anchor(cv::Point(0, 0)), Anchor(cv::Point(2, 2))),
     testing::Values(BorderType(cv::BORDER_REFLECT101), BorderType(cv::BORDER_REPLICATE), BorderType(cv::BORDER_CONSTANT), BorderType(cv::BORDER_REFLECT)),


### PR DESCRIPTION
Add option CV_32FC1 for cuda box filter.

Because of type incompatibility with previous code, I had to solve how to choose which npp function to use. I avoided class templatization with current option as default template parameter and rather chose to runtime switch based on srcType.

cuda::copyMakeBorder, which is used inside, is implemented for CV_32FC1.
