### PR TITLE
Bug fix for MLP predict for small values to avoid nan responses.

### DIFF
--- a/modules/ml/src/ann_mlp.cpp
+++ b/modules/ml/src/ann_mlp.cpp
@@ -432,8 +432,15 @@ public:
                     double* data = sums.ptr<double>(i);
                     for( j = 0; j < cols; j++ )
                     {
-                        double t = scale2*(1. - data[j])/(1. + data[j]);
-                        data[j] = t;
+                        if(!cvIsInf(data[j]))
+                        {
+                            double t = scale2*(1. - data[j])/(1. + data[j]);
+                            data[j] = t;
+                        }
+                        else
+                        {
+                            data[j] = -scale2;
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
resolves #6394  

### What does this PR change?
It isn't checked if the result of exp function on line 419 returns -inf. The activation function is calculated with '-inf' value and '-nan' is returned. 

To fix this bug, I've replaced the lines 435 and 436 for the code below
```
if(!cvIsInf(data[j]))
{
      double t = scale2*(1. - data[j])/(1. + data[j]);
      data[j] = t;
}
else
{
      data[j] = -scale2;
}
```
