### PR TITLE
add inliers export for estimateRigidTrasform [GSoC]

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -224,8 +224,6 @@ CV_EXPORTS_W void calcOpticalFlowFarneback( InputArray prev, InputArray next, In
 
 @param src First input 2D point set stored in std::vector or Mat, or an image stored in Mat.
 @param dst Second input 2D point set of the same size and the same type as A, or another image.
-@param inliers_mask Output mask of good points (inliers) set by a robust method (RANSAC). Note that
-the input mask values are ignored.
 @param fullAffine If true, the function finds an optimal affine transformation with no additional
 restrictions (6 degrees of freedom). Otherwise, the class of transformations to choose from is
 limited to combinations of translation, rotation, and uniform scaling (5 degrees of freedom).
@@ -249,11 +247,40 @@ when fullAffine=false.
 @sa
 getAffineTransform, getPerspectiveTransform, findHomography
  */
-CV_EXPORTS_W Mat estimateRigidTransform( InputArray src, InputArray dst, OutputArray inliers_mask,
-                                         bool fullAffine );
-
-/** @overload */
 CV_EXPORTS_W Mat estimateRigidTransform( InputArray src, InputArray dst, bool fullAffine );
+
+/** @brief Computes an optimal affine transformation between two 2D point sets.
+
+@param from First input 2D point set stored in std::vector or Mat.
+@param to Second input 2D point set of the same size and the same type as A.
+@param inliers_mask Output mask of good points (inliers) set by a robust method (RANSAC). Note that
+the input mask values are ignored.
+@param fullAffine If true, the function finds an optimal affine transformation with no additional
+restrictions (6 degrees of freedom). Otherwise, the class of transformations to choose from is
+limited to combinations of translation, rotation, and uniform scaling (5 degrees of freedom).
+@param inlierThreshold Maximum allowed error to treat a point pair as an inlier.
+@param maxIters The maximum number of RANSAC iterations.
+
+The function finds an optimal affine transform *[A|b]* (a 2 x 3 floating-point matrix) using the RANSAC algorithm that
+approximates best the affine transformation between two point sets.
+
+The problem is formulated as follows: you need to find a 2x2 matrix *A* and
+2x1 vector *b* so that:
+
+\f[[A^*|b^*] = arg  \min _{[A|b]}  \sum _i  \| \texttt{dst}[i] - A { \texttt{src}[i]}^T - b  \| ^2\f]
+where src[i] and dst[i] are the i-th points in src and dst, respectively
+\f$[A|b]\f$ can be either arbitrary (when fullAffine=true ) or have a form of
+\f[\begin{bmatrix} a_{11} & a_{12} & b_1  \\ -a_{12} & a_{11} & b_2  \end{bmatrix}\f]
+when fullAffine=false.
+
+@sa
+getAffineTransform, getPerspectiveTransform, findHomography, estimateRigidTransform
+ */
+CV_EXPORTS_W Mat findAffineTransform( InputArray from, InputArray to,
+                                      OutputArray inliers_mask = noArray(),
+                                      bool fullAffine = true,
+                                      double inlierThreshold = 0.05,
+                                      int maxIters = 500 );
 
 enum
 {

--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -224,6 +224,8 @@ CV_EXPORTS_W void calcOpticalFlowFarneback( InputArray prev, InputArray next, In
 
 @param src First input 2D point set stored in std::vector or Mat, or an image stored in Mat.
 @param dst Second input 2D point set of the same size and the same type as A, or another image.
+@param inliers_mask Output mask of good points (inliers) set by a robust method (RANSAC). Note that
+the input mask values are ignored.
 @param fullAffine If true, the function finds an optimal affine transformation with no additional
 restrictions (6 degrees of freedom). Otherwise, the class of transformations to choose from is
 limited to combinations of translation, rotation, and uniform scaling (5 degrees of freedom).
@@ -247,8 +249,11 @@ when fullAffine=false.
 @sa
 getAffineTransform, getPerspectiveTransform, findHomography
  */
-CV_EXPORTS_W Mat estimateRigidTransform( InputArray src, InputArray dst, bool fullAffine );
+CV_EXPORTS_W Mat estimateRigidTransform( InputArray src, InputArray dst, OutputArray inliers_mask,
+                                         bool fullAffine );
 
+/** @overload */
+CV_EXPORTS_W Mat estimateRigidTransform( InputArray src, InputArray dst, bool fullAffine );
 
 enum
 {

--- a/modules/video/test/test_estimaterigid.cpp
+++ b/modules/video/test/test_estimaterigid.cpp
@@ -48,7 +48,6 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
-#include <vector>
 
 using namespace cv;
 using namespace std;
@@ -108,7 +107,6 @@ bool CV_RigidTransform_Test::testNPoints(int from)
         rng.fill(noise, RNG::NORMAL, Scalar::all(0), Scalar::all(0.001*(n<=7 ? 0 : n <= 30 ? 1 : 10)));
         tpts += noise;
 
-        // test overload
         Mat aff_est = estimateRigidTransform(fpts, tpts, true);
 
         double thres = 0.1*cvtest::norm(aff, NORM_L2);
@@ -153,8 +151,7 @@ bool CV_RigidTransform_Test::testImage()
     Mat rotated;
     warpAffine(img, rotated, aff, img.size());
 
-    std::vector<uchar> inliers_mask;
-    Mat aff_est = estimateRigidTransform(img, rotated, inliers_mask, true);
+    Mat aff_est = estimateRigidTransform(img, rotated, true);
 
     const double thres = 0.033;
     if (cvtest::norm(aff_est, aff, NORM_INF) > thres)
@@ -162,35 +159,6 @@ bool CV_RigidTransform_Test::testImage()
         ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
         ts->printf( cvtest::TS::LOG, "Threshold = %f, norm of difference = %f", thres,
             cvtest::norm(aff_est, aff, NORM_INF) );
-        return false;
-    }
-
-    /* test inliers exporting */
-    if (inliers_mask.empty())
-    {
-        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
-        ts->printf( cvtest::TS::LOG, "inliers mask is empty" );
-        return false;
-    }
-
-    // count inliers
-    size_t num_inliers = 0;
-    for (size_t i = 0; i < inliers_mask.size(); ++i)
-    {
-        if (!(inliers_mask[i] == 1 || inliers_mask[i] == 0))
-        {
-            ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
-            ts->printf( cvtest::TS::LOG, "inliers mask contains invalid value %d", (int)inliers_mask[i] );
-            return false;
-        }
-        if (inliers_mask[i])
-            ++num_inliers;
-    }
-
-    if(num_inliers < 200)
-    {
-        ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
-        ts->printf( cvtest::TS::LOG, "low number of inliers (expected 200), have %zu", num_inliers );
         return false;
     }
 

--- a/modules/video/test/test_estimaterigid.cpp
+++ b/modules/video/test/test_estimaterigid.cpp
@@ -48,6 +48,7 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
+#include <vector>
 
 using namespace cv;
 using namespace std;
@@ -107,6 +108,7 @@ bool CV_RigidTransform_Test::testNPoints(int from)
         rng.fill(noise, RNG::NORMAL, Scalar::all(0), Scalar::all(0.001*(n<=7 ? 0 : n <= 30 ? 1 : 10)));
         tpts += noise;
 
+        // test overload
         Mat aff_est = estimateRigidTransform(fpts, tpts, true);
 
         double thres = 0.1*cvtest::norm(aff, NORM_L2);
@@ -151,7 +153,8 @@ bool CV_RigidTransform_Test::testImage()
     Mat rotated;
     warpAffine(img, rotated, aff, img.size());
 
-    Mat aff_est = estimateRigidTransform(img, rotated, true);
+    std::vector<uchar> inliers_mask;
+    Mat aff_est = estimateRigidTransform(img, rotated, inliers_mask, true);
 
     const double thres = 0.033;
     if (cvtest::norm(aff_est, aff, NORM_INF) > thres)
@@ -159,6 +162,35 @@ bool CV_RigidTransform_Test::testImage()
         ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
         ts->printf( cvtest::TS::LOG, "Threshold = %f, norm of difference = %f", thres,
             cvtest::norm(aff_est, aff, NORM_INF) );
+        return false;
+    }
+
+    /* test inliers exporting */
+    if (inliers_mask.empty())
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
+        ts->printf( cvtest::TS::LOG, "inliers mask is empty" );
+        return false;
+    }
+
+    // count inliers
+    size_t num_inliers = 0;
+    for (size_t i = 0; i < inliers_mask.size(); ++i)
+    {
+        if (!(inliers_mask[i] == 1 || inliers_mask[i] == 0))
+        {
+            ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
+            ts->printf( cvtest::TS::LOG, "inliers mask contains invalid value %d", (int)inliers_mask[i] );
+            return false;
+        }
+        if (inliers_mask[i])
+            ++num_inliers;
+    }
+
+    if(num_inliers < 200)
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
+        ts->printf( cvtest::TS::LOG, "low number of inliers (expected 200), have %zu", num_inliers );
         return false;
     }
 


### PR DESCRIPTION
Hi all,

I'm Jiri and I'll be working on new camera model for stitching pipeline this GSoC.

this PR adds inliers export for `estimateRigidTrasform`.

* added new parameter for `estimateRigidTrasform`
* added overload to support current API
* extended existing test

One think to consider: should I use this API change to also add support other things that are now hard coded? Max iters in RANSAC, RANSAC good ratio...

cc: @prclibo