### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -290,7 +290,7 @@ int CvCascadeClassifier::predict( int sampleIdx )
 {
     CV_DbgAssert( sampleIdx < numPos + numNeg );
     for (vector< Ptr<CvCascadeBoost> >::iterator it = stageClassifiers.begin();
-        it != stageClassifiers.end(); it++ )
+        it != stageClassifiers.end();++it )
     {
         if ( (*it)->predict( sampleIdx ) == 0.f )
             return 0;
@@ -365,7 +365,7 @@ void CvCascadeClassifier::writeStages( FileStorage &fs, const Mat& featureMap ) 
     int i = 0;
     fs << CC_STAGES << "[";
     for( vector< Ptr<CvCascadeBoost> >::const_iterator it = stageClassifiers.begin();
-        it != stageClassifiers.end(); it++, i++ )
+        it != stageClassifiers.end();++it, ++i )
     {
         sprintf( cmnt, "stage %d", i );
         cvWriteComment( fs.fs, cmnt, 0 );
@@ -557,7 +557,7 @@ void CvCascadeClassifier::getUsedFeaturesIdxMap( Mat& featureMap )
     featureMap.setTo(Scalar(-1));
 
     for( vector< Ptr<CvCascadeBoost> >::const_iterator it = stageClassifiers.begin();
-        it != stageClassifiers.end(); it++ )
+        it != stageClassifiers.end();++it )
         (*it)->markUsedFeaturesInMap( featureMap );
 
     for( int fi = 0, idx = 0; fi < varCount; fi++ )

--- a/modules/calib3d/src/circlesgrid.cpp
+++ b/modules/calib3d/src/circlesgrid.cpp
@@ -129,7 +129,7 @@ void CirclesGridClusterFinder::hierarchicalClustering(const std::vector<Point2f>
     }
 
     patternPoints.reserve(clusters[patternClusterIdx].size());
-    for(std::list<size_t>::iterator it = clusters[patternClusterIdx].begin(); it != clusters[patternClusterIdx].end(); it++)
+    for(std::list<size_t>::iterator it = clusters[patternClusterIdx].begin(); it != clusters[patternClusterIdx].end();++it)
     {
         patternPoints.push_back(points[*it]);
     }
