### PR TITLE
Fixed memory leak in flann KMeansIndex

### DIFF
--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -874,6 +874,8 @@ private:
             computeClustering(node->childs[c],indices+start, end-start, branching, level+1);
             start=end;
         }
+
+        delete[] centers;
     }
 
 


### PR DESCRIPTION
fixes #6398

Test command: `opencv_test_features2d --gtest_filter=Features2d_FLANN_Composite.regression`