### PR TITLE
python: support for size_t args (default value)

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -228,6 +228,7 @@ gen_template_rw_prop_init = Template("""
 
 simple_argtype_mapping = {
     "bool": ("bool", "b", "0"),
+    "size_t": ("size_t", "I", "0"),
     "int": ("int", "i", "0"),
     "float": ("float", "f", "0.f"),
     "double": ("double", "d", "0"),


### PR DESCRIPTION
resolves a [problem when passing size_t as argument](http://pullrequest.opencv.org/buildbot/builders/precommit-contrib_linux64/builds/2404/steps/compile%20release/logs/warnings%20%284%29) , currently, they're treated as "Object" ('O') and don't get proper initialization