@@ -320,7 +320,7 @@ void CirclesGridClusterFinder::getSortedCorners(const std::vector<cv::Point2f> &
 
   std::vector<Point2f>::const_iterator firstCornerIterator = std::find(hull2f.begin(), hull2f.end(), firstCorner);
   sortedCorners.clear();
-  for(std::vector<Point2f>::const_iterator it = firstCornerIterator; it != hull2f.end(); it++)
+  for(std::vector<Point2f>::const_iterator it = firstCornerIterator; it != hull2f.end();++it)
   {
     std::vector<Point2f>::const_iterator itCorners = std::find(corners.begin(), corners.end(), *it);
     if(itCorners != corners.end())
@@ -328,7 +328,7 @@ void CirclesGridClusterFinder::getSortedCorners(const std::vector<cv::Point2f> &
       sortedCorners.push_back(*it);
     }
   }
-  for(std::vector<Point2f>::const_iterator it = hull2f.begin(); it != firstCornerIterator; it++)
+  for(std::vector<Point2f>::const_iterator it = hull2f.begin(); it != firstCornerIterator;++it)
   {
     std::vector<Point2f>::const_iterator itCorners = std::find(corners.begin(), corners.end(), *it);
     if(itCorners != corners.end())
@@ -493,21 +493,21 @@ void Graph::floydWarshall(cv::Mat &distanceMatrix, int infinity) const
   const int n = (int)getVerticesCount();
   distanceMatrix.create(n, n, CV_32SC1);
   distanceMatrix.setTo(infinity);
-  for (Vertices::const_iterator it1 = vertices.begin(); it1 != vertices.end(); it1++)
+  for (Vertices::const_iterator it1 = vertices.begin(); it1 != vertices.end();++it1)
   {
     distanceMatrix.at<int> ((int)it1->first, (int)it1->first) = 0;
-    for (Neighbors::const_iterator it2 = it1->second.neighbors.begin(); it2 != it1->second.neighbors.end(); it2++)
+    for (Neighbors::const_iterator it2 = it1->second.neighbors.begin(); it2 != it1->second.neighbors.end();++it2)
     {
       CV_Assert( it1->first != *it2 );
       distanceMatrix.at<int> ((int)it1->first, (int)*it2) = edgeWeight;
     }
   }
 
-  for (Vertices::const_iterator it1 = vertices.begin(); it1 != vertices.end(); it1++)
+  for (Vertices::const_iterator it1 = vertices.begin(); it1 != vertices.end();++it1)
   {
-    for (Vertices::const_iterator it2 = vertices.begin(); it2 != vertices.end(); it2++)
+    for (Vertices::const_iterator it2 = vertices.begin(); it2 != vertices.end();++it2)
     {
-      for (Vertices::const_iterator it3 = vertices.begin(); it3 != vertices.end(); it3++)
+      for (Vertices::const_iterator it3 = vertices.begin(); it3 != vertices.end();++it3)
       {
       int i1 = (int)it1->first, i2 = (int)it2->first, i3 = (int)it3->first;
         int val1 = distanceMatrix.at<int> (i2, i3);
@@ -618,10 +618,10 @@ void CirclesGridFinder::rng2gridGraph(Graph &rng, std::vector<cv::Point2f> &vect
   for (size_t i = 0; i < rng.getVerticesCount(); i++)
   {
     Graph::Neighbors neighbors1 = rng.getNeighbors(i);
-    for (Graph::Neighbors::iterator it1 = neighbors1.begin(); it1 != neighbors1.end(); it1++)
+    for (Graph::Neighbors::iterator it1 = neighbors1.begin(); it1 != neighbors1.end(); ++it1)
     {
       Graph::Neighbors neighbors2 = rng.getNeighbors(*it1);
-      for (Graph::Neighbors::iterator it2 = neighbors2.begin(); it2 != neighbors2.end(); it2++)
+      for (Graph::Neighbors::iterator it2 = neighbors2.begin(); it2 != neighbors2.end(); ++it2)
       {
         if (i < *it2)
         {

--- a/modules/calib3d/src/fundam.cpp
+++ b/modules/calib3d/src/fundam.cpp
@@ -1046,7 +1046,7 @@ void cv::convertPointsHomogeneous( InputArray _src, OutputArray _dst )
 }
 
 double cv::sampsonDistance(InputArray _pt1, InputArray _pt2, InputArray _F) {
-    CV_Assert(_pt1.type() == CV_64F && _pt1.type() == CV_64F && _F.type() == CV_64F);
+    CV_Assert(_pt1.type() == CV_64F && _pt2.type() == CV_64F && _F.type() == CV_64F);
     CV_DbgAssert(_pt1.rows() == 3 && _F.size() == Size(3, 3) && _pt1.rows() == _pt2.rows());
 
     Mat pt1(_pt1.getMat());

--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -2414,7 +2414,7 @@ void cv::calcCovarMatrix( InputArray _src, OutputArray _covar, InputOutputArray 
         Mat _data(static_cast<int>(src.size()), size.area(), type);
 
         int i = 0;
-        for(std::vector<cv::Mat>::iterator each = src.begin(); each != src.end(); each++, i++ )
+        for(std::vector<cv::Mat>::iterator each = src.begin(); each != src.end(); ++each, ++i )
         {
             CV_Assert( (*each).size() == size && (*each).type() == type );
             Mat dataRow(size.height, size.width, type, _data.ptr(i));

--- a/modules/cudalegacy/test/NCVTest.hpp
+++ b/modules/cudalegacy/test/NCVTest.hpp
@@ -214,12 +214,12 @@ private:
         stream << "====================================================" << std::endl << std::endl;
         stream << "Test initialization report: " << std::endl;
         for (std::map<std::string,std::string>::iterator it=report.statsText.begin();
-             it != report.statsText.end(); it++)
+             it != report.statsText.end(); ++it)
         {
             stream << it->first << "=" << it->second << std::endl;
         }
         for (std::map<std::string,Ncv32u>::iterator it=report.statsNums.begin();
-            it != report.statsNums.end(); it++)
+            it != report.statsNums.end(); ++it)
         {
             stream << it->first << "=" << it->second << std::endl;
         }

--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -8033,7 +8033,7 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
     makeAgastOffsets(pixel_, (int)img.step, type);
 
     std::vector<KeyPoint>::iterator kpt;
-    for(kpt = kpts.begin(); kpt != kpts.end(); kpt++)
+    for(kpt = kpts.begin(); kpt != kpts.end(); ++kpt)
     {
         switch(type) {
           case AgastFeatureDetector::AGAST_5_8:
@@ -8149,7 +8149,7 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
                     }
                 }
             }
-            currCorner++;
+            ++currCorner;
         }
 
         // collecting maximum corners

--- a/modules/ts/src/ocl_test.cpp
+++ b/modules/ts/src/ocl_test.cpp
@@ -267,7 +267,7 @@ double TestUtils::checkRectSimilarity(const Size & sz, std::vector<Rect>& ob1, s
         cv::Mat cpu_result(sz, CV_8UC1);
         cpu_result.setTo(0);
 
-        for (vector<Rect>::const_iterator r = ob1.begin(); r != ob1.end(); r++)
+        for (vector<Rect>::const_iterator r = ob1.begin(); r != ob1.end(); ++r)
         {
             cv::Mat cpu_result_roi(cpu_result, *r);
             cpu_result_roi.setTo(1);
@@ -277,7 +277,7 @@ double TestUtils::checkRectSimilarity(const Size & sz, std::vector<Rect>& ob1, s
 
         cv::Mat gpu_result(sz, CV_8UC1);
         gpu_result.setTo(0);
-        for(vector<Rect>::const_iterator r2 = ob2.begin(); r2 != ob2.end(); r2++)
+        for(vector<Rect>::const_iterator r2 = ob2.begin(); r2 != ob2.end(); ++r2)
         {
             cv::Mat gpu_result_roi(gpu_result, *r2);
             gpu_result_roi.setTo(1);

--- a/modules/videoio/src/cap_gphoto2.cpp
+++ b/modules/videoio/src/cap_gphoto2.cpp
@@ -981,7 +981,7 @@ CameraWidget * DigitalCameraCapture::findWidgetByName(
                 CR(gp_widget_get_name(it->second, &name));
                 if (strstr(name, subName))
                     break;
-                it++;
+                ++it;
             }
             return (it != end) ? it->second : NULL;
         }

--- a/samples/cpp/detect_blob.cpp
+++ b/samples/cpp/detect_blob.cpp
@@ -159,14 +159,14 @@ int main(int argc, char *argv[])
     String label;
     // Descriptor loop
     vector<String>::iterator itDesc;
-    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); itDesc++)
+    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); ++itDesc)
     {
         vector<KeyPoint> keyImg1;
         if (*itDesc == "BLOB")
         {
             b = SimpleBlobDetector::create(*itBLOB);
             label = Legende(*itBLOB);
-            itBLOB++;
+            ++itBLOB;
         }
         try
         {
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
                 sbd->detect(img, keyImg, Mat());
                 drawKeypoints(img, keyImg, result);
                 int i = 0;
-                for (vector<KeyPoint>::iterator k = keyImg.begin(); k != keyImg.end(); k++, i++)
+                for (vector<KeyPoint>::iterator k = keyImg.begin(); k != keyImg.end(); ++k, ++i)
                     circle(result, k->pt, (int)k->size, palette[i % 65536]);
             }
             namedWindow(*itDesc + label, WINDOW_AUTOSIZE);

--- a/samples/cpp/detect_mser.cpp
+++ b/samples/cpp/detect_mser.cpp
@@ -466,7 +466,7 @@ int main(int argc, char *argv[])
     // Descriptor loop
     vector<String>::iterator itDesc;
     Mat result(img.rows, img.cols, CV_8UC3);
-    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); itDesc++)
+    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); ++itDesc)
     {
         vector<KeyPoint> keyImg1;
         if (*itDesc == "MSER"){
@@ -475,7 +475,7 @@ int main(int argc, char *argv[])
                 b = MSER::create(itMSER->delta, itMSER->minArea, itMSER->maxArea, itMSER->maxVariation, itMSER->minDiversity, itMSER->maxEvolution,
                                  itMSER->areaThreshold, itMSER->minMargin, itMSER->edgeBlurSize);
                 label = Legende(*itMSER);
-                itMSER++;
+                ++itMSER;
 
             }
             else
@@ -483,7 +483,7 @@ int main(int argc, char *argv[])
                 b = MSER::create(itMSER->delta, itMSER->minArea, itMSER->maxArea, itMSER->maxVariation, itMSER->minDiversity);
                 b.dynamicCast<MSER>()->setPass2Only(itMSER->pass2Only);
                 label = Legende(*itMSER);
-                itMSER++;
+                ++itMSER;
             }
         }
         if (img.type()==CV_8UC3)
@@ -513,9 +513,9 @@ int main(int argc, char *argv[])
                 int i = 0;
                 //result = Scalar(0, 0, 0);
                 int nbPixelInMSER=0;
-                for (vector<vector <Point> >::iterator itr = region.begin(); itr != region.end(); itr++, i++)
+                for (vector<vector <Point> >::iterator itr = region.begin(); itr != region.end(); ++itr, ++i)
                 {
-                    for (vector <Point>::iterator itp = region[i].begin(); itp != region[i].end(); itp ++)
+                    for (vector <Point>::iterator itp = region[i].begin(); itp != region[i].end(); ++itp)
                     {
                         // all pixels belonging to region become blue
                         result.at<Vec3b>(itp->y, itp->x) = Vec3b(128, 0, 0);

--- a/samples/cpp/facedetect.cpp
+++ b/samples/cpp/facedetect.cpp
@@ -193,7 +193,7 @@ void detectAndDraw( Mat& img, CascadeClassifier& cascade,
                                  //|CASCADE_DO_ROUGH_SEARCH
                                  |CASCADE_SCALE_IMAGE,
                                  Size(30, 30) );
-        for( vector<Rect>::const_iterator r = faces2.begin(); r != faces2.end(); r++ )
+        for( vector<Rect>::const_iterator r = faces2.begin(); r != faces2.end(); ++r )
         {
             faces.push_back(Rect(smallImg.cols - r->x - r->width, r->y, r->width, r->height));
         }

--- a/samples/cpp/matchmethod_orb_akaze_brisk.cpp
+++ b/samples/cpp/matchmethod_orb_akaze_brisk.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 
     // Descriptor loop
     vector<String>::iterator itDesc;
-    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); itDesc++)
+    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); ++itDesc)
     {
         Ptr<DescriptorMatcher> descriptorMatcher;
         // Match between img1 and img2
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
             // or detect and compute descriptors in one step
             b->detectAndCompute(img2, Mat(),keyImg2, descImg2,false);
             // Match method loop
-            for (itMatcher = typeAlgoMatch.begin(); itMatcher != typeAlgoMatch.end(); itMatcher++){
+            for (itMatcher = typeAlgoMatch.begin(); itMatcher != typeAlgoMatch.end(); ++itMatcher){
                 descriptorMatcher = DescriptorMatcher::create(*itMatcher);
                 if ((*itMatcher == "BruteForce-Hamming" || *itMatcher == "BruteForce-Hamming(2)") && (b->descriptorType() == CV_32F || b->defaultNorm() <= NORM_L2SQR))
                 {
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
                     cout << "in img1\tin img2\n";
                     // Use to compute distance between keyPoint matches and to evaluate match algorithm
                     double cumSumDist2=0;
-                    for (it = bestMatches.begin(); it != bestMatches.end(); it++)
+                    for (it = bestMatches.begin(); it != bestMatches.end(); ++it)
                     {
                         cout << it->queryIdx << "\t" <<  it->trainIdx << "\t"  <<  it->distance << "\n";
                         Point2d p=keyImg1[it->queryIdx].pt-keyImg2[it->trainIdx].pt;
@@ -165,15 +165,15 @@ int main(int argc, char *argv[])
     int i=0;
     cout << "Cumulative distance between keypoint match for different algorithm and feature detector \n\t";
     cout << "We cannot say which is the best but we can say results are differents! \n\t";
-    for (vector<String>::iterator itMatcher = typeAlgoMatch.begin(); itMatcher != typeAlgoMatch.end(); itMatcher++)
+    for (vector<String>::iterator itMatcher = typeAlgoMatch.begin(); itMatcher != typeAlgoMatch.end(); ++itMatcher)
     {
         cout<<*itMatcher<<"\t";
     }
     cout << "\n";
-    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); itDesc++)
+    for (itDesc = typeDesc.begin(); itDesc != typeDesc.end(); ++itDesc)
     {
         cout << *itDesc << "\t";
-        for (vector<String>::iterator itMatcher = typeAlgoMatch.begin(); itMatcher != typeAlgoMatch.end(); itMatcher++, i++)
+        for (vector<String>::iterator itMatcher = typeAlgoMatch.begin(); itMatcher != typeAlgoMatch.end(); ++itMatcher, ++i)
         {
             cout << desMethCmp[i]<<"\t";
         }

--- a/samples/cpp/smiledetect.cpp
+++ b/samples/cpp/smiledetect.cpp
@@ -153,7 +153,7 @@ void detectAndDraw( Mat& img, CascadeClassifier& cascade,
                                  //|CASCADE_DO_ROUGH_SEARCH
                                  |CASCADE_SCALE_IMAGE,
                                  Size(30, 30) );
-        for( vector<Rect>::const_iterator r = faces2.begin(); r != faces2.end(); r++ )
+        for( vector<Rect>::const_iterator r = faces2.begin(); r != faces2.end(); ++r )
         {
             faces.push_back(Rect(smallImg.cols - r->x - r->width, r->y, r->width, r->height));
         }

--- a/samples/tapi/ufacedetect.cpp
+++ b/samples/tapi/ufacedetect.cpp
@@ -195,7 +195,7 @@ void detectAndDraw( UMat& img, Mat& canvas, CascadeClassifier& cascade,
                                  //|CASCADE_DO_ROUGH_SEARCH
                                  |CASCADE_SCALE_IMAGE,
                                  Size(30, 30) );
-        for( vector<Rect>::const_iterator r = faces2.begin(); r != faces2.end(); r++ )
+        for( vector<Rect>::const_iterator r = faces2.begin(); r != faces2.end(); ++r )
         {
             faces.push_back(Rect(smallImg.cols - r->x - r->width, r->y, r->width, r->height));
         }


### PR DESCRIPTION
Cppcheck is a C/C++ static analyzer.

The goal of these simple changes is to prevent some problem or to optimize.

All of these: (performance) Prefer prefix ++/-- operators for non-primitive types.
[modules/calib3d/src/fundam.cpp:1049] -> [modules/calib3d/src/fundam.cpp:1049]: (style) Same expression on both sides of '&&'.