### PR TITLE
Fixed hardcoded relative path in calib_stereo

### DIFF
--- a/samples/cpp/stereo_calib.cpp
+++ b/samples/cpp/stereo_calib.cpp
@@ -212,7 +212,7 @@ StereoCalib(const vector<string>& imagelist, Size boardSize,bool displayCorners 
     cout << "average epipolar err = " <<  err/npoints << endl;
 
     // save intrinsic parameters
-    FileStorage fs("../data/intrinsics.yml", FileStorage::WRITE);
+    FileStorage fs("intrinsics.yml", FileStorage::WRITE);
     if( fs.isOpened() )
     {
         fs << "M1" << cameraMatrix[0] << "D1" << distCoeffs[0] <<


### PR DESCRIPTION
resolves #6456 

Change hardcoded relative path for instrinsics file to current path, matching the extrinsics file.
