### PR TITLE
implementation of cv::threshold(CV_64F)

### DIFF
--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -904,6 +904,85 @@ thresh_32f( const Mat& _src, Mat& _dst, float thresh, float maxval, int type )
     }
 }
 
+static void
+thresh_64f(const Mat& _src, Mat& _dst, double thresh, double maxval, int type)
+{
+    int i, j;
+    Size roi = _src.size();
+    roi.width *= _src.channels();
+    const double* src = _src.ptr<double>();
+    double* dst = _dst.ptr<double>();
+    size_t src_step = _src.step / sizeof(src[0]);
+    size_t dst_step = _dst.step / sizeof(dst[0]);
+
+    if (_src.isContinuous() && _dst.isContinuous())
+    {
+        roi.width *= roi.height;
+        roi.height = 1;
+    }
+
+    switch (type)
+    {
+    case THRESH_BINARY:
+        for (i = 0; i < roi.height; i++, src += src_step, dst += dst_step)
+        {
+            j = 0;
+
+            for (; j < roi.width; j++)
+                dst[j] = src[j] > thresh ? maxval : 0;
+        }
+        break;
+
+    case THRESH_BINARY_INV:
+        for (i = 0; i < roi.height; i++, src += src_step, dst += dst_step)
+        {
+            j = 0;
+
+            for (; j < roi.width; j++)
+                dst[j] = src[j] <= thresh ? maxval : 0;
+        }
+        break;
+
+    case THRESH_TRUNC:
+        for (i = 0; i < roi.height; i++, src += src_step, dst += dst_step)
+        {
+            j = 0;
+
+            for (; j < roi.width; j++)
+                dst[j] = std::min(src[j], thresh);
+        }
+        break;
+
+    case THRESH_TOZERO:
+        for (i = 0; i < roi.height; i++, src += src_step, dst += dst_step)
+        {
+            j = 0;
+
+            for (; j < roi.width; j++)
+            {
+                double v = src[j];
+                dst[j] = v > thresh ? v : 0;
+            }
+        }
+        break;
+
+    case THRESH_TOZERO_INV:
+        for (i = 0; i < roi.height; i++, src += src_step, dst += dst_step)
+        {
+            j = 0;
+
+            for (; j < roi.width; j++)
+            {
+                double v = src[j];
+                dst[j] = v <= thresh ? v : 0;
+            }
+        }
+        break;
+    default:
+        return CV_Error(CV_StsBadArg, "");
+    }
+}
+
 #ifdef HAVE_IPP
 static bool ipp_getThreshVal_Otsu_8u( const unsigned char* _src, int step, Size size, unsigned char &thresh)
 {
@@ -1129,6 +1208,10 @@ public:
         {
             thresh_32f( srcStripe, dstStripe, (float)thresh, (float)maxval, thresholdType );
         }
+        else if( srcStripe.depth() == CV_64F )
+        {
+            thresh_64f(srcStripe, dstStripe, (double)thresh, (double)maxval, thresholdType);
+        }
     }
 
 private:
@@ -1268,6 +1351,8 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
         maxval = imaxval;
     }
     else if( src.depth() == CV_32F )
+        ;
+    else if( src.depth() == CV_64F )
         ;
     else
         CV_Error( CV_StsUnsupportedFormat, "" );

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -1210,7 +1210,7 @@ public:
         }
         else if( srcStripe.depth() == CV_64F )
         {
-            thresh_64f(srcStripe, dstStripe, (double)thresh, (double)maxval, thresholdType);
+            thresh_64f(srcStripe, dstStripe, thresh, maxval, thresholdType);
         }
     }
 

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -56,8 +56,8 @@ protected:
     void prepare_to_validation( int );
 
     int thresh_type;
-    float thresh_val;
-    float max_val;
+    double thresh_val;
+    double max_val;
 };
 
 
@@ -120,7 +120,7 @@ void CV_ThreshTest::run_func()
 
 
 static void test_threshold( const Mat& _src, Mat& _dst,
-                            float thresh, float maxval, int thresh_type )
+                            double thresh, double maxval, int thresh_type )
 {
     int i, j;
     int depth = _src.depth(), cn = _src.channels();
@@ -144,7 +144,7 @@ static void test_threshold( const Mat& _src, Mat& _dst,
         imaxval = cvRound(maxval);
     }
 
-    assert( depth == CV_8U || depth == CV_16S || depth == CV_32F );
+    assert( depth == CV_8U || depth == CV_16S || depth == CV_32F || depth == CV_64F );
 
     switch( thresh_type )
     {
@@ -165,12 +165,19 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                 for( j = 0; j < width_n; j++ )
                     dst[j] = (short)(src[j] > ithresh ? imaxval : 0);
             }
-            else
+            else if( depth == CV_32F )
             {
                 const float* src = _src.ptr<float>(i);
                 float* dst = _dst.ptr<float>(i);
                 for( j = 0; j < width_n; j++ )
                     dst[j] = src[j] > thresh ? maxval : 0.f;
+            }
+            else
+            {
+                const double* src = _src.ptr<double>(i);
+                double* dst = _dst.ptr<double>(i);
+                for( j = 0; j < width_n; j++ )
+                    dst[j] = src[j] > thresh ? maxval : 0.0;
             }
         }
         break;
