### PR TITLE
Updates for XCode 7.3

### DIFF
--- a/3rdparty/zlib/CMakeLists.txt
+++ b/3rdparty/zlib/CMakeLists.txt
@@ -82,7 +82,7 @@ if(UNIX)
   endif()
 endif()
 
-ocv_warnings_disable(CMAKE_C_FLAGS -Wshorten-64-to-32 -Wattributes -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations)
+ocv_warnings_disable(CMAKE_C_FLAGS -Wshorten-64-to-32 -Wattributes -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wshift-negative-value)
 
 set_target_properties(${ZLIB_LIBRARY} PROPERTIES
         OUTPUT_NAME ${ZLIB_LIBRARY}

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -369,7 +369,12 @@ public:
     static enum PERF_STRATEGY getCurrentModulePerformanceStrategy();
     static enum PERF_STRATEGY setModulePerformanceStrategy(enum PERF_STRATEGY strategy);
 
-    class PerfSkipTestException: public cv::Exception {};
+    class PerfSkipTestException: public cv::Exception
+    {
+        int dummy; // workaround for MacOSX Xcode 7.3 bug (don't make class "empty")
+    public:
+        PerfSkipTestException() : dummy(0) {}
+    };
 
 protected:
     virtual void PerfTestBody() = 0;

--- a/samples/cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
+++ b/samples/cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
@@ -57,7 +57,7 @@ void Tracker::setFirstFrame(const Mat frame, vector<Point2f> bb, string title, S
     drawBoundingBox(first_frame, bb);
     putText(first_frame, title, Point(0, 60), FONT_HERSHEY_PLAIN, 5, Scalar::all(0), 4);
     object_bb = bb;
-    delete ptMask;
+    delete[] ptMask;
 }
 
 Mat Tracker::process(const Mat frame, Stats& stats)


### PR DESCRIPTION
- silence warning in zlib
- fixed wrong `delete` call in AKAZE tracking sample
- added dummy perf exception class variable
