### PR TITLE
Use CMAKE_LIBRARY_PATH_FLAG variable instead of -L.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,7 +659,7 @@ if(HAVE_CUDA)
     set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} ${CUDA_cufft_LIBRARY})
   endif()
   foreach(p ${CUDA_LIBS_PATH})
-    set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} -L${p})
+    set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} ${CMAKE_LIBRARY_PATH_FLAG}${p})
   endforeach()
 endif()
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
resolves #6710 

### What does this PR change?

It uses CMAKE_LIBRARY_PATH_FLAG cmake flag to automatically detect wich flag to use instead of the hard-coded "-L" flag.

