### PR TITLE
fix typo in grabcut.cpp

### DIFF
--- a/modules/imgproc/src/grabcut.cpp
+++ b/modules/imgproc/src/grabcut.cpp
@@ -333,7 +333,7 @@ static void checkMask( const Mat& img, const Mat& mask )
         {
             uchar val = mask.at<uchar>(y,x);
             if( val!=GC_BGD && val!=GC_FGD && val!=GC_PR_BGD && val!=GC_PR_FGD )
-                CV_Error( CV_StsBadArg, "mask element value must be equel"
+                CV_Error( CV_StsBadArg, "mask element value must be equal "
                     "GC_BGD or GC_FGD or GC_PR_BGD or GC_PR_FGD" );
         }
     }


### PR DESCRIPTION
fix typo: "equel" -> "equal "
