### PR TITLE
Fixed #6587: C-API exports again CV_VERSION* macros

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -45,6 +45,7 @@
 #ifndef __OPENCV_CORE_C_H__
 #define __OPENCV_CORE_C_H__
 
+#include "opencv2/core/version.hpp"
 #include "opencv2/core/types_c.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
resolves #6587 

### What does this PR change?
Export as in OpenCV 2.4 CV_VERSION macros for C-API.

