### PR TITLE
Improved Java wrapper generation

### DIFF
--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -1428,7 +1428,7 @@ JNIEXPORT $rtype JNICALL Java_org_opencv_${module}_${clazz}_$fname
 
 """ ).substitute( \
         rtype = rtype, \
-        module = self.module, \
+        module = self.module.replace('_', '_1'), \
         clazz = clazz.replace('_', '_1'), \
         fname = (fi.jname + '_' + str(suffix_counter)).replace('_', '_1'), \
         args  = ", ".join(["%s %s" % (type_dict[a.ctype].get("jni_type"), a.name) for a in jni_args]), \
@@ -1521,7 +1521,7 @@ JNIEXPORT void JNICALL Java_org_opencv_%(module)s_%(j_cls)s_delete
     delete (%(cls)s*) self;
 }
 
-""" % {"module" : module, "cls" : self.smartWrap(ci.name, ci.fullName(isCPP=True)), "j_cls" : ci.jname.replace('_', '_1')}
+""" % {"module" : module.replace('_', '_1'), "cls" : self.smartWrap(ci.name, ci.fullName(isCPP=True)), "j_cls" : ci.jname.replace('_', '_1')}
             )
 
     def getClass(self, classname):


### PR DESCRIPTION
resolves https://github.com/Itseez/opencv_contrib/issues/652

While generating Java JNI wrappers package names with an underscore (`_`) character where not properly escaped according to https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#resolving_native_method_names (see also: https://github.com/Itseez/opencv_contrib/issues/652).

This fix replaces all the occurrences of `_` with `_1` resulting in proper JNI method names.