### PR TITLE
Replace outdated NTSC RGB luma factors with sRGB ones

### DIFF
--- a/modules/imgcodecs/src/utils.cpp
+++ b/modules/imgcodecs/src/utils.cpp
@@ -43,8 +43,8 @@
 #include "utils.hpp"
 
 #define  SCALE  14
-#define  cR  (int)(0.299*(1 << SCALE) + 0.5)
-#define  cG  (int)(0.587*(1 << SCALE) + 0.5)
+#define  cR  (int)(0.2126*(1 << SCALE) + 0.5)
+#define  cG  (int)(0.7152*(1 << SCALE) + 0.5)
 #define  cB  ((1 << SCALE) - cR - cG)
 
 void icvCvt_BGR2Gray_8u_C3C1R( const uchar* rgb, int rgb_step,

--- a/modules/imgproc/perf/perf_floodfill.cpp
+++ b/modules/imgproc/perf/perf_floodfill.cpp
@@ -55,7 +55,7 @@ PERF_TEST_P(Size_Source_Fl, floodFill1, Combine(
     int b = 152;//(unsigned)theRNG() & 255;
     int g = 136;//(unsigned)theRNG() & 255;
     int r = 53;//(unsigned)theRNG() & 255;
-    newval = (colorType == IMREAD_COLOR) ? Scalar(b, g, r) : Scalar(r*0.299 + g*0.587 + b*0.114);
+    newval = (colorType == IMREAD_COLOR) ? Scalar(b, g, r) : Scalar(r*0.2126 + g*0.7152 + b*0.0722);
 
     Rect outputRect = Rect();
     Mat source = Mat();


### PR DESCRIPTION
Replace outdated NTSC RGB luma factors with sRGB ones. Here's some additional info:
http://www.brucelindbloom.com/index.html?WorkingSpaceInfo.html