### PR TITLE
Fix bug 6445

### DIFF
--- a/modules/imgcodecs/src/grfmt_pxm.cpp
+++ b/modules/imgcodecs/src/grfmt_pxm.cpp
@@ -190,7 +190,6 @@ bool  PxMDecoder::readData( Mat& img )
 {
     int color = img.channels() > 1;
     uchar* data = img.ptr();
-    int step = (int)img.step;
     PaletteEntry palette[256];
     bool   result = false;
     int  bit_depth = CV_ELEM_SIZE1(m_type)*8;
@@ -229,7 +228,7 @@ bool  PxMDecoder::readData( Mat& img )
         case 1:
             if( !m_binary )
             {
-                for( y = 0; y < m_height; y++, data += step )
+                for( y = 0; y < m_height; y++, data += img.step )
                 {
                     for( x = 0; x < m_width; x++ )
                         src[x] = ReadNumber( m_strm, 1 ) != 0;
@@ -242,7 +241,7 @@ bool  PxMDecoder::readData( Mat& img )
             }
             else
             {
-                for( y = 0; y < m_height; y++, data += step )
+                for( y = 0; y < m_height; y++, data += img.step )
                 {
                     m_strm.getBytes( src, src_pitch );
 
@@ -258,7 +257,7 @@ bool  PxMDecoder::readData( Mat& img )
         ////////////////////////// 8 BPP /////////////////////////
         case 8:
         case 24:
-            for( y = 0; y < m_height; y++, data += step )
+            for( y = 0; y < m_height; y++, data += img.step )
             {
                 if( !m_binary )
                 {
@@ -310,7 +309,7 @@ bool  PxMDecoder::readData( Mat& img )
                         }
                     }
                     else
-                        memcpy( data, src, m_width*(bit_depth/8) );
+                        memcpy( data, src, m_width);
                 }
                 else
                 {


### PR DESCRIPTION
resolves #6445

### What does this PR change?
Root cause for 6445 crash: when calling imread to read the pgm file, when returning with success reading file, the destructor will free the resource which used by memcpy, but in the code, the resource calculation was not correct, therefore, it will cause memory corruption during resource free. Patch update the resource calculation used in memcpy.
Also update the step with img.step if we need read large size of pgm file, like issue 6317 mentioned.