### PR TITLE
features2d: Added missing SimpleBlob parameters

### DIFF
--- a/modules/features2d/src/features2d_init.cpp
+++ b/modules/features2d/src/features2d_init.cpp
@@ -139,12 +139,16 @@ CV_INIT_ALGORITHM(SimpleBlobDetector, "Feature2D.SimpleBlob",
                   obj.info()->addParam(obj, "filterByColor",    obj.params.filterByColor);
                   obj.info()->addParam(obj, "blobColor",        obj.params.blobColor);
                   obj.info()->addParam(obj, "filterByArea",     obj.params.filterByArea);
+                  obj.info()->addParam(obj, "minArea",          obj.params.minArea);
                   obj.info()->addParam(obj, "maxArea",          obj.params.maxArea);
                   obj.info()->addParam(obj, "filterByCircularity", obj.params.filterByCircularity);
+                  obj.info()->addParam(obj, "minCircularity",   obj.params.minCircularity);
                   obj.info()->addParam(obj, "maxCircularity",   obj.params.maxCircularity);
                   obj.info()->addParam(obj, "filterByInertia",  obj.params.filterByInertia);
+                  obj.info()->addParam(obj, "minInertiaRatio",  obj.params.minInertiaRatio);
                   obj.info()->addParam(obj, "maxInertiaRatio",  obj.params.maxInertiaRatio);
                   obj.info()->addParam(obj, "filterByConvexity", obj.params.filterByConvexity);
+                  obj.info()->addParam(obj, "minConvexity",     obj.params.minConvexity);
                   obj.info()->addParam(obj, "maxConvexity",     obj.params.maxConvexity);
                   )
 


### PR DESCRIPTION
resolves #6744 

### What does this PR change?
This adds missing SimpleBlobDetector parameters to features2d_init.cpp, so they can be modified using Algorithm::set.