### PR TITLE
Fixed #6563: ML: Incorrect management for invalid files

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -3036,6 +3036,7 @@ public:
     {
         FileStorage fs(filename, FileStorage::READ);
         FileNode fn = objname.empty() ? fs.getFirstTopLevelNode() : fs[objname];
+        if (fn.empty()) return Ptr<_Tp>();
         Ptr<_Tp> obj = _Tp::create();
         obj->read(fn);
         return !obj->empty() ? obj : Ptr<_Tp>();


### PR DESCRIPTION
Resolves #6563

Invalid files/filestorage/filenode in ml module don't generate an empty pointer as suggested.