### PR TITLE
Correcting return variable type from videoDevice::findType to be int

### DIFF
--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -2580,7 +2580,7 @@ bool videoDevice::setupDevice(unsigned int id)
 
 bool videoDevice::setupDevice(unsigned int w, unsigned int h, unsigned int idealFramerate)
 {
-    unsigned int id = findType(w * h, idealFramerate);
+    int id = findType(w * h, idealFramerate);
     if( id < 0 )
         return false;
 


### PR DESCRIPTION
resolves #6256

### What does this PR change?
This PR changes the return type of videoDevice::findType from unsigned int to int

This enables the correct detection of -1 as an error return code and does not allow continuation of device creation.