### PR TITLE
Fixed documentation warnings produced by updated doxygen

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
@@ -116,32 +116,32 @@ These operations allow to reorder or recombine elements in one or multiple vecto
 Element-wise binary and unary operations.
 
 - Arithmetics:
-@ref operator+(const v_reg &a, const v_reg &b) "+",
-@ref operator-(const v_reg &a, const v_reg &b) "-",
-@ref operator*(const v_reg &a, const v_reg &b) "*",
-@ref operator/(const v_reg &a, const v_reg &b) "/",
+@ref operator +(const v_reg &a, const v_reg &b) "+",
+@ref operator -(const v_reg &a, const v_reg &b) "-",
+@ref operator *(const v_reg &a, const v_reg &b) "*",
+@ref operator /(const v_reg &a, const v_reg &b) "/",
 @ref v_mul_expand
 
 - Non-saturating arithmetics: @ref v_add_wrap, @ref v_sub_wrap
 
 - Bitwise shifts:
-@ref operator<<(const v_reg &a, int s) "<<",
-@ref operator>>(const v_reg &a, int s) ">>",
+@ref operator <<(const v_reg &a, int s) "<<",
+@ref operator >>(const v_reg &a, int s) ">>",
 @ref v_shl, @ref v_shr
 
 - Bitwise logic:
-@ref operator&(const v_reg &a, const v_reg &b) "&",
-@ref operator|(const v_reg &a, const v_reg &b) "|",
-@ref operator^(const v_reg &a, const v_reg &b) "^",
-@ref operator~(const v_reg &a) "~"
+@ref operator &(const v_reg &a, const v_reg &b) "&",
+@ref operator |(const v_reg &a, const v_reg &b) "|",
+@ref operator ^(const v_reg &a, const v_reg &b) "^",
+@ref operator ~(const v_reg &a) "~"
 
 - Comparison:
-@ref operator>(const v_reg &a, const v_reg &b) ">",
-@ref operator>=(const v_reg &a, const v_reg &b) ">=",
-@ref operator<(const v_reg &a, const v_reg &b) "<",
-@ref operator<=(const v_reg &a, const v_reg &b) "<=",
-@ref operator==(const v_reg &a, const v_reg &b) "==",
-@ref operator!=(const v_reg &a, const v_reg &b) "!="
+@ref operator >(const v_reg &a, const v_reg &b) ">",
+@ref operator >=(const v_reg &a, const v_reg &b) ">=",
+@ref operator <(const v_reg &a, const v_reg &b) "<",
+@ref operator <=(const v_reg &a, const v_reg &b) "<=",
+@ref operator ==(const v_reg &a, const v_reg &b) "==",
+@ref operator !=(const v_reg &a, const v_reg &b) "!="
 
 - min/max: @ref v_min, @ref v_max
 


### PR DESCRIPTION
Fixes following warnings:
```
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:130: warning: unable to resolve reference to `operator-(const v_reg &a, const v_reg &b)' for \ref command
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:131: warning: unable to resolve reference to `operator*(const v_reg &a, const v_reg &b)' for \ref command
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:139: warning: unable to resolve reference to `operator>>(const v_reg &a, int s)' for \ref command
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:145: warning: unable to resolve reference to `operator^(const v_reg &a, const v_reg &b)' for \ref command
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:146: warning: unable to resolve reference to `operator~(const v_reg &a)' for \ref command
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:149: warning: unable to resolve reference to `operator>(const v_reg &a, const v_reg &b)' for \ref command
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:150: warning: unable to resolve reference to `operator>=(const v_reg &a, const v_reg &b)' for \ref command
/build/precommit_docs/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:154: warning: unable to resolve reference to `operator!=(const v_reg &a, const v_reg &b)' for \ref command
```
