### PR TITLE
Fixed 6585: C API compilation error due to undefined cvRound

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -45,6 +45,7 @@
 #ifndef __OPENCV_CORE_C_H__
 #define __OPENCV_CORE_C_H__
 
+#include "opencv2/core/fast_math.hpp"
 #include "opencv2/core/types_c.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
resolves #6585 

### What does this PR change?
Fix compilation error with OpenCV 3 and C-API with gcc 5.3.1 and Ubuntu 16.04.

