### PR TITLE
add support for multiple OpenNI2 devices

### DIFF
--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -231,6 +231,14 @@ CvCapture_OpenNI2::CvCapture_OpenNI2( int index )
         return;
     }
 
+    // find appropriate device URI
+    openni::Array<openni::DeviceInfo> ldevs;
+    if (index > 0)
+    {
+        openni::OpenNI::enumerateDevices(&ldevs);
+        deviceURI = ldevs[index].getUri();
+    }
+
     status = device.open(deviceURI);
     if( status != openni::STATUS_OK )
     {


### PR DESCRIPTION
Add support for capturing from multiple OpenNI2 devices, tested with two Orbbec sensors.

