### PR TITLE
GraphCut deprecated in CUDA 7.5 and removed in 8.0

### DIFF
--- a/modules/cudalegacy/src/graphcuts.cpp
+++ b/modules/cudalegacy/src/graphcuts.cpp
@@ -42,7 +42,8 @@
 
 #include "precomp.hpp"
 
-#if !defined (HAVE_CUDA) || defined (CUDA_DISABLER)
+// GraphCut has been removed in NPP 8.0
+#if !defined (HAVE_CUDA) || defined (CUDA_DISABLER) || (CUDART_VERSION >= 8000)
 
 void cv::cuda::graphcut(GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, Stream&) { throw_no_cuda(); }
 void cv::cuda::graphcut(GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, GpuMat&, Stream&) { throw_no_cuda(); }


### PR DESCRIPTION
### What does this PR change?
Fixes compilation with CUDA 8.0.

