### PR TITLE
fix #6315 no member named 'GetCocoaServer'

### DIFF
--- a/modules/viz/src/vtk/vtkCocoaInteractorFix.mm
+++ b/modules/viz/src/vtk/vtkCocoaInteractorFix.mm
@@ -160,7 +160,7 @@
 
 //----------------------------------------------------------------------------
 
-#if VTK_MAJOR_VERSION >= 6 && VTK_MINOR_VERSION  >=2
+#if VTK_MAJOR_VERSION >= 6 && VTK_MINOR_VERSION >=2 || VTK_MAJOR_VERSION >=7
 
 namespace cv { namespace viz
     {


### PR DESCRIPTION
resolves #6315

### What does this PR change?
Change `modules/viz/src/vtk/vtkCocoaInteractorFix.mm` to correctly test VTK version.

