### PR TITLE
Restored cmake 2.8.7 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,7 +605,7 @@ include(cmake/OpenCVDetectVTK.cmake)
 # -- Custom HAL replacement --
 # Package config in: OpenCV_HALConfig.cmake or opencv_hal-config.cmake
 # Use variables: OpenCV_HAL_LIBRARIES, OpenCV_HAL_HEADERS and OpenCV_HAL_INCLUDE_DIRS variables
-find_package(OpenCV_HAL CONFIG QUIET)
+find_package(OpenCV_HAL NO_MODULE QUIET)
 set(_includes "")
 if (OpenCV_HAL_FOUND)
   # 1. libraries


### PR DESCRIPTION
Parameter `CONFIG` is not supported by cmake 2.8.7, but synonymous parameter `NO_MODULE` is supported: 
- [cmake documentation 2.8.7](https://cmake.org/cmake/help/v2.8.7/cmake.html#command:find_package).
- [cmake documentation 3.0](https://cmake.org/cmake/help/v3.0/command/find_package.html)

Replaces PR #6539
