### PR TITLE
fix wrong docs

### DIFF
--- a/doc/user_guide/ug_traincascade.rst
+++ b/doc/user_guide/ug_traincascade.rst
@@ -326,7 +326,13 @@ Command line arguments of ``opencv_traincascade`` application grouped by purpose
 
     * ``-minHitRate <min_hit_rate>``
 
-        Minimal desired hit rate for each stage of the classifier. Overall hit rate may be estimated as (min_hit_rate^number_of_stages).
+        Minimal desired hit rate for each stage of the classifier. The overal hit rate can be calculated as follows.
+
+        overall_hit_rate = 1.0 - overall_fail_rate
+        overall_fail_rate  = max_fail_rate ^ number_of_stages
+        max_fail_rate = 1.0 - min_hit_rate
+
+        and thus overall_hit_rate = ( 1.0 - ( 1.0 - min_hit_rate ) ^ number_of_stages )
 
     * ``-maxFalseAlarmRate <max_false_alarm_rate>``
 


### PR DESCRIPTION
It is simply unlogical that the overall hit rate of a cascade would be worse then the individual minimal hit rates for each seperate weak classifier. I guess this is a copy paste error from the following feature that can be set, being the maxFalseAlarmRate.

Example:
A cascade with `-minHitRate 0.95` and `-numStages 20`, would according to this function, have a overall hit rate of 0.35, which is terribly low. 

In my opinion this cascade would have a minHitRate of at least 0.95, and even higher if the individual weak classifiers have higher values. How they combine correctly, I will investigate and push in another PR.

