### PR TITLE
cmake: fix JNI configuration problem for Android samples

### DIFF
--- a/cmake/OpenCVDetectAndroidSDK.cmake
+++ b/cmake/OpenCVDetectAndroidSDK.cmake
@@ -287,7 +287,7 @@ macro(add_android_project target path)
           set(android_proj_NATIVE_DEPS ${android_proj_NATIVE_DEPS} android)
         endif()
 
-        add_library(${JNI_LIB_NAME} MODULE ${android_proj_jni_files})
+        add_library(${JNI_LIB_NAME} SHARED ${android_proj_jni_files})
         ocv_target_include_modules_recurse(${JNI_LIB_NAME} ${android_proj_NATIVE_DEPS})
         ocv_target_include_directories(${JNI_LIB_NAME} "${path}/jni")
         ocv_target_link_libraries(${JNI_LIB_NAME} ${OPENCV_LINKER_LIBS} ${android_proj_NATIVE_DEPS})


### PR DESCRIPTION
Some CMake 3.x (2.8.12.2 is fine) provides broken build configurations with following build error message on building JNI code for Android samples (`libdetection_based_tracker.so`):
```
    ld: fatal error: -soname: must take a non-empty argument
```

Linker command line sample contains this:
```
-shared -Wl,-soname, -o
```