### PR TITLE
add SSSE3 code to cornerScore()

### DIFF
--- a/modules/features2d/src/fast_score.cpp
+++ b/modules/features2d/src/fast_score.cpp
@@ -125,7 +125,45 @@ int cornerScore<16>(const uchar* ptr, const int pixel[], int threshold)
     for( k = 0; k < N; k++ )
         d[k] = (short)(v - ptr[pixel[k]]);
 
-#if CV_SSE2
+#if CV_SSSE3
+    __m128i q0 = _mm_set1_epi16(-1000), q1 = _mm_set1_epi16(1000);
+    for( k = 0; k < 16; k += 8 )
+    {
+        __m128i v_base0 = _mm_lddqu_si128((__m128i*)(d+k));
+        __m128i v_base1 = _mm_lddqu_si128((__m128i*)(d+k+8));
+        __m128i v0 = _mm_alignr_epi8(v_base1, v_base0, 2);
+        __m128i a = _mm_min_epi16(v0, v_base1);
+        __m128i b = _mm_max_epi16(v0, v_base1);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 4);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 6);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 8);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 10);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 12);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 14);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        q0 = _mm_max_epi16(q0, _mm_min_epi16(a, v_base0));
+        q1 = _mm_min_epi16(q1, _mm_max_epi16(b, v_base0));
+        v0 = _mm_alignr_epi8(_mm_set_epi16(0, 0, 0, 0, 0, 0, 0, d[k+16]), v_base1, 2);
+        q0 = _mm_max_epi16(q0, _mm_min_epi16(a, v0));
+        q1 = _mm_min_epi16(q1, _mm_max_epi16(b, v0));
+    }
+    q0 = _mm_max_epi16(q0, _mm_sub_epi16(_mm_setzero_si128(), q1));
+    q0 = _mm_max_epi16(q0, _mm_unpackhi_epi64(q0, q0));
+    q0 = _mm_max_epi16(q0, _mm_srli_si128(q0, 4));
+    q0 = _mm_max_epi16(q0, _mm_srli_si128(q0, 2));
+    threshold = (short)_mm_cvtsi128_si32(q0) - 1;
+#elif CV_SSE2
     __m128i q0 = _mm_set1_epi16(-1000), q1 = _mm_set1_epi16(1000);
     for( k = 0; k < 16; k += 8 )
     {
@@ -214,12 +252,45 @@ int cornerScore<12>(const uchar* ptr, const int pixel[], int threshold)
     short d[N + 4];
     for( k = 0; k < N; k++ )
         d[k] = (short)(v - ptr[pixel[k]]);
-#if CV_SSE2
+#if CV_SSE2 || CV_SSSE3
     for( k = 0; k < 4; k++ )
         d[N+k] = d[k];
 #endif
 
-#if CV_SSE2
+#if CV_SSSE3
+    __m128i q0 = _mm_set1_epi16(-1000), q1 = _mm_set1_epi16(1000);
+    for( k = 0; k < 16; k += 8 )
+    {
+        __m128i v_base0 = _mm_lddqu_si128((__m128i*)(d+k));
+        __m128i v_base1 = _mm_lddqu_si128((__m128i*)(d+k+8));
+        __m128i v0 = _mm_alignr_epi8(v_base1, v_base0, 2);
+        __m128i v1 = _mm_alignr_epi8(v_base1, v_base0, 4);
+        __m128i a = _mm_min_epi16(v0, v1);
+        __m128i b = _mm_max_epi16(v0, v1);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 6);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 8);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 10);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 12);
+        a = _mm_min_epi16(a, v0);
+        b = _mm_max_epi16(b, v0);
+        q0 = _mm_max_epi16(q0, _mm_min_epi16(a, v_base0));
+        q1 = _mm_min_epi16(q1, _mm_max_epi16(b, v_base0));
+        v0 = _mm_alignr_epi8(v_base1, v_base0, 14);
+        q0 = _mm_max_epi16(q0, _mm_min_epi16(a, v0));
+        q1 = _mm_min_epi16(q1, _mm_max_epi16(b, v0));
+    }
+    q0 = _mm_max_epi16(q0, _mm_sub_epi16(_mm_setzero_si128(), q1));
+    q0 = _mm_max_epi16(q0, _mm_unpackhi_epi64(q0, q0));
+    q0 = _mm_max_epi16(q0, _mm_srli_si128(q0, 4));
+    q0 = _mm_max_epi16(q0, _mm_srli_si128(q0, 2));
+    threshold = (short)_mm_cvtsi128_si32(q0) - 1;
+#elif CV_SSE2
     __m128i q0 = _mm_set1_epi16(-1000), q1 = _mm_set1_epi16(1000);
     for( k = 0; k < 16; k += 8 )
     {
@@ -299,7 +370,32 @@ int cornerScore<8>(const uchar* ptr, const int pixel[], int threshold)
     for( k = 0; k < N; k++ )
         d[k] = (short)(v - ptr[pixel[k]]);
 
-#if CV_SSE2
+#if CV_SSSE3
+    __m128i v_base0 = _mm_lddqu_si128((__m128i*)(d));
+    __m128i v_base1 = _mm_lddqu_si128((__m128i*)(d+5));
+    v_base1 = _mm_shuffle_epi8(v_base1, _mm_set_epi8(15,14,15,14,15,14,15,14,13,12,11,10,9,8,7,6));
+
+    __m128i v0 = _mm_alignr_epi8(v_base1, v_base0, 2);
+    __m128i v1 = _mm_alignr_epi8(v_base1, v_base0, 4);
+    __m128i a = _mm_min_epi16(v0, v1);
+    __m128i b = _mm_max_epi16(v0, v1);
+    v0 = _mm_alignr_epi8(v_base1, v_base0, 6);
+    a = _mm_min_epi16(a, v0);
+    b = _mm_max_epi16(b, v0);
+    v0 = _mm_alignr_epi8(v_base1, v_base0, 8);
+    a = _mm_min_epi16(a, v0);
+    b = _mm_max_epi16(b, v0);
+    __m128i q0 = _mm_min_epi16(a, v_base0);
+    __m128i q1 = _mm_max_epi16(b, v_base0);
+    v0 = _mm_alignr_epi8(v_base1, v_base0, 10);
+    q0 = _mm_max_epi16(q0, _mm_min_epi16(a, v0));
+    q1 = _mm_min_epi16(q1, _mm_max_epi16(b, v0));
+    q0 = _mm_max_epi16(q0, _mm_sub_epi16(_mm_setzero_si128(), q1));
+    q0 = _mm_max_epi16(q0, _mm_unpackhi_epi64(q0, q0));
+    q0 = _mm_max_epi16(q0, _mm_srli_si128(q0, 4));
+    q0 = _mm_max_epi16(q0, _mm_srli_si128(q0, 2));
+    threshold = (short)_mm_cvtsi128_si32(q0) - 1;
+#elif CV_SSE2
     __m128i v0 = _mm_loadu_si128((__m128i*)(d+1));
     __m128i v1 = _mm_loadu_si128((__m128i*)(d+2));
     __m128i a = _mm_min_epi16(v0, v1);


### PR DESCRIPTION
I improve the function "cornerScore()".
I eliminate the wasted "_mm_loadu_si128()" instruction for using ssse3 instruction.


