### PR TITLE
watershed.py: check if windows are still open

### DIFF
--- a/samples/python/watershed.py
+++ b/samples/python/watershed.py
@@ -55,7 +55,7 @@ class App:
         cv2.imshow('watershed', vis)
 
     def run(self):
-        while True:
+        while cv2.getWindowProperty('img', 0) != -1 or cv2.getWindowProperty('watershed', 0) != -1:
             ch = 0xFF & cv2.waitKey(50)
             if ch == 27:
                 break


### PR DESCRIPTION
### What does this PR change?

I changed the `while` loop condition so it checks if the two windows that this example creates still exist, and stops the program otherwise. This is done via `cv2.getWindowProperty()`. Before, if both windows were closed using the `X` button instead of pressing `ESC` to quit, the loop would still continue and there would be no way to quit the program other than killing the Python process. Now the `while` loop stops when both windows are manually closed. I think this is good practice and should be somewhere in the examples.

What I do is get the `CV_WND_PROP_FULLSCREEN` property of the window using [`cv2.getWindowProperty()`](http://docs.opencv.org/2.4/modules/highgui/doc/qt_new_functions.html#getwindowproperty) (the flag is defined as `0` in [highgui_c.h](https://github.com/Itseez/opencv/blob/master/modules/highgui/include/opencv2/highgui/highgui_c.h)). This returns a value `>= 0` as long as the window is open, and `-1` as soon as the window is closed. This way it can be used to check if the window still exists.

*(It may also be beneficial to set the window names as properties in the `App` class, so it is clear where the names come from.)*