### PR TITLE
Fixed problem with nonfree python test: could not find local test images

### DIFF
--- a/modules/python/test/nonfree_tests/nonfree_surf.py
+++ b/modules/python/test/nonfree_tests/nonfree_surf.py
@@ -6,7 +6,7 @@ import numpy as np
 import cv2
 import cv2.cv as cv
 
-from test import OpenCVTests
+from tests_common import OpenCVTests
 
 class NonFreeFunctionTests(OpenCVTests):
 

--- a/modules/python/test/test.py
+++ b/modules/python/test/test.py
@@ -17,119 +17,14 @@ import argparse
 
 import cv2.cv as cv
 
-from test2 import *
-
-class OpenCVTests(unittest.TestCase):
-
-    # path to local repository folder containing 'samples' folder
-    repoPath = None
-    # github repository url
-    repoUrl = 'https://raw.github.com/Itseez/opencv/2.4'
-    # path to local folder containing 'camera_calibration.tar.gz'
-    dataPath = None
-    # data url
-    dataUrl = 'http://docs.opencv.org/data'
-
-    depths = [ cv.IPL_DEPTH_8U, cv.IPL_DEPTH_8S, cv.IPL_DEPTH_16U, cv.IPL_DEPTH_16S, cv.IPL_DEPTH_32S, cv.IPL_DEPTH_32F, cv.IPL_DEPTH_64F ]
-
-    mat_types = [
-        cv.CV_8UC1,
-        cv.CV_8UC2,
-        cv.CV_8UC3,
-        cv.CV_8UC4,
-        cv.CV_8SC1,
-        cv.CV_8SC2,
-        cv.CV_8SC3,
-        cv.CV_8SC4,
-        cv.CV_16UC1,
-        cv.CV_16UC2,
-        cv.CV_16UC3,
-        cv.CV_16UC4,
-        cv.CV_16SC1,
-        cv.CV_16SC2,
-        cv.CV_16SC3,
-        cv.CV_16SC4,
-        cv.CV_32SC1,
-        cv.CV_32SC2,
-        cv.CV_32SC3,
-        cv.CV_32SC4,
-        cv.CV_32FC1,
-        cv.CV_32FC2,
-        cv.CV_32FC3,
-        cv.CV_32FC4,
-        cv.CV_64FC1,
-        cv.CV_64FC2,
-        cv.CV_64FC3,
-        cv.CV_64FC4,
-    ]
-    mat_types_single = [
-        cv.CV_8UC1,
-        cv.CV_8SC1,
-        cv.CV_16UC1,
-        cv.CV_16SC1,
-        cv.CV_32SC1,
-        cv.CV_32FC1,
-        cv.CV_64FC1,
-    ]
-
-    def depthsize(self, d):
-        return { cv.IPL_DEPTH_8U : 1,
-                 cv.IPL_DEPTH_8S : 1,
-                 cv.IPL_DEPTH_16U : 2,
-                 cv.IPL_DEPTH_16S : 2,
-                 cv.IPL_DEPTH_32S : 4,
-                 cv.IPL_DEPTH_32F : 4,
-                 cv.IPL_DEPTH_64F : 8 }[d]
-
-    def get_sample(self, filename, iscolor = cv.CV_LOAD_IMAGE_COLOR):
-        if not filename in self.image_cache:
-            filedata = None
-            if OpenCVTests.repoPath is not None:
-                candidate = OpenCVTests.repoPath + '/' + filename
-                if os.path.isfile(candidate):
-                    with open(candidate, 'rb') as f:
-                        filedata = f.read()
-            if filedata is None:
-                filedata = urllib.urlopen(OpenCVTests.repoUrl + '/' + filename).read()
-            imagefiledata = cv.CreateMatHeader(1, len(filedata), cv.CV_8UC1)
-            cv.SetData(imagefiledata, filedata, len(filedata))
-            self.image_cache[filename] = cv.DecodeImageM(imagefiledata, iscolor)
-        return self.image_cache[filename]
-
-    def get_data(self, filename, urlbase):
-        if (not os.path.isfile(filename)):
-            if OpenCVTests.dataPath is not None:
-                candidate = OpenCVTests.dataPath + '/' + filename
-                if os.path.isfile(candidate):
-                    return candidate
-            urllib.urlretrieve(urlbase + '/' + filename, filename)
-        return filename
-
-    def setUp(self):
-        self.image_cache = {}
-
-    def snap(self, img):
-        self.snapL([img])
-
-    def snapL(self, L):
-        for i,img in enumerate(L):
-            cv.NamedWindow("snap-%d" % i, 1)
-            cv.ShowImage("snap-%d" % i, img)
-        cv.WaitKey()
-        cv.DestroyAllWindows()
-
-    def hashimg(self, im):
-        """ Compute a hash for an image, useful for image comparisons """
-        return hashlib.md5(im.tostring()).digest()
-
-#import new OpenCV tests(do we really need old ones in this case)
-from tests_common import NewOpenCVTests
+from tests_common import OpenCVTests, NewOpenCVTests
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 def load_tests(loader, tests, pattern):
     tests.addTests(loader.discover(basedir, pattern='nonfree_*.py'))
     tests.addTests(loader.discover(basedir, pattern='test_*.py'))