@@ -191,12 +198,19 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                 for( j = 0; j < width_n; j++ )
                     dst[j] = (short)(src[j] > ithresh ? 0 : imaxval);
             }
-            else
+            else if( depth == CV_32F )
             {
                 const float* src = _src.ptr<float>(i);
                 float* dst = _dst.ptr<float>(i);
                 for( j = 0; j < width_n; j++ )
                     dst[j] = src[j] > thresh ? 0.f : maxval;
+            }
+            else
+            {
+                const double* src = _src.ptr<double>(i);
+                double* dst = _dst.ptr<double>(i);
+                for( j = 0; j < width_n; j++ )
+                    dst[j] = src[j] > thresh ? 0.0 : maxval;
             }
         }
         break;
@@ -223,13 +237,23 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                     dst[j] = (short)(s > ithresh ? ithresh2 : s);
                 }
             }
-            else
+            else if( depth == CV_32F )
             {
                 const float* src = _src.ptr<float>(i);
                 float* dst = _dst.ptr<float>(i);
                 for( j = 0; j < width_n; j++ )
                 {
                     float s = src[j];
+                    dst[j] = s > thresh ? thresh : s;
+                }
+            }
+            else
+            {
+                const double* src = _src.ptr<double>(i);
+                double* dst = _dst.ptr<double>(i);
+                for( j = 0; j < width_n; j++ )
+                {
+                    double s = src[j];
                     dst[j] = s > thresh ? thresh : s;
                 }
             }
@@ -258,7 +282,7 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                     dst[j] = (short)(s > ithresh ? s : 0);
                 }
             }
-            else
+            else if( depth == CV_32F )
             {
                 const float* src = _src.ptr<float>(i);
                 float* dst = _dst.ptr<float>(i);
@@ -266,6 +290,16 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                 {
                     float s = src[j];
                     dst[j] = s > thresh ? s : 0.f;
+                }
+            }
+            else
+            {
+                const double* src = _src.ptr<double>(i);
+                double* dst = _dst.ptr<double>(i);
+                for( j = 0; j < width_n; j++ )
+                {
+                    double s = src[j];
+                    dst[j] = s > thresh ? s : 0.0;
                 }
             }
         }
@@ -293,7 +327,7 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                     dst[j] = (short)(s > ithresh ? 0 : s);
                 }
             }
-            else
+            else if (depth == CV_32F)
             {
                 const float* src = _src.ptr<float>(i);
                 float* dst = _dst.ptr<float>(i);
@@ -301,6 +335,16 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                 {
                     float s = src[j];
                     dst[j] = s > thresh ? 0.f : s;
+                }
+            }
+            else
+            {
+                const double* src = _src.ptr<double>(i);
+                double* dst = _dst.ptr<double>(i);
+                for( j = 0; j < width_n; j++ )
+                {
+                    double s = src[j];
+                    dst[j] = s > thresh ? 0.0 : s;
                 }
             }
         }

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -170,7 +170,7 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                 const float* src = _src.ptr<float>(i);
                 float* dst = _dst.ptr<float>(i);
                 for( j = 0; j < width_n; j++ )
-                    dst[j] = src[j] > thresh ? maxval : 0.f;
+                    dst[j] = (float)(src[j] > thresh ? maxval : 0.f);
             }
             else
             {
@@ -203,7 +203,7 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                 const float* src = _src.ptr<float>(i);
                 float* dst = _dst.ptr<float>(i);
                 for( j = 0; j < width_n; j++ )
-                    dst[j] = src[j] > thresh ? 0.f : maxval;
+                    dst[j] = (float)(src[j] > thresh ? 0.f : maxval);
             }
             else
             {
@@ -244,7 +244,7 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                 for( j = 0; j < width_n; j++ )
                 {
                     float s = src[j];
-                    dst[j] = s > thresh ? thresh : s;
+                    dst[j] = (float)(s > thresh ? thresh : s);
                 }
             }
             else


### PR DESCRIPTION
resolves #6519

### What does this PR change?
- I impremented cv::threshold(CV_64F)
 - SSE2/NEON implementation is **not** included in this PR
- I added test case of cv::threshold(CV_64F) to <code>modules/imgproc/test/test_thresh.cpp</code>