### PR TITLE
Patch for B-Frame seeking problems

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -971,7 +971,8 @@ bool CvCapture_FFMPEG::grabFrame()
         {
             //picture_pts = picture->best_effort_timestamp;
             if( picture_pts == AV_NOPTS_VALUE_ )
-                picture_pts = packet.pts != AV_NOPTS_VALUE_ && packet.pts != 0 ? packet.pts : packet.dts;
+                picture_pts = picture->pkt_pts != AV_NOPTS_VALUE_ && picture->pkt_pts != 0 ? picture->pkt_pts : picture->pkt_dts;
+
             frame_number++;
             valid = true;
         }


### PR DESCRIPTION
resolves #4890

### What does this PR change?
This change resolved the long standing issue https://github.com/Itseez/opencv/issues/4890

I added on the issue a way to reproduce the bug and detect the problem. Here is a patch that fixes it.

I tried this modified code on x264 encoded videos with and without b-frames
I tried it on an xvid avi
I tried it on a QTRLE mov

They all worked.

This being said, I checked the git log on the file and I don't see any corner cases that would explain why packet.pts was used instead of picture->pkt_pts. In theory containers without dts or without pts should work with this code.

I also admit that I don't understand the use of 'first_frame_number' (not a corner case either).
Using best_effort_timestamp to resolve the current frame number makes it so decrementing first_frame_number from dts_to_frame_number is not needed. Is there something I'm missing?

I tried this with opencv compiled against ffmpeg 2.8.6 and 2.8.7

Thanks