+    tests.addTests(loader.discover(basedir, pattern='test2.py'))
     return tests
 
 # Tests to run first; check the handful of basic operations that the later tests rely on

--- a/modules/python/test/tests_common.py
+++ b/modules/python/test/tests_common.py
@@ -8,12 +8,117 @@ import hashlib
 import os
 import numpy as np
 import cv2
+import cv2.cv as cv
 
 # Python 3 moved urlopen to urllib.requests
 try:
     from urllib.request import urlopen
 except ImportError:
     from urllib import urlopen
+
+class OpenCVTests(unittest.TestCase):
+
+    # path to local repository folder containing 'samples' folder
+    repoPath = None
+    # github repository url
+    repoUrl = 'https://raw.github.com/Itseez/opencv/2.4'
+    # path to local folder containing 'camera_calibration.tar.gz'
+    dataPath = None
+    # data url
+    dataUrl = 'http://docs.opencv.org/data'
+
+    depths = [ cv.IPL_DEPTH_8U, cv.IPL_DEPTH_8S, cv.IPL_DEPTH_16U, cv.IPL_DEPTH_16S, cv.IPL_DEPTH_32S, cv.IPL_DEPTH_32F, cv.IPL_DEPTH_64F ]
+
+    mat_types = [
+        cv.CV_8UC1,
+        cv.CV_8UC2,
+        cv.CV_8UC3,
+        cv.CV_8UC4,
+        cv.CV_8SC1,
+        cv.CV_8SC2,
+        cv.CV_8SC3,
+        cv.CV_8SC4,
+        cv.CV_16UC1,
+        cv.CV_16UC2,
+        cv.CV_16UC3,
+        cv.CV_16UC4,
+        cv.CV_16SC1,
+        cv.CV_16SC2,
+        cv.CV_16SC3,
+        cv.CV_16SC4,
+        cv.CV_32SC1,
+        cv.CV_32SC2,
+        cv.CV_32SC3,
+        cv.CV_32SC4,
+        cv.CV_32FC1,
+        cv.CV_32FC2,
+        cv.CV_32FC3,
+        cv.CV_32FC4,
+        cv.CV_64FC1,
+        cv.CV_64FC2,
+        cv.CV_64FC3,
+        cv.CV_64FC4,
+    ]
+    mat_types_single = [
+        cv.CV_8UC1,
+        cv.CV_8SC1,
+        cv.CV_16UC1,
+        cv.CV_16SC1,
+        cv.CV_32SC1,
+        cv.CV_32FC1,
+        cv.CV_64FC1,
+    ]
+
+    def depthsize(self, d):
+        return { cv.IPL_DEPTH_8U : 1,
+                 cv.IPL_DEPTH_8S : 1,
+                 cv.IPL_DEPTH_16U : 2,
+                 cv.IPL_DEPTH_16S : 2,
+                 cv.IPL_DEPTH_32S : 4,
+                 cv.IPL_DEPTH_32F : 4,
+                 cv.IPL_DEPTH_64F : 8 }[d]
+
+    def get_sample(self, filename, iscolor = cv.CV_LOAD_IMAGE_COLOR):
+        if not filename in self.image_cache:
+            filedata = None
+            if OpenCVTests.repoPath is not None:
+                candidate = OpenCVTests.repoPath + '/' + filename
+                if os.path.isfile(candidate):
+                    with open(candidate, 'rb') as f:
+                        filedata = f.read()
+            if filedata is None:
+                filedata = urllib.urlopen(OpenCVTests.repoUrl + '/' + filename).read()
+            imagefiledata = cv.CreateMatHeader(1, len(filedata), cv.CV_8UC1)
+            cv.SetData(imagefiledata, filedata, len(filedata))
+            self.image_cache[filename] = cv.DecodeImageM(imagefiledata, iscolor)
+        return self.image_cache[filename]
+
+    def get_data(self, filename, urlbase):
+        if (not os.path.isfile(filename)):
+            if OpenCVTests.dataPath is not None:
+                candidate = OpenCVTests.dataPath + '/' + filename
+                if os.path.isfile(candidate):
+                    return candidate
+            urllib.urlretrieve(urlbase + '/' + filename, filename)
+        return filename
+
+    def setUp(self):
+        self.image_cache = {}
+
+    def snap(self, img):
+        self.snapL([img])
+
+    def snapL(self, L):
+        for i,img in enumerate(L):
+            cv.NamedWindow("snap-%d" % i, 1)
+            cv.ShowImage("snap-%d" % i, img)
+        cv.WaitKey()
+        cv.DestroyAllWindows()
+
+    def hashimg(self, im):
+        """ Compute a hash for an image, useful for image comparisons """
+        return hashlib.md5(im.tostring()).digest()
+
 
 class NewOpenCVTests(unittest.TestCase):
 


### PR DESCRIPTION
Test `nonfree_surf.py` got empty `OpenCVTests.repoPath` and `OpenCVTests.dataPath` variables, probably due to complex import scheme (mix of `load_tests` and `import`).

Also moved `test2` module import to `load_tests` function.
